### PR TITLE
Revert updates to upgrade graph and re-enable PCC validation

### DIFF
--- a/.github/workflows/process-fbc-fragment.yaml
+++ b/.github/workflows/process-fbc-fragment.yaml
@@ -176,7 +176,7 @@ jobs:
           PCC_FOLDER_PATH=main/pcc
           
           #Validate PCC
-          #python3 utils/utils/validators/catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH}
+          python3 utils/utils/validators/catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH}
 
       - name: Push latest PCC Cache
         if: ${{ steps.check-if-pcc-cache-valid.outputs.PCC_CACHE_VALID == 'NO' }}

--- a/.github/workflows/trigger-nightly-fbc-build.yaml
+++ b/.github/workflows/trigger-nightly-fbc-build.yaml
@@ -176,7 +176,7 @@ jobs:
           PCC_FOLDER_PATH=main/pcc
           
           #Validate PCC
-          #python3 utils/utils/validators/catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH}
+          python3 utils/utils/validators/catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH}
 
       - name: Push latest PCC Cache
         if: ${{ steps.check-if-pcc-cache-valid.outputs.PCC_CACHE_VALID == 'NO' }}

--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -126,8 +126,8 @@ patch:
         replaces: rhods-operator.2.24.0
         skipRange: '>=2.24.0 <2.25.0'
       - name: rhods-operator.3.0.0
-        replaces: rhods-operator.2.21.0
-        skipRange: '>=2.21.0 <2.24.0'
+        replaces: rhods-operator.2.25.0
+        skipRange: '>=2.25.0 <2.26.0'
 
   olm.bundle:
     - quay.io/rhoai/odh-operator-bundle@sha256:37b9bec0b92829e7052978f0222c5526781f2bfc4c1ed6e1299767d9845b0684


### PR DESCRIPTION
RHOAI v2.25 is live and the PR reverts the workarounds to bypass failures caused by partial 2.25 release