### PR TITLE
Integrate RHAIIS vLLM images

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -25,6 +25,10 @@ additionalImages:
   - name: RELATED_IMAGE_OSE_CLI_IMAGE
     value: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.18@sha256:f4e17cd54c0e5dd64f428679f28e16a6018caecb72d0a43ba977b03b89778ce8"
   - name: RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.2@sha256:df300e32078427d779738bd919cc53aee772118246388f3ea8d529af0e8a85e9"
-  - name: RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.2@sha256:f36864ec0d7a18a3143296ba2e624eca1fa6ba0af87a7196b325384785bbcf4b"
+    value: "registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.2.3@sha256:ad756c01ec99a99cc7d93401c41b8d92ca96fb1ab7c5262919d818f2be4f3768"
+  - name: RELATED_IMAGE_RHAIIS_VLLM_ROCM_IMAGE
+    value: "registry.redhat.io/rhaiis/vllm-rocm-rhel9:3.2.3@sha256:8624e2a5086cf1303b59154a817f60a3476d6ca48899261a2e477eb9e99ae781"
+  - name: RELATED_IMAGE_RHAIIS_VLLM_AMD64_SPYRE_IMAGE
+    value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.2.3@sha256:cdd8daa0c68422fa0dade392ace341b4438910046416290ac81635c466b48a5a"
+  # - name: RELATED_IMAGE_RHAIIS_VLLM_S390X_SPYRE_IMAGE
+  #   value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.2.4@sha256:<>"


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHOAIENG-36481 

The PR include changes to consume
- RHAIIS 3.2.3 images (CUDA, ROCm, Spyre for x86) without the TGIS adapter
- RHAIIS 3.2.4 image for Spyre on s390x (Z)

Notes

- The RHAIIS 3.2.4 vLLM Spyre image is not yet released; it is included as a placeholder for now.
- The variables RELATED_IMAGE_RHAIIS_VLLM_AMD64_SPYRE_IMAGE and RELATED_IMAGE_RHAIIS_VLLM_S390X_SPYRE_IMAGE currently point to architecture-specific image manifests, not a manifest list.