### PR TITLE
Enable arm support

### DIFF
--- a/bundle/csv-patch.yaml
+++ b/bundle/csv-patch.yaml
@@ -3,6 +3,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
   annotations:
     feast-cronjob-image: registry.redhat.io/openshift4/ose-cli@sha256:bc35a9fc663baf0d6493cc57e89e77a240a36c43cf38fb78d8e61d3b87cf5cc5


### PR DESCRIPTION
OLM relies on architecture labels to determine which platforms the operator should be exposed on in OperatorHub. This change will also make the RHOAI Operator availabel for installation via operatorhub in ARM clusters.