### PR TITLE
fix duplicate key in build config

### DIFF
--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -75,7 +75,6 @@ config:
         rhoai/odh-training-rocm62-torch24-py311-rhel9: rhoai/odh-training-rocm62-torch24-py311-rhel9
         rhoai/odh-training-rocm62-torch25-py311-rhel9: rhoai/odh-training-rocm62-torch25-py311-rhel9
         rhoai/odh-training-rocm64-torch28-py312-rhel9: rhoai/odh-training-rocm64-torch28-py312-rhel9
-        rhoai/odh-llama-stack-core-rhel9: rhoai/odh-llama-stack-core-rhel9
         rhoai/odh-trainer-rhel9: rhoai/odh-trainer-rhel9
   supported-ocp-versions:
     build:


### PR DESCRIPTION
llama-stack-core is already defined on line 62.