### PR TITLE
pin images to 3.2.2

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -23,6 +23,6 @@ additionalImages:
   - name: RELATED_IMAGE_OSE_CLI_IMAGE
     value: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.18@sha256:f4e17cd54c0e5dd64f428679f28e16a6018caecb72d0a43ba977b03b89778ce8"
   - name: RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.2@sha256:df300e32078427d779738bd919cc53aee772118246388f3ea8d529af0e8a85e9"
+    value: "registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.2.2@sha256:df300e32078427d779738bd919cc53aee772118246388f3ea8d529af0e8a85e9"
   - name: RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.2@sha256:f36864ec0d7a18a3143296ba2e624eca1fa6ba0af87a7196b325384785bbcf4b"
+    value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.2.2@sha256:f36864ec0d7a18a3143296ba2e624eca1fa6ba0af87a7196b325384785bbcf4b"


### PR DESCRIPTION
Use fixed tag so renovate doesn't update the digest to latest 3.2.x version.

Ref: https://redhat-internal.slack.com/archives/C09C0TPC0L8/p1761064849097889?thread_ts=1760714709.625689&cid=C09C0TPC0L8