### PR TITLE
unify ci, nightly and stage pipeline for fbc

### DIFF
--- a/.tekton/rhoai-fbc-fragment-v2-25-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-v2-25-push.yaml
@@ -9,7 +9,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: 'event == "push" && target_branch
       == "rhoai-2.25" && ( "catalog/**".pathChanged() || ".tekton/rhoai-fbc-fragment-v2-25-push.yaml".pathChanged()
       ) && !"catalog/catalog-patch.yaml".pathChanged() && !".github/workflows/**".pathChanged()'
-  creationTimestamp:
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: rhoai-fbc-fragment-v2-25
@@ -28,9 +27,6 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-  - name: additional-labels
-    value:
-    - version=v2.25.1
   - name: output-image
     value: quay.io/rhoai/rhoai-fbc-fragment:{{target_branch}}
   - name: build-platforms
@@ -42,15 +38,15 @@ spec:
   - name: dockerfile
     value: Dockerfile
   - name: path-context
-    value: catalog/v4.17
+    value: catalog/v4.19
   - name: build-args-file
     value: catalog/catalog_build_args.map
   - name: skip-checks
     value: false
-  - name: build-source-image
-    value: false
-  - name: is_nightly
-    value: false
+  - name: build-type
+    value: "ci"
+  - name: rhoai-version
+    value: "2.25.1"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/rhoai-fbc-fragment-v2-25-scheduled.yaml
+++ b/.tekton/rhoai-fbc-fragment-v2-25-scheduled.yaml
@@ -14,6 +14,9 @@ metadata:
   name: rhoai-fbc-fragment-v2-25-on-schedule
   namespace: rhoai-tenant
 spec:
+  timeouts:
+    pipeline: 8h
+    tasks: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -23,9 +26,6 @@ spec:
     value:
     - '{{target_branch}}-{{revision}}'
     - '{{target_branch}}-nightly'
-  - name: additional-labels
-    value:
-    - version=v2.25.1
   - name: output-image
     value: quay.io/rhoai/rhoai-fbc-fragment:{{target_branch}}
   - name: build-platforms
@@ -37,15 +37,15 @@ spec:
   - name: dockerfile
     value: Dockerfile
   - name: path-context
-    value: catalog/v4.17
+    value: catalog/v4.19
   - name: build-args-file
     value: catalog/catalog_build_args.map
   - name: skip-checks
     value: false
-  - name: build-source-image
-    value: false
-  - name: is_nightly
-    value: true
+  - name: build-type
+    value: "nightly"   # Possible values: 'nightly', 'stage', 'ci'
+  - name: rhoai-version
+    value: "2.25.1"
   - name: workflow_url
     value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/conforma-reporter.yaml"
   - name: smoke_url
@@ -61,18 +61,6 @@ spec:
       value: pipelines/fbc-fragment-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-rhoai-fbc-fragment-v2-25
-  timeouts:
-    pipeline: 8h
-    tasks: 6h
-  taskRunSpecs:
-    - pipelineTaskName: fbc-fips-check-oci-ta
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 16Gi
-        limits:
-          cpu: '32'
-          memory: 64Gi
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
This PR introduces changes to consolidate all fragment builds (CI, nightly, and stage) under a single shared Tekton pipeline definition.

Currently, the stage FBCF build pipelines are embedded within their own configuration and do not use the shared pipeline definition. This inconsistency has created several maintenance and release risks, as discrepancies between pipeline configurations can go unnoticed and lead to failures during builds or releases.

By unifying all fragment builds under one shared pipeline, we improve consistency, reduce divergence, and simplify ongoing maintenance.

Depends on: 

- https://github.com/red-hat-data-services/konflux-central/pull/1046
- https://github.com/red-hat-data-services/rhoai-konflux-tasks/pull/123