### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-operator-bundle-v2-20

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -124,7 +124,8 @@ LABEL \
 LABEL com.redhat.component="odh-operator-bundle" \
       description="odh-operator-bundle" \
       distribution-scope="public" \
-      name="managed-open-data-hub/odh-operator-bundle" \
+      name="rhoai/odh-operator-bundle" \
+      cpe="cpe:/a:redhat:openshift_ai:2.20::el8" \
       vendor="Red Hat, Inc." \
       summary="odh-operator-bundle" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
