### PR TITLE
chore: update CATALOG_GENERATION_REF_OCP_VERSION to v4.19 in workflow files

### DIFF
--- a/.github/workflows/process-fbc-fragment.yaml
+++ b/.github/workflows/process-fbc-fragment.yaml
@@ -130,7 +130,7 @@ jobs:
           BUILD_CONFIG_PATH=${BRANCH}/config/build-config.yaml
           PATCH_YAML_PATH=${BRANCH}/catalog/catalog-patch.yaml
           
-          CATALOG_GENERATION_REF_OCP_VERSION=v4.17
+          CATALOG_GENERATION_REF_OCP_VERSION=v4.19
           CSV_META_MIN_OCP_VERSION=417
           BUNDLE_OBJECT_CATALOG_YAML_PATH=main/pcc/bundle_object_catalog.yaml
           CSV_META_CATALOG_YAML_PATH=main/pcc/csv_meta_catalog.yaml

--- a/.github/workflows/trigger-nightly-fbc-build.yaml
+++ b/.github/workflows/trigger-nightly-fbc-build.yaml
@@ -128,7 +128,7 @@ jobs:
           BUILD_CONFIG_PATH=${BRANCH}/config/build-config.yaml
           PATCH_YAML_PATH=${BRANCH}/catalog/catalog-patch.yaml
           
-          CATALOG_GENERATION_REF_OCP_VERSION=v4.17
+          CATALOG_GENERATION_REF_OCP_VERSION=v4.19
           CSV_META_MIN_OCP_VERSION=417
           BUNDLE_OBJECT_CATALOG_YAML_PATH=main/pcc/bundle_object_catalog.yaml
           CSV_META_CATALOG_YAML_PATH=main/pcc/csv_meta_catalog.yaml


### PR DESCRIPTION
This will make opm migrate pull from redhat-operator-index:v4.19, which contains the bundles for 2.25.2, 3.0.0, and 3.2.0, so the PCC validation will pass and the 2.16.4 release workflow can proceed.