### PR TITLE
Add RHAIIS vLLM Cuda Image

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -22,3 +22,5 @@ additionalImages:
     value: "registry.redhat.io/openshift4/ose-etcd-rhel9:v4.18@sha256:c9fe48e77f9923a508542509000e2d4e46e05048daaeef8e53230f4eb59ffd91"
   - name: RELATED_IMAGE_OSE_CLI_IMAGE
     value: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.18@sha256:f4e17cd54c0e5dd64f428679f28e16a6018caecb72d0a43ba977b03b89778ce8"
+  - name: RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE
+    value: "registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.2@sha256:3cf0dd386f4763c7b9131ae42ea2a1791c5620cf0f688f85d317968deb6a13e8"


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHOAIENG-34827

After the 3.2.2 release tomorrow, the floating tag 3.2 will be updated to point to 3.2.2, and Renovate will automatically update the corresponding SHA digest.