### PR TITLE
Add ose-kube-rbac-proxy image

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -18,6 +18,8 @@ additionalImages:
     value: "registry.redhat.io/rhel9/mariadb-105:latest@sha256:5de3d3e85d3590d0fb7806f0ddc04a04bd0110b34793a7038b33b4a8b0791184"
   - name: RELATED_IMAGE_OSE_OAUTH_PROXY_IMAGE
     value: "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:v4.18@sha256:c174c11374a52ddb7ecfa400bbd9fe0c0f46129bd27458991bec69237229ac7d"
+  - name: RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE
+    value: "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:467557f453bde3feaa0129f38c52fba00c3b98acddbf8978bf21ef13a9890fab"
   - name: RELATED_IMAGE_OSE_ETCD_IMAGE
     value: "registry.redhat.io/openshift4/ose-etcd-rhel9:v4.18@sha256:c9fe48e77f9923a508542509000e2d4e46e05048daaeef8e53230f4eb59ffd91"
   - name: RELATED_IMAGE_OSE_CLI_IMAGE


### PR DESCRIPTION
Ref: https://redhat-internal.slack.com/archives/C07SBP17R7Z/p1759154972184509?thread_ts=1759150726.533399&cid=C07SBP17R7Z

This is required for https://github.com/opendatahub-io/opendatahub-operator/pull/2555