### PR TITLE
pin ose* images to latest eus release tag

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -17,8 +17,8 @@ additionalImages:
   - name: RELATED_IMAGE_DSP_MARIADB_IMAGE
     value: "registry.redhat.io/rhel9/mariadb-105:latest@sha256:5de3d3e85d3590d0fb7806f0ddc04a04bd0110b34793a7038b33b4a8b0791184"
   - name: RELATED_IMAGE_OSE_OAUTH_PROXY_IMAGE
-    value: "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:latest@sha256:c174c11374a52ddb7ecfa400bbd9fe0c0f46129bd27458991bec69237229ac7d"
+    value: "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:v4.18@sha256:c174c11374a52ddb7ecfa400bbd9fe0c0f46129bd27458991bec69237229ac7d"
   - name: RELATED_IMAGE_OSE_ETCD_IMAGE
-    value: "registry.redhat.io/openshift4/ose-etcd-rhel9@sha256:ea7545b79599f3868d442fdffdfe9b12a02a4b56ac155f02c0fac4720d475796"
+    value: "registry.redhat.io/openshift4/ose-etcd-rhel9:v4.18@sha256:c9fe48e77f9923a508542509000e2d4e46e05048daaeef8e53230f4eb59ffd91"
   - name: RELATED_IMAGE_OSE_CLI_IMAGE
-    value: "registry.redhat.io/openshift4/ose-cli-rhel9@sha256:a11ea4a722fadc2cdf532675dd409d384342bea15559aec4b10c2b12ab6d3041"
+    value: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.18@sha256:f4e17cd54c0e5dd64f428679f28e16a6018caecb72d0a43ba977b03b89778ce8"


### PR DESCRIPTION
As discussed in this [thread](https://redhat-internal.slack.com/archives/C05NXTEHLGY/p1756723841930859?thread_ts=1756376637.383729&cid=C05NXTEHLGY), pinning all OSE images to the latest EUS release tag