### PR TITLE
Add Postgresql 16

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -20,6 +20,8 @@ additionalImages:
     value: "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:v4.18@sha256:ed78d0c5946a2cc75c8bc2db6dbad5d757102acfa9defcd3f4a30829aa47d9d1"
   - name: RELATED_IMAGE_OSE_ETCD_IMAGE
     value: "registry.redhat.io/openshift4/ose-etcd-rhel9:v4.18@sha256:de67ebe1de42971f1cb99df039044a6c79471802dedf666282e349c579f79c3a"
+  - name: RELATED_IMAGE_POSTGRESQL_16_IMAGE
+    value: "registry.redhat.io/rhel9/postgresql-16:latest@sha256:3ffdde9a8e930b9cc95d659606487aac1d4d46691c04d2d926a49256d3aee6de"
   - name: RELATED_IMAGE_OSE_CLI_IMAGE
     value: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.18@sha256:eaa42ee5a963696339c318b511a330b2b6fc9e1eb173d2d47f9cb757f6eb3da9"
   - name: RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHOAIENG-25706

**Please Note:** We’ve configured Renovate for automated digest updates. The image reference follows the below format: `<image-name>:<tag>@<sha256:digest>`

This format allows Renovate to identify which tag should be used for digest updates and automatically refresh the digest when a new image for that tag is published. If you want to track a different tag, replace **latest** with the desired tag so Renovate can update the corresponding digest automatically.