### PR TITLE
Revert additional image patch to 2.21.0 release

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -9,12 +9,12 @@
 #        - This ensures updates are tied to a specific tag, avoiding unintended major or minor version bumps
 additionalImages:
   - name: RELATED_IMAGE_DSP_TOOLBOX_IMAGE
-    value: "registry.redhat.io/ubi9/toolbox:latest@sha256:1cb2555fa6df701cce0ad17783de45ef64e4233c638622f05760f686a52c5fae"
+    value: "registry.redhat.io/ubi9/toolbox:latest@sha256:7656f815a0d13ed37f56d11635559a87a3d00840253755c71b644b858f67d556"
   - name: RELATED_IMAGE_DSP_INSTRUCTLAB_NVIDIA_IMAGE
     value: "registry.redhat.io/rhelai1/instructlab-nvidia-rhel9:1.5@sha256:3e6eb035c69b204746a44b3a58b2751c20050cfb6af2ba7989ba327809f87c0b"
   - name: RELATED_IMAGE_DSP_PROXYV2_IMAGE
     value: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel9:2.6@sha256:ab57c24b4ec39c376bce0e718deed8f0e629be231acfe3ba8f430215672e0efd"
   - name: RELATED_IMAGE_DSP_MARIADB_IMAGE
-    value: "registry.redhat.io/rhel9/mariadb-105:latest@sha256:2ad192efeb9bbab7dd14f92f5ddfb89f8836c49af91ab1324dff7246b463d2a4"
+    value: "registry.redhat.io/rhel9/mariadb-105:latest@sha256:c390b12f5c2c3ea7cd897b59eba7127ce22f474130cd8c1bbbbaadae870baca4"
   - name: RELATED_IMAGE_OSE_OAUTH_PROXY_IMAGE
-    value: "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:latest@sha256:b92e5cea1103c799a84e8da27423547ef471a7d7b558e0226875b49388cbdb98"
+    value: "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:latest@sha256:2a16c353fd13dc1f3f5c4266f1b9786a8e7a100dc05f2d554bdaef082271063f"


### PR DESCRIPTION
Keeping the csv consistent with 2.21.0 release with only the required updates for the cve