### PR TITLE
Use team-specific and generic image variable names

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -1,20 +1,20 @@
 # Each additional image must follow the format:
 #
-# name:  Must be in the format RELATED_IMAGE_<IMAGE_NAME>_<TAG_LABEL>_IMAGE
-#        - IMAGE_NAME: A descriptive, uppercase identifier for the image
-#        - TAG_LABEL: A tag reference (e.g., LATEST, 2_6), use underscores for separators
+# name:  Must be in the format RELATED_IMAGE_[COMPONENT_NAME]_<IMAGE_NAME>_IMAGE
+#        - COMPONENT_NAME (optional): Name of the component which uses the image. Omit if the image is shared by multiple components.
+#        - IMAGE_NAME: A descriptive, uppercase identifier for the image (omit version details to keep it generic)
 #
 # value: Must follow the format registry.redhat.io/<ORG>/<REPO>:<TAG>@<SHA256_DIGEST>
 #        - Use the full image reference including both tag and SHA digest
-#        - This is to ensure exact digest updates based on the tag versioning
+#        - This ensures updates are tied to a specific tag, avoiding unintended major or minor version bumps
 additionalImages:
-  - name: RELATED_IMAGE_TOOLBOX_LATEST_IMAGE
+  - name: RELATED_IMAGE_DSP_TOOLBOX_IMAGE
     value: "registry.redhat.io/ubi9/toolbox:latest@sha256:40b48c85d3d257c4030a65ba0a44d80ea84cd416df3719b4844d3f39b7b14d02"
-  - name: RELATED_IMAGE_INSTRUCTLAB_NVIDIA_RHEL9_1_5_IMAGE
+  - name: RELATED_IMAGE_DSP_INSTRUCTLAB_NVIDIA_IMAGE
     value: "registry.redhat.io/rhelai1/instructlab-nvidia-rhel9:1.5@sha256:3e6eb035c69b204746a44b3a58b2751c20050cfb6af2ba7989ba327809f87c0b"
-  - name: RELATED_IMAGE_PROXYV2_RHEL9_2_6_IMAGE
+  - name: RELATED_IMAGE_DSP_PROXYV2_IMAGE
     value: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel9:2.6@sha256:ab57c24b4ec39c376bce0e718deed8f0e629be231acfe3ba8f430215672e0efd"
-  - name: RELATED_IMAGE_MARIADB_105_LATEST_IMAGE
+  - name: RELATED_IMAGE_DSP_MARIADB_IMAGE
     value: "registry.redhat.io/rhel9/mariadb-105:latest@sha256:07d3e7f5d46c14f3ec78dd8c8df46886017e2d079f1a0cef6b5fa68dd4f9a50b"
-  - name: RELATED_IMAGE_OSE_OAUTH_PROXY_RHEL9_LATEST_IMAGE
+  - name: RELATED_IMAGE_OSE_OAUTH_PROXY_IMAGE
     value: "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:latest@sha256:3bb1803cae39a31cc87bcf8affee0ad2576f1d2774a6c3de556adbbbc2687abc"

--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -10,8 +10,8 @@
 additionalImages:
   - name: RELATED_IMAGE_TOOLBOX_LATEST_IMAGE
     value: "registry.redhat.io/ubi9/toolbox:latest@sha256:40b48c85d3d257c4030a65ba0a44d80ea84cd416df3719b4844d3f39b7b14d02"
-  - name: RELATED_IMAGE_INSTRUCTLAB_NVIDIA_RHEL9_LATEST_IMAGE
-    value: "registry.redhat.io/rhelai1/instructlab-nvidia-rhel9:latest@sha256:3e6eb035c69b204746a44b3a58b2751c20050cfb6af2ba7989ba327809f87c0b"
+  - name: RELATED_IMAGE_INSTRUCTLAB_NVIDIA_RHEL9_1_5_IMAGE
+    value: "registry.redhat.io/rhelai1/instructlab-nvidia-rhel9:1.5@sha256:3e6eb035c69b204746a44b3a58b2751c20050cfb6af2ba7989ba327809f87c0b"
   - name: RELATED_IMAGE_PROXYV2_RHEL9_2_6_IMAGE
     value: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel9:2.6@sha256:ab57c24b4ec39c376bce0e718deed8f0e629be231acfe3ba8f430215672e0efd"
   - name: RELATED_IMAGE_MARIADB_105_LATEST_IMAGE


### PR DESCRIPTION
Dropping the tag name and rhel version from the variable name, as this tight coupling becomes problematic when teams want to opt in to newer minor/major versions. Updating the tag or the underlying rhel version would require renaming the variable in both the patch file and the platform operator, which defeats the purpose of [RHOAIENG-25691](https://issues.redhat.com/browse/RHOAIENG-25691) initiative.

Instead, we're using team-specific, generic variable names to allow teams to independently manage and update the tags of their third-party image dependencies. This approach enables teams to opt in to minor or major version updates at their own pace without impacting others.

The trade-off, however, is that if the image references start with different versions today, but converges at a later point, the same image might be referenced more than once under different variable names.

Additionally, omitting the component name for the OAuth proxy image, as it will be shared among components and should remain consistent.


Slack Conversation: https://redhat-internal.slack.com/archives/C08PBG1D08L/p1747669138345699?thread_ts=1747669116.525469&cid=C08PBG1D08L 



Below PRs needs to be updated accordingly:
- https://github.com/opendatahub-io/opendatahub-operator/pull/1945
- https://github.com/opendatahub-io/opendatahub-operator/pull/1948 