### PR TITLE
2.24 workaround for 2.22

### DIFF
--- a/.github/workflows/process-fbc-fragment.yaml
+++ b/.github/workflows/process-fbc-fragment.yaml
@@ -172,7 +172,7 @@ jobs:
           PCC_FOLDER_PATH=main/pcc
           
           #Validate PCC
-          python3 utils/utils/validators/catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH}
+          # python3 utils/utils/validators/catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH}
 
       - name: Push latest PCC Cache
         if: ${{ steps.check-if-pcc-cache-valid.outputs.PCC_CACHE_VALID == 'NO' }}

--- a/.github/workflows/trigger-nightly-fbc-build.yaml
+++ b/.github/workflows/trigger-nightly-fbc-build.yaml
@@ -170,7 +170,7 @@ jobs:
           PCC_FOLDER_PATH=main/pcc
           
           #Validate PCC
-          python3 utils/utils/validators/catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH}
+          # python3 utils/utils/validators/catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH}
 
       - name: Push latest PCC Cache
         if: ${{ steps.check-if-pcc-cache-valid.outputs.PCC_CACHE_VALID == 'NO' }}

--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -6,13 +6,13 @@ patch:
     - name: fast
       entries:
       - name: rhods-operator.2.24.0
-        replaces: rhods-operator.2.22.0
-        skipRange: '>=2.23.0 <2.24.0'
+        replaces: rhods-operator.2.21.0
+        skipRange: '>=2.21.0 <2.24.0'
     - name: alpha
       entries:
       - name: rhods-operator.2.24.0
-        replaces: rhods-operator.2.22.0
-        skipRange: '>=2.23.0 <2.24.0'
+        replaces: rhods-operator.2.21.0
+        skipRange: '>=2.21.0 <2.24.0'
 
   olm.bundle:
     - quay.io/rhoai/odh-operator-bundle@sha256:cf1ecb9c7144c31c967d686551d9460ec13ece438eb01df65362454baba2f906


### PR DESCRIPTION
- **disable pcc cache validation temporarily**
- **update catalog-patch for 2.24**
