### PR TITLE
add ose-prom-label-proxy-rhel9

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -26,6 +26,8 @@ additionalImages:
     value: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:5f1fc557bef7e06ad285e94e20e4c1bb4f2b8b31c6239d195fd93ff02a530f9c"
   - name: RELATED_IMAGE_POSTGRESQL_16_IMAGE
     value: "registry.redhat.io/rhel9/postgresql-16:latest@sha256:3ffdde9a8e930b9cc95d659606487aac1d4d46691c04d2d926a49256d3aee6de"
+  - name: RELATED_IMAGE_OSE_PROM_LABEL_PROXY_IMAGE
+    value: "registry.redhat.io/openshift4/ose-prom-label-proxy-rhel9:v4.20@sha256:3666fd36afed36b24732a1a51e20979b27f65d7db233ada089c668454bc7891b"
   - name: RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE
     value: "registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.2.3@sha256:ad756c01ec99a99cc7d93401c41b8d92ca96fb1ab7c5262919d818f2be4f3768"
   - name: RELATED_IMAGE_RHAIIS_VLLM_ROCM_IMAGE


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHOAIENG-38224
Related PR: https://github.com/opendatahub-io/opendatahub-operator/pull/2415

**Please Note:** 

We’ve configured Renovate for automated digest updates. The image reference follows the below format: 

`<image-name>:<tag>@<sha256:digest>`

Including both tag and SHA digest in the image reference allows Renovate to identify which tag should be used for digest updates and automatically refresh the digest when a new image for that tag is published. This ensures updates are tied to a specific tag, avoiding unintended major or minor version bumps. 

It was [decided](https://redhat-internal.slack.com/archives/C05NXTEHLGY/p1758193863102139?thread_ts=1756376637.383729&cid=C05NXTEHLGY) earlier that RHOAI would standardize on pinning all OSE images to latest EUS release, which is 4.20 as of today. If you wish to track a different tag, replace `4.20` with the desired tag so Renovate can update the corresponding digest automatically.