### PR TITLE
revive embedded channel for IBM

### DIFF
--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -13,6 +13,11 @@ patch:
       - name: rhods-operator.2.21.0
         replaces: rhods-operator.2.20.0
         skipRange: '>=2.20.0 <2.21.0'
+    - name: embedded
+      entries:
+      - name: rhods-operator.2.21.0
+        replaces: rhods-operator.2.11.0-0.1727935135.p
+        skipRange: '>=2.11.0 <2.21.0'
 
   olm.bundle:
     - quay.io/rhoai/odh-operator-bundle@sha256:99a8601321e1041ccaa75c35e2f92cdaeaf4b5336b7c37dbb6466bae0b15ae37


### PR DESCRIPTION
This PR reintroduces the embedded channel to deliver RHOAI components to IBM for their FedRamp process and which needs to be Designed for FIPS.

## More Details:

- Resume RHOAI releases on the embedded channel, starting with 2.21 (June release)
- Continue adding new RHOAI releases on a 6-month cadence
- The embedded release will be frozen for features, receiving only critical CVE patches for the next 6-month support period.

## Supported Upgrade Paths

### From 2.11

- Direct upgrade to 2.21 using the embedded channel

### From 2.19

- Switch to fast
- Sequential upgrade to --> 2.20 --> 2.21
- Switch to embedded for any future upgrades

## When RHOAI 2.21 is released, we will have to provide support for:

- 2.8-EUS
- 2.16-EUS
- 2.19-stable
- 2.21-fast (1 month)
- 2.21-embedded (6 months)