### PR TITLE
update replaces to use 2.19.1

### DIFF
--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -6,14 +6,14 @@ patch:
     - name: stable
       entries:
       - name: rhods-operator.2.19.2
-        replaces: rhods-operator.2.19.0
+        replaces: rhods-operator.2.19.1
         skipRange: '>=2.19.0 <2.19.2'
     - name: stable-2.19
       package: rhods-operator
       schema: olm.channel
       entries:
       - name: rhods-operator.2.19.2
-        replaces: rhods-operator.2.19.0
+        replaces: rhods-operator.2.19.1
         skipRange: '>=2.19.0 <2.19.2'
 
   olm.bundle:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/RHOAIENG-29072

fixes the following error:
```
level=fatal msg="failed to load or rebuild cache: failed to rebuild cache: build package index: process package \"rhods-operator\": invalid index:\n└── invalid package \"rhods-operator\":\n    ├── invalid channel \"stable\":\n    │   └── multiple channel heads found in graph: rhods-operator.2.19.1, rhods-operator.2.19.2\n    └── invalid channel \"stable-2.19\":\n        └── multiple channel heads found in graph: rhods-operator.2.19.1, rhods-operator.2.19.2"
```