### PR TITLE
Remove unused rhel7/etcd image from csv patch

### DIFF
--- a/bundle/csv-patch.yaml
+++ b/bundle/csv-patch.yaml
@@ -7,7 +7,6 @@ metadata:
   annotations:
     feast-cronjob-image: registry.redhat.io/openshift4/ose-cli@sha256:bc35a9fc663baf0d6493cc57e89e77a240a36c43cf38fb78d8e61d3b87cf5cc5
     anaconda-cronjob-image: registry.redhat.io/openshift4/ose-cli@sha256:75bf9b911b6481dcf29f7942240d1555adaa607eec7fc61bedb7f624f87c36d4
-    odh-etcd-image: registry.redhat.io/rhel7/etcd@sha256:d3495b263b103681f1b09a558be43c21989bfc269eb90f84c2609042cebdc626
     ose-oauth-proxy-image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:bd49cfc8452b3d96467cc222db9487e120abc6cc5ba81349c6b3703706f36a08
     ose-oauth-proxy-dashboard-image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4f8d66597feeb32bb18699326029f9a71a5aca4a57679d636b876377c2e95695
     ose-oauth-proxy-dw-image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:1ea6a01bf3e63cdcf125c6064cbd4a4a270deaf0f157b3eabb78f60556840366


### PR DESCRIPTION
This was originally updated in modelmesh in this PR:
https://github.com/opendatahub-io/modelmesh-serving/pull/313

There were still some references to it in old unused manifests, and
those have now also been removed:
https://github.com/red-hat-data-services/modelmesh-serving/pull/369