### PR TITLE
replace arch-specific vLLM Spyre images with single manifest-list entry

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -32,9 +32,7 @@ additionalImages:
     value: "registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.2.5@sha256:094db84a1da5e8a575d0c9eade114fa30f4a2061064a338e3e032f3578f8082a"
   - name: RELATED_IMAGE_RHAIIS_VLLM_ROCM_IMAGE
     value: "registry.redhat.io/rhaiis/vllm-rocm-rhel9:3.2.5@sha256:bc99ee0a29f72ff34f930c9436d41feda2ab84bb5a53f7e76a9b8dbf8c776c44"
-  - name: RELATED_IMAGE_RHAIIS_VLLM_AMD64_SPYRE_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.2.5@sha256:80ae3e435a5be2c1f117f36599103ab05357917dd6e37f0df6613cb3ac2c13ea"
-  - name: RELATED_IMAGE_RHAIIS_VLLM_S390X_SPYRE_IMAGE
+  - name: RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE
     value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.2.5@sha256:80ae3e435a5be2c1f117f36599103ab05357917dd6e37f0df6613cb3ac2c13ea"
   - name: RELATED_IMAGE_ODH_PYTHON_312_IMAGE
     value: "registry.redhat.io/ubi9/python-312:latest@sha256:d14dd0aa47b885e9e6d229c641cda40008c5d46ca90b02df1f5faf8baf178125"


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHOAIENG-48885

Updates pathc so vLLM Spyre is referenced by one related image instead of separate AMD64 and S390X entries.

Changes
Removed architecture-specific related images:

- RELATED_IMAGE_RHAIIS_VLLM_AMD64_SPYRE_IMAGE
- RELATED_IMAGE_RHAIIS_VLLM_S390X_SPYRE_IMAGE

Added single related image:

- RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE (same image reference as before)