### PR TITLE
WIP: Update csv patch annotations to el9 images

### DIFF
--- a/bundle/csv-patch.yaml
+++ b/bundle/csv-patch.yaml
@@ -5,25 +5,25 @@ metadata:
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
   annotations:
-    feast-cronjob-image: registry.redhat.io/openshift4/ose-cli@sha256:bc35a9fc663baf0d6493cc57e89e77a240a36c43cf38fb78d8e61d3b87cf5cc5
-    anaconda-cronjob-image: registry.redhat.io/openshift4/ose-cli@sha256:75bf9b911b6481dcf29f7942240d1555adaa607eec7fc61bedb7f624f87c36d4
-    odh-etcd-image: registry.redhat.io/rhel7/etcd@sha256:d3495b263b103681f1b09a558be43c21989bfc269eb90f84c2609042cebdc626
-    ose-oauth-proxy-image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:bd49cfc8452b3d96467cc222db9487e120abc6cc5ba81349c6b3703706f36a08
-    ose-oauth-proxy-dashboard-image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4f8d66597feeb32bb18699326029f9a71a5aca4a57679d636b876377c2e95695
-    ose-oauth-proxy-dw-image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:1ea6a01bf3e63cdcf125c6064cbd4a4a270deaf0f157b3eabb78f60556840366
-    ubi-minimal-image: registry.redhat.io/ubi8/ubi-minimal@sha256:5d2d4d4dbec470f8ffb679915e2a8ae25ad754cd9193fa966deee1ecb7b3ee00
-    ubi9-image: registry.redhat.io/ubi9@sha256:770cf07083e1c85ae69c25181a205b7cdef63c11b794c89b3b487d4670b4c328
-    prometheus-base-image: registry.redhat.io/openshift4/ose-prometheus@sha256:c432e571eb737d55323b5f350b5f714803bf525144cfee3f20782660d9bf10ad
-    prometheus-alertmanager-image: registry.redhat.io/openshift4/ose-prometheus-alertmanager@sha256:169b788b3f8eb8909ecc1d698ab0a6bf103b49043c7f5fd569789b179928def6
-    prometheus-config-reloader-image: registry.redhat.io/openshift4/ose-prometheus-config-reloader@sha256:bd543e039c7c2b0857a7e0ce34d582b8954a8ad3a3f13a2eaaff2904cdae7c53
-    prometheus-operator-image: registry.redhat.io/openshift4/ose-prometheus-operator@sha256:4aeb07f66dc39889e3d0e66eee7c4ea2e39ce4025852d1d1eaf662af8bd8eeb6
-    ose-cli-image: registry.redhat.io/openshift4/ose-cli@sha256:25fef269ac6e7491cb8340119a9b473acbeb53bc6970ad029fdaae59c3d0ca61
-    odh-ml-pipeline-moveresult-image: registry.redhat.io/ubi8/ubi-micro@sha256:396baed3d689157d96aa7d8988fdfea7eb36684c8335eb391cf1952573e689c1
-    odh-ml-pipeline-mariadb-image: registry.redhat.io/rhel8/mariadb-103@sha256:f0ee0d27bb784e289f7d88cc8ee0e085ca70e88a5d126562105542f259a1ac01
-    ose-oauth-proxy-dsp-image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:8ce44de8c683f198bf24ba36cd17e89708153d11f5b42c0a27e77f8fdb233551
-    odh-ml-pipeline-envoy-proxy-image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel8@sha256:b30d60cd458133430d4c92bf84911e03cecd02f60e88a58d1c6c003543cf833a
-    ose-cli-etcd-image: registry.redhat.io/openshift4/ose-cli@sha256:4cfb4219f46c8cc25a5e567fd4cb8babe9a3778b0b86a1e354a3403994ef3677
-    ose-etcd-image: registry.redhat.io/openshift4/ose-etcd@sha256:d3275cd886d13865937d225d8138db7f6b7bf59ac1a94d9fbe61e35286bee6ff
+    feast-cronjob-image: registry.redhat.io/openshift4/ose-cli-rhel9@sha256:b1dbd11b70fae906ba445082bbbe9a1427731b9a0b64d6e67dd4c309d1477300
+    anaconda-cronjob-image: registry.redhat.io/openshift4/ose-cli-rhel9@sha256:b1dbd11b70fae906ba445082bbbe9a1427731b9a0b64d6e67dd4c309d1477300
+    odh-etcd-image: registry.redhat.io/openshift4/ose-etcd-rhel9@sha256:202f94efa9bf1b5dc2628d5bc94689b3e4a3112aaac6f084925a64463ee79c49
+    ose-oauth-proxy-image: registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:3bb1803cae39a31cc87bcf8affee0ad2576f1d2774a6c3de556adbbbc2687abc
+    ose-oauth-proxy-dashboard-image: registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:3bb1803cae39a31cc87bcf8affee0ad2576f1d2774a6c3de556adbbbc2687abc
+    ose-oauth-proxy-dw-image: registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:3bb1803cae39a31cc87bcf8affee0ad2576f1d2774a6c3de556adbbbc2687abc
+    ubi-minimal-image: registry.redhat.io/ubi9/ubi-minimal@sha256:21ed5a01130d3a77eb4a26a80de70a4433860255b394e95dc2c26817de1da061
+    ubi9-image: registry.redhat.io/ubi9@sha256:ce22c16161e358578f697cd31ec6b1533a8d8dca1bdce2159fc1c27171d49a08
+    prometheus-base-image: registry.redhat.io/openshift4/ose-prometheus-rhel9@sha256:f8702b3a167e8d970716be9240016b765dbb98f65cf31a3c1c6c699318225e57
+    prometheus-alertmanager-image: registry.redhat.io/openshift4/ose-prometheus-alertmanager-rhel9@sha256:57b7bacb0856098b4e3535d2db6a78ecfb337b674668a11c1a25659938afcaca
+    prometheus-config-reloader-image: registry.redhat.io/openshift4/ose-prometheus-config-reloader-rhel9@sha256:03297117105b6f9f3826f64cedcd3826b931ba561c31fb4d7fd58f29969ae1a9
+    prometheus-operator-image: registry.redhat.io/openshift4/ose-prometheus-rhel9-operator@sha256:c938b8197f4abbffeacab21fa30b6e9b3868e805ed475739c894cfcbc3b86cb4
+    ose-cli-image: registry.redhat.io/openshift4/ose-cli-rhel9@sha256:b1dbd11b70fae906ba445082bbbe9a1427731b9a0b64d6e67dd4c309d1477300
+    odh-ml-pipeline-moveresult-image: registry.redhat.io/ubi9/ubi-micro@sha256:93ae5bced8702423154dea0bf6785d5e2c42788dabac39d288e0ca23afd88884
+    odh-ml-pipeline-mariadb-image: registry.redhat.io/rhel9/mariadb-105@sha256:f2d9a532997fd2bd1022a10c8b02a77eb8786a4eddb3e613f683de2a79d99840
+    ose-oauth-proxy-dsp-image: registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:3bb1803cae39a31cc87bcf8affee0ad2576f1d2774a6c3de556adbbbc2687abc
+    odh-ml-pipeline-envoy-proxy-image: registry.redhat.io/openshift-service-mesh/proxyv2-rhel9@sha256:ab57c24b4ec39c376bce0e718deed8f0e629be231acfe3ba8f430215672e0efd
+    ose-cli-etcd-image: registry.redhat.io/openshift4/ose-cli-rhel9@sha256:b1dbd11b70fae906ba445082bbbe9a1427731b9a0b64d6e67dd4c309d1477300
+    ose-etcd-image: registry.redhat.io/openshift4/ose-etcd-rhel9@sha256:202f94efa9bf1b5dc2628d5bc94689b3e4a3112aaac6f084925a64463ee79c49
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "false"


### PR DESCRIPTION
I think this is probably _not_ how to update this, and instead it
should somehow(?) get populated from images specified in component
manifests somewhere.

Is there some script that populates this normally?