### PR TITLE
standardize all fragment builds (CI, nightly, stage) to use a single shared pipeline

### DIFF
--- a/.tekton/rhoai-fbc-fragment-v3-2-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-v3-2-push.yaml
@@ -28,9 +28,6 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-  - name: additional-labels
-    value:
-    - version=v3.2.0
   - name: output-image
     value: quay.io/rhoai/rhoai-fbc-fragment:{{target_branch}}
   - name: build-platforms
@@ -47,10 +44,10 @@ spec:
     value: catalog/catalog_build_args.map
   - name: skip-checks
     value: false
-  - name: build-source-image
-    value: false
-  - name: is_nightly
-    value: false
+  - name: build-type
+    value: "ci"
+  - name: rhoai-version
+    value: "3.2.0"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/rhoai-fbc-fragment-v3-2-scheduled.yaml
+++ b/.tekton/rhoai-fbc-fragment-v3-2-scheduled.yaml
@@ -26,9 +26,6 @@ spec:
     value:
     - '{{target_branch}}-{{revision}}'
     - '{{target_branch}}-nightly'
-  - name: additional-labels
-    value:
-    - version=v3.2.0
   - name: output-image
     value: quay.io/rhoai/rhoai-fbc-fragment:{{target_branch}}
   - name: build-platforms
@@ -45,10 +42,10 @@ spec:
     value: catalog/catalog_build_args.map
   - name: skip-checks
     value: false
-  - name: build-source-image
-    value: false
-  - name: is_nightly
-    value: true
+  - name: build-type
+    value: "nightly"   # Possible values: 'nightly', 'stage', 'ci'
+  - name: rhoai-version
+    value: "3.2.0"
   - name: workflow_url
     value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/conforma-reporter.yaml"
   - name: smoke_url


### PR DESCRIPTION
This PR introduces changes to consolidate all fragment builds (CI, nightly, and stage) under a single shared Tekton pipeline definition.

Currently, the stage FBCF build pipelines are embedded within their own configuration and do not use the shared pipeline definition. This inconsistency has created several maintenance and release risks, as discrepancies between pipeline configurations can go unnoticed and lead to failures during builds or releases.

By unifying all fragment builds under one shared pipeline, we improve consistency, reduce divergence, and simplify ongoing maintenance.

Pipeline Changes: https://github.com/red-hat-data-services/konflux-central/pull/970