### PR TITLE
Add RELATED_IMAGE_ODH_PYTHON_312 to additional images

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -36,5 +36,5 @@ additionalImages:
     value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.2.5@sha256:80ae3e435a5be2c1f117f36599103ab05357917dd6e37f0df6613cb3ac2c13ea"
   - name: RELATED_IMAGE_RHAIIS_VLLM_S390X_SPYRE_IMAGE
     value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.2.5@sha256:80ae3e435a5be2c1f117f36599103ab05357917dd6e37f0df6613cb3ac2c13ea"
-  - name: RELATED_IMAGE_ODH_PYTHON_312
+  - name: RELATED_IMAGE_ODH_PYTHON_312_IMAGE
     value: "registry.redhat.io/ubi9/python-312:latest@sha256:55e489965ae3bcd954d33a7022c8a4af4774ac2cdfd8a4011f1f28ae3b7b8f8f"

--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -37,4 +37,4 @@ additionalImages:
   - name: RELATED_IMAGE_RHAIIS_VLLM_S390X_SPYRE_IMAGE
     value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.2.5@sha256:80ae3e435a5be2c1f117f36599103ab05357917dd6e37f0df6613cb3ac2c13ea"
   - name: RELATED_IMAGE_ODH_PYTHON_312_IMAGE
-    value: "registry.redhat.io/ubi9/python-312:latest@sha256:29a2f858d8c2ef549b72f2c702833659f28c944b0236f055d0169e98e790788c"
+    value: "registry.redhat.io/ubi9/python-312:latest@sha256:3da39d0c938994161bdf9b6b13eb2eacd9a023c86dd5166f3da31df171c88780"

--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -36,3 +36,5 @@ additionalImages:
     value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.2.5@sha256:80ae3e435a5be2c1f117f36599103ab05357917dd6e37f0df6613cb3ac2c13ea"
   - name: RELATED_IMAGE_RHAIIS_VLLM_S390X_SPYRE_IMAGE
     value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.2.5@sha256:80ae3e435a5be2c1f117f36599103ab05357917dd6e37f0df6613cb3ac2c13ea"
+  - name: RELATED_IMAGE_ODH_PYTHON_312
+    value: "registry.redhat.io/ubi9/python-312:latest@sha256:55e489965ae3bcd954d33a7022c8a4af4774ac2cdfd8a4011f1f28ae3b7b8f8f"

--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -37,4 +37,4 @@ additionalImages:
   - name: RELATED_IMAGE_RHAIIS_VLLM_S390X_SPYRE_IMAGE
     value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.2.5@sha256:80ae3e435a5be2c1f117f36599103ab05357917dd6e37f0df6613cb3ac2c13ea"
   - name: RELATED_IMAGE_ODH_PYTHON_312_IMAGE
-    value: "registry.redhat.io/ubi9/python-312:latest@sha256:55e489965ae3bcd954d33a7022c8a4af4774ac2cdfd8a4011f1f28ae3b7b8f8f"
+    value: "registry.redhat.io/ubi9/python-312:latest@sha256:29a2f858d8c2ef549b72f2c702833659f28c944b0236f055d0169e98e790788c"


### PR DESCRIPTION
Add Python 3.12 UBI image reference to bundle/additional-images-patch.yaml for OpenDataHub components that require Python 3.12 runtime.