### PR TITLE
Include the rhoai-2.* branch to trigger the workflow on pushes to rhoai-2.20 and later branches.

### DIFF
--- a/.github/workflows/process-fbc-fragment.yaml
+++ b/.github/workflows/process-fbc-fragment.yaml
@@ -7,6 +7,7 @@ on:
       - catalog/catalog-patch.yaml
     branches:
       - 'rhoai-2.1[6-9]+'
+      - 'rhoai-2.2[0-9]+' # Trigger the workflow on pushes to any rhoai-2.20 branch
 permissions:
   contents: write
 

--- a/.github/workflows/process-operator-bundle.yaml
+++ b/.github/workflows/process-operator-bundle.yaml
@@ -9,7 +9,7 @@ on:
       - to-be-processed/bundle/**
     branches:
       - 'rhoai-2.1[6-9]+'
-
+      - 'rhoai-2.2[0-9]+' # Trigger the workflow on pushes to any rhoai-2.20 branch
 permissions:
   contents: write
 

--- a/.github/workflows/trigger-nightly-bundle-build.yaml
+++ b/.github/workflows/trigger-nightly-bundle-build.yaml
@@ -7,7 +7,7 @@ on:
       - schedule/bundle-github-trigger.txt
     branches:
       - 'rhoai-2.1[6-9]+'
-
+      - 'rhoai-2.2[0-9]+' # Trigger the workflow on pushes to any rhoai-2.20 branch
 permissions:
   contents: write
 env:

--- a/.github/workflows/trigger-nightly-fbc-build.yaml
+++ b/.github/workflows/trigger-nightly-fbc-build.yaml
@@ -7,6 +7,7 @@ on:
       - schedule/catalog-github-trigger.txt
     branches:
       - 'rhoai-2.1[6-9]+'
+      - 'rhoai-2.2[0-9]+' # Trigger the workflow on pushes to any rhoai-2.20 branch
 permissions:
   contents: write
 env:


### PR DESCRIPTION
…ai-2.20 and later branches.