### PR TITLE
Enable 3.2 -> 3.3 and 2.25 -> 3.3 upgrade

### DIFF
--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -8,8 +8,258 @@ patch:
       schema: olm.channel
       entries:
       - name: rhods-operator.3.3.0
-        replaces: rhods-operator.3.0.0
-        skipRange: '>=3.0.0 <3.3.0'
+        replaces: rhods-operator.3.2.0
+        skipRange: '>=3.2.0 <3.3.0'
+    - name: stable-3.3
+      package: rhods-operator
+      schema: olm.channel
+      entries:
+      - name: rhods-operator.1.20.1-8
+      - name: rhods-operator.1.21.0-22
+        replaces: rhods-operator.1.20.1-8
+      - name: rhods-operator.1.22.0-2
+        replaces: rhods-operator.1.21.0-22
+      - name: rhods-operator.1.22.1-2
+        replaces: rhods-operator.1.22.0-2
+      - name: rhods-operator.1.22.1-4
+        replaces: rhods-operator.1.22.1-2
+        skipRange: '>=1.22.0-2 <1.22.1-10'
+      - name: rhods-operator.1.23.0
+        replaces: rhods-operator.1.22.1-4
+        skipRange: '>=1.22.0-1 <1.22.1-10'
+      - name: rhods-operator.1.24.0
+        replaces: rhods-operator.1.23.0
+      - name: rhods-operator.1.25.0
+        replaces: rhods-operator.1.24.0
+      - name: rhods-operator.1.26.0
+        replaces: rhods-operator.1.25.0
+      - name: rhods-operator.1.27.0
+        replaces: rhods-operator.1.26.0
+      - name: rhods-operator.1.28.0
+        replaces: rhods-operator.1.27.0
+      - name: rhods-operator.1.28.1
+        replaces: rhods-operator.1.28.0
+        skipRange: '>=1.27.0 <1.28.1'
+      - name: rhods-operator.1.29.0
+        replaces: rhods-operator.1.28.1
+        skipRange: '>=1.28.0 <1.29.0'
+      - name: rhods-operator.1.30.0
+        replaces: rhods-operator.1.29.0
+      - name: rhods-operator.1.31.0
+        replaces: rhods-operator.1.30.0
+      - name: rhods-operator.1.32.0
+        replaces: rhods-operator.1.31.0
+        skipRange: '>=1.31.0 <1.32.0'
+      - name: rhods-operator.1.33.0
+        replaces: rhods-operator.1.32.0
+        skipRange: '>=1.32.0 <1.33.0'
+      - name: rhods-operator.2.10.0
+        replaces: rhods-operator.2.8.3
+        skipRange: '>=2.8.0 <2.10.0'
+      - name: rhods-operator.2.11.0
+        skipRange: '>=2.10.0 <2.11.0'
+      - name: rhods-operator.2.11.0-0.1727935135.p
+        replaces: rhods-operator.2.10.0
+        skipRange: '>=2.10.0 <2.11.0'
+        skips:
+        - rhods-operator.2.11.0
+      - name: rhods-operator.2.12.0
+        replaces: rhods-operator.2.11.0-0.1727935135.p
+        skipRange: '>=2.11.0 <2.12.0'
+      - name: rhods-operator.2.13.0
+        replaces: rhods-operator.2.12.0
+        skipRange: '>=2.10.0 <2.13.0'
+      - name: rhods-operator.2.13.1
+        replaces: rhods-operator.2.13.0
+        skipRange: '>=2.13.0 <2.13.1'
+      - name: rhods-operator.2.4.0
+        replaces: rhods-operator.1.33.0
+        skipRange: '>=1.33.0 <2.4.0'
+      - name: rhods-operator.2.5.0
+        replaces: rhods-operator.2.4.0
+        skipRange: '>=2.4.0 <2.5.0'
+      - name: rhods-operator.2.6.0
+        replaces: rhods-operator.2.5.0
+        skipRange: '>=2.5.0 <2.6.0'
+      - name: rhods-operator.2.7.0
+        replaces: rhods-operator.2.6.0
+        skipRange: '>=2.6.0 <2.7.0'
+      - name: rhods-operator.2.8.0
+        replaces: rhods-operator.2.7.0
+        skipRange: '>=2.6.0 <2.8.0'
+      - name: rhods-operator.2.8.1
+        replaces: rhods-operator.2.8.0
+        skipRange: '>=2.8.0 <2.8.1'
+      - name: rhods-operator.2.8.2
+        replaces: rhods-operator.2.8.1
+        skipRange: '>=2.8.0 <2.8.2'
+      - name: rhods-operator.2.8.3
+        replaces: rhods-operator.2.8.2
+        skipRange: '>=2.8.0 <2.8.3'
+      - name: rhods-operator.2.16.0
+        replaces: rhods-operator.2.13.1
+        skipRange: '>=2.13.0 <2.16.0'
+      - name: rhods-operator.2.16.1
+        replaces: rhods-operator.2.16.0
+        skipRange: '>=2.16.0 <2.16.1'
+      - name: rhods-operator.2.16.2
+        replaces: rhods-operator.2.16.1
+        skipRange: '>=2.16.0 <2.16.2'
+      - name: rhods-operator.2.19.0
+        replaces: rhods-operator.2.16.2
+        skipRange: '>=2.16.0 <2.19.0'
+      - name: rhods-operator.2.19.1
+        replaces: rhods-operator.2.19.0
+        skipRange: '>=2.19.0 <2.19.1'
+      - name: rhods-operator.2.19.2
+        replaces: rhods-operator.2.19.1
+        skipRange: '>=2.19.0 <2.19.2'
+      - name: rhods-operator.2.22.0
+        replaces: rhods-operator.2.19.2
+        skipRange: '>=2.19.0 <2.22.0'
+      - name: rhods-operator.2.22.1
+        replaces: rhods-operator.2.22.0
+        skipRange: '>=2.22.0 <2.22.1'
+      - name: rhods-operator.2.22.2
+        replaces: rhods-operator.2.22.1
+        skipRange: '>=2.22.0 <2.22.2'
+      - name: rhods-operator.2.25.0
+        replaces: rhods-operator.2.22.2
+        skipRange: '>=2.22.0 <2.25.0'
+      - name: rhods-operator.2.25.1
+        replaces: rhods-operator.2.25.0
+        skipRange: '>=2.22.0 <2.25.1'
+      - name: rhods-operator.2.25.2
+        replaces: rhods-operator.2.25.1
+        skipRange: '>=2.22.0 <2.25.2'
+      - name: rhods-operator.3.3.0
+        replaces: rhods-operator.3.2.0
+        skipRange: '>=2.25.0 <3.3.0'
+    - name: stable-3.x
+      package: rhods-operator
+      schema: olm.channel
+      entries:
+      - name: rhods-operator.1.20.1-8
+      - name: rhods-operator.1.21.0-22
+        replaces: rhods-operator.1.20.1-8
+      - name: rhods-operator.1.22.0-2
+        replaces: rhods-operator.1.21.0-22
+      - name: rhods-operator.1.22.1-2
+        replaces: rhods-operator.1.22.0-2
+      - name: rhods-operator.1.22.1-4
+        replaces: rhods-operator.1.22.1-2
+        skipRange: '>=1.22.0-2 <1.22.1-10'
+      - name: rhods-operator.1.23.0
+        replaces: rhods-operator.1.22.1-4
+        skipRange: '>=1.22.0-1 <1.22.1-10'
+      - name: rhods-operator.1.24.0
+        replaces: rhods-operator.1.23.0
+      - name: rhods-operator.1.25.0
+        replaces: rhods-operator.1.24.0
+      - name: rhods-operator.1.26.0
+        replaces: rhods-operator.1.25.0
+      - name: rhods-operator.1.27.0
+        replaces: rhods-operator.1.26.0
+      - name: rhods-operator.1.28.0
+        replaces: rhods-operator.1.27.0
+      - name: rhods-operator.1.28.1
+        replaces: rhods-operator.1.28.0
+        skipRange: '>=1.27.0 <1.28.1'
+      - name: rhods-operator.1.29.0
+        replaces: rhods-operator.1.28.1
+        skipRange: '>=1.28.0 <1.29.0'
+      - name: rhods-operator.1.30.0
+        replaces: rhods-operator.1.29.0
+      - name: rhods-operator.1.31.0
+        replaces: rhods-operator.1.30.0
+      - name: rhods-operator.1.32.0
+        replaces: rhods-operator.1.31.0
+        skipRange: '>=1.31.0 <1.32.0'
+      - name: rhods-operator.1.33.0
+        replaces: rhods-operator.1.32.0
+        skipRange: '>=1.32.0 <1.33.0'
+      - name: rhods-operator.2.10.0
+        replaces: rhods-operator.2.8.3
+        skipRange: '>=2.8.0 <2.10.0'
+      - name: rhods-operator.2.11.0
+        skipRange: '>=2.10.0 <2.11.0'
+      - name: rhods-operator.2.11.0-0.1727935135.p
+        replaces: rhods-operator.2.10.0
+        skipRange: '>=2.10.0 <2.11.0'
+        skips:
+        - rhods-operator.2.11.0
+      - name: rhods-operator.2.12.0
+        replaces: rhods-operator.2.11.0-0.1727935135.p
+        skipRange: '>=2.11.0 <2.12.0'
+      - name: rhods-operator.2.13.0
+        replaces: rhods-operator.2.12.0
+        skipRange: '>=2.10.0 <2.13.0'
+      - name: rhods-operator.2.13.1
+        replaces: rhods-operator.2.13.0
+        skipRange: '>=2.13.0 <2.13.1'
+      - name: rhods-operator.2.4.0
+        replaces: rhods-operator.1.33.0
+        skipRange: '>=1.33.0 <2.4.0'
+      - name: rhods-operator.2.5.0
+        replaces: rhods-operator.2.4.0
+        skipRange: '>=2.4.0 <2.5.0'
+      - name: rhods-operator.2.6.0
+        replaces: rhods-operator.2.5.0
+        skipRange: '>=2.5.0 <2.6.0'
+      - name: rhods-operator.2.7.0
+        replaces: rhods-operator.2.6.0
+        skipRange: '>=2.6.0 <2.7.0'
+      - name: rhods-operator.2.8.0
+        replaces: rhods-operator.2.7.0
+        skipRange: '>=2.6.0 <2.8.0'
+      - name: rhods-operator.2.8.1
+        replaces: rhods-operator.2.8.0
+        skipRange: '>=2.8.0 <2.8.1'
+      - name: rhods-operator.2.8.2
+        replaces: rhods-operator.2.8.1
+        skipRange: '>=2.8.0 <2.8.2'
+      - name: rhods-operator.2.8.3
+        replaces: rhods-operator.2.8.2
+        skipRange: '>=2.8.0 <2.8.3'
+      - name: rhods-operator.2.16.0
+        replaces: rhods-operator.2.13.1
+        skipRange: '>=2.13.0 <2.16.0'
+      - name: rhods-operator.2.16.1
+        replaces: rhods-operator.2.16.0
+        skipRange: '>=2.16.0 <2.16.1'
+      - name: rhods-operator.2.16.2
+        replaces: rhods-operator.2.16.1
+        skipRange: '>=2.16.0 <2.16.2'
+      - name: rhods-operator.2.19.0
+        replaces: rhods-operator.2.16.2
+        skipRange: '>=2.16.0 <2.19.0'
+      - name: rhods-operator.2.19.1
+        replaces: rhods-operator.2.19.0
+        skipRange: '>=2.19.0 <2.19.1'
+      - name: rhods-operator.2.19.2
+        replaces: rhods-operator.2.19.1
+        skipRange: '>=2.19.0 <2.19.2'
+      - name: rhods-operator.2.22.0
+        replaces: rhods-operator.2.19.2
+        skipRange: '>=2.19.0 <2.22.0'
+      - name: rhods-operator.2.22.1
+        replaces: rhods-operator.2.22.0
+        skipRange: '>=2.22.0 <2.22.1'
+      - name: rhods-operator.2.22.2
+        replaces: rhods-operator.2.22.1
+        skipRange: '>=2.22.0 <2.22.2'
+      - name: rhods-operator.2.25.0
+        replaces: rhods-operator.2.22.2
+        skipRange: '>=2.22.0 <2.25.0'
+      - name: rhods-operator.2.25.1
+        replaces: rhods-operator.2.25.0
+        skipRange: '>=2.22.0 <2.25.1'
+      - name: rhods-operator.2.25.2
+        replaces: rhods-operator.2.25.1
+        skipRange: '>=2.22.0 <2.25.2'
+      - name: rhods-operator.3.3.0
+        replaces: rhods-operator.3.2.0
+        skipRange: '>=2.25.0 <3.3.0'
   
   olm.bundle:
     - quay.io/rhoai/odh-operator-bundle@sha256:debf992cc78401daa07d9e557467b64e012499a54ac978ee249f7b77fa2789a6


### PR DESCRIPTION
- enable 3.2 -> 3.3 upgrade via fast-3.x channel
- enable 2.25 -> 3.3 upgrade via stable-3.x and stable-3.3 channel

Both stable-3.x and stable-3.3 channel uses stable-2.25 as base for channel entries