### PR TITLE
removing ocp 4.20

### DIFF
--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -44,12 +44,12 @@ config:
         base-image: brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.18
       - name: v4.19
         base-image: brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
-      - name: v4.20
-        base-image: brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.20
+      # - name: v4.20
+      #   base-image: brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.20
     release:
       - v4.15
       - v4.16
       - v4.17
       - v4.18
       - v4.19
-      - v4.20
+      # - v4.20


### PR DESCRIPTION
ocp 4.20 is not building due to a known error in FIPS check processing
