### PR TITLE
add missing rhoai operator args/labels

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -1,5 +1,7 @@
 FROM scratch
 
+ARG ODH_RHEL9_OPERATOR_GIT_URL=
+ARG ODH_RHEL9_OPERATOR_GIT_COMMIT=
 ARG ODH_BUILT_IN_DETECTOR_GIT_URL=
 ARG ODH_BUILT_IN_DETECTOR_GIT_COMMIT=
 ARG ODH_DASHBOARD_GIT_URL=
@@ -167,6 +169,8 @@ LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 LABEL \
+      odh-rhel9-operator.git.url="${ODH_RHEL9_OPERATOR_GIT_URL}" \
+      odh-rhel9-operator.git.commit="${ODH_RHEL9_OPERATOR_GIT_COMMIT}" \
       odh-built-in-detector.git.url="${ODH_BUILT_IN_DETECTOR_GIT_URL}" \
       odh-built-in-detector.git.commit="${ODH_BUILT_IN_DETECTOR_GIT_COMMIT}" \
       odh-dashboard.git.url="${ODH_DASHBOARD_GIT_URL}" \

--- a/catalog/v4.19/Dockerfile
+++ b/catalog/v4.19/Dockerfile
@@ -2,6 +2,8 @@
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
 FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
 
+ARG ODH_RHEL9_OPERATOR_GIT_URL=
+ARG ODH_RHEL9_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
 ARG ODH_BUILT_IN_DETECTOR_GIT_URL=
@@ -174,6 +176,8 @@ RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
 LABEL operators.operatorframework.io.index.configs.v1=/configs
 
 LABEL \
+      odh-rhel9-operator.git.url="${ODH_RHEL9_OPERATOR_GIT_URL}" \
+      odh-rhel9-operator.git.commit="${ODH_RHEL9_OPERATOR_GIT_COMMIT}" \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       odh-built-in-detector.git.url="${ODH_BUILT_IN_DETECTOR_GIT_URL}" \

--- a/catalog/v4.20/Dockerfile
+++ b/catalog/v4.20/Dockerfile
@@ -2,6 +2,8 @@
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
 FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.20
 
+ARG ODH_RHEL9_OPERATOR_GIT_URL=
+ARG ODH_RHEL9_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
 ARG ODH_BUILT_IN_DETECTOR_GIT_URL=
@@ -173,6 +175,8 @@ RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
 LABEL operators.operatorframework.io.index.configs.v1=/configs
 
 LABEL \
+      odh-rhel9-operator.git.url="${ODH_RHEL9_OPERATOR_GIT_URL}" \
+      odh-rhel9-operator.git.commit="${ODH_RHEL9_OPERATOR_GIT_COMMIT}" \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       odh-built-in-detector.git.url="${ODH_BUILT_IN_DETECTOR_GIT_URL}" \


### PR DESCRIPTION
rhoai operator labels were inadvertently removed in https://github.com/red-hat-data-services/RHOAI-Build-Config/commit/27df956e5ddd94d5331c6ca4ac6d5c182302b217#diff-773f02e26d3dac3b2ed2c6d1fe408d1b2987cb16af16b7508ddca0bf407d60deL3-L11, this PR adds them back
