### PR TITLE
Fixes the fast and alpha channel to show correct versions

### DIFF
--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -11,12 +11,12 @@ patch:
     - name: alpha
       entries:
       - name: rhods-operator.2.25.1
-        replaces: rhods-operator.2.24.0
+        replaces: rhods-operator.2.25.0
         skipRange: '>=2.24.0 <2.25.1'
     - name: stable
       entries:
       - name: rhods-operator.2.25.1
-        replaces: rhods-operator.2.22.2
+        replaces: rhods-operator.2.25.0
         skipRange: '>=2.22.0 <2.25.1'
     - name: stable-2.25
       package: rhods-operator


### PR DESCRIPTION
Fixes build issue

`  time="2025-12-02T14:05:36Z" level=fatal msg="failed to load or rebuild cache: failed to rebuild cache: build package index: process package \"rhods-operator\": invalid index:\n└── invalid package \"rhods-operator\":\n    ├── invalid channel \"alpha\":\n    │   └── multiple channel heads found in graph: rhods-operator.2.25.0, rhods-operator.2.25.1\n    └── invalid channel \"stable\":\n        └── multiple channel heads found in graph: rhods-operator.2.25.0, rhods-operator.2.25.1"`