### PR TITLE
Add Postgresql 16

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -18,6 +18,8 @@ additionalImages:
     value: "registry.redhat.io/rhel9/mariadb-105:latest@sha256:a376c86dc5b288516604d46bfb6025972e962b2be5a00e70d5d479ae465e0bcf"
   - name: RELATED_IMAGE_OSE_OAUTH_PROXY_IMAGE
     value: "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:v4.18@sha256:ed78d0c5946a2cc75c8bc2db6dbad5d757102acfa9defcd3f4a30829aa47d9d1"
+  - name: RELATED_IMAGE_POSTGRESQL_16_IMAGE
+    value: "registry.redhat.io/rhel9/postgresql-16:latest@sha256:3ffdde9a8e930b9cc95d659606487aac1d4d46691c04d2d926a49256d3aee6de"
   # - name: RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE
   #   value: "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:467557f453bde3feaa0129f38c52fba00c3b98acddbf8978bf21ef13a9890fab"
   - name: RELATED_IMAGE_OSE_ETCD_IMAGE


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHOAIENG-25706

Please Note: We’ve configured Renovate for automated digest updates. The image reference follows the below format: `<image-name>:<tag>@<sha256:digest>`

This format allows Renovate to identify which tag should be used for digest updates and automatically refresh the digest when a new image for that tag is published. If you want to track a different tag, replace latest with the desired tag so Renovate can update the corresponding digest automatically.