### PR TITLE
build source image for OCP 419, rhoai 3.x

### DIFF
--- a/.tekton/rhoai-fbc-fragment-rhoai-32-ocp-419-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-32-ocp-419-push.yaml
@@ -41,6 +41,8 @@ spec:
     value: catalog/rhoai-3.2/catalog_build_args.map
   - name: skip-checks
     value: false
+  - name: build-source-image
+    value: true
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version

--- a/.tekton/rhoai-fbc-fragment-rhoai-33-ocp-419-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-33-ocp-419-push.yaml
@@ -41,6 +41,8 @@ spec:
     value: catalog/rhoai-3.3/catalog_build_args.map
   - name: skip-checks
     value: false
+  - name: build-source-image
+    value: true
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version


### PR DESCRIPTION
the rhoai addon release pipeline expects to have a source image pushed

example https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhtap-releng-tenant/applications/rhoai-fbc-fragment-ocp-419/pipelineruns/managed-z7jfh?releaseName=rhoai-fbc-addon-ocp-419-stage-1766554787-1-2-3

@riprasad fyi