### PR TITLE
Switch to refactored bundle processor

### DIFF
--- a/.github/workflows/process-operator-bundle.yaml
+++ b/.github/workflows/process-operator-bundle.yaml
@@ -10,14 +10,15 @@ on:
       - to-be-processed/bundle/**
     branches:
       - 'rhoai-2.1[6-9]+'
-      - 'rhoai-2.2[0-9]+' # Trigger the workflow on pushes to any rhoai-2.20 branch
+      - 'rhoai-2.2[0-9]+' # Trigger the workflow on pushes to any rhoai-2.20 branch and above
       - 'rhoai-3.[0-9]+' # Trigger the workflow on pushes to any rhoai-3.x branch
+
 permissions:
   contents: write
 
 env:
   GITHUB_ORG: red-hat-data-services
-  GITHUB_RKA_ORG: rhoai-rhtap
+  LOG_FILE_NAME: bundle-processor.log
 
 jobs:
   process-bundle:
@@ -38,7 +39,7 @@ jobs:
       - name: Git checkout utils
         uses: actions/checkout@v4
         with:
-          repository: ${{ env.GITHUB_RKA_ORG }}/RHOAI-Konflux-Automation
+          repository: ${{ env.GITHUB_ORG }}/RHOAI-Konflux-Automation
           ref: main
           path: utils
       - name: Install dependencies
@@ -53,38 +54,64 @@ jobs:
           ln -s $yq_filename yq
           cp $yq_filename /usr/local/bin/yq
   
-          pip install --default-timeout=100 -r utils/utils/bundle-processor/requirements.txt
+          pip install --default-timeout=100 -r utils/utils/processors/requirements.txt
+
       - name: Process Operator Bundle
         env:
           BRANCH: ${{ steps.get_branch.outputs.branch }}
           OC_TOKEN: ${{ secrets.KONFLUX_INTERNAL_OC_TOKEN }}
           CLUSTER: p02
           RHOAI_QUAY_API_TOKEN: ${{ secrets.RHOAI_QUAY_API_TOKEN }}
+          # NOTE: LOG_FILE_DIR is set at step level (not workflow level) for container jobs.
+          # At workflow level, ${{ github.workspace }} resolves to the HOST path (e.g., /home/runner/work/REPO/REPO),
+          # which doesn't exist inside the container. Using '.' writes to the current working directory,
+          # which is correctly set to the container's mounted workspace.
+          LOG_FILE_DIR: .
+          LOG_FILE_NAME: ${{ env.LOG_FILE_NAME }}
         run: |
           #Declare basic variables
           OPENSHIFT_VERSION=v4.13
           RHOAI_VERSION=v${BRANCH/rhoai-/}
           COMPONENT_SUFFIX=${RHOAI_VERSION/./-}
           OPERATOR_BUNDLE_COMPONENT_NAME=odh-operator-bundle-${COMPONENT_SUFFIX}
-          
+
           #copy all the raw content to tmp location
           RAW_INPUTS_DIR=utils/tmp/bundle
           mkdir -p $RAW_INPUTS_DIR
           cp -r ${BRANCH}/to-be-processed/bundle/* $RAW_INPUTS_DIR
-          
+
           #Declare Bundle processing variables
           BUILD_CONFIG_PATH=${BRANCH}/config/build-config.yaml
           BUNDLE_CSV_PATH=${RAW_INPUTS_DIR}/manifests/rhods-operator.clusterserviceversion.yaml
           PATCH_YAML_PATH=${BRANCH}/bundle/bundle-patch.yaml
-          SINGLE_BUNDLE_PATH=utils/utils/single_bundle_catalog_semver.yaml
           OUTPUT_FILE_PATH=${RAW_INPUTS_DIR}/manifests/rhods-operator.clusterserviceversion.yaml
-          SNAPSHOT_JSON_PATH=${BRANCH}/config/snapshot.json
           ANNOTATION_YAML_PATH=${RAW_INPUTS_DIR}/metadata/annotations.yaml
           PUSH_PIPELINE_PATH=${BRANCH}/.tekton/${OPERATOR_BUNDLE_COMPONENT_NAME}-push.yaml
-          
+
           #Invoke Bundle processor to patch the catalog
-          python3 utils/utils/bundle-processor/bundle-processor.py -op bundle-patch -b ${BUILD_CONFIG_PATH} -c ${BUNDLE_CSV_PATH} -p ${PATCH_YAML_PATH} -sn ${SNAPSHOT_JSON_PATH} -o ${OUTPUT_FILE_PATH} -v ${BRANCH} -a ${ANNOTATION_YAML_PATH} --push-pipeline-yaml-path ${PUSH_PIPELINE_PATH} --push-pipeline-operation enable
+          python3 utils/utils/processors/bundle-processor.py \
+            -op bundle-patch \
+            -b ${BUILD_CONFIG_PATH} \
+            -c ${BUNDLE_CSV_PATH} \
+            -p ${PATCH_YAML_PATH} \
+            -o ${OUTPUT_FILE_PATH} \
+            -v ${BRANCH} \
+            -a ${ANNOTATION_YAML_PATH} \
+            -y ${PUSH_PIPELINE_PATH} \
+            -x enable
+
           cp -r ${RAW_INPUTS_DIR}/* ${BRANCH}/bundle
+
+      - name: Print debug logs
+        if: always()
+        run: |
+          if [ -f "${{ env.LOG_FILE_NAME }}" ]; then
+            echo "=== Bundle processor log ==="
+            cat "${{ env.LOG_FILE_NAME }}"
+          else
+            echo "Log file not found: ${{ env.LOG_FILE_NAME }}"
+          fi
+
       - name: Commit and push the changes to release branch
         uses: actions-js/push@master
         with:

--- a/.github/workflows/trigger-nightly-bundle-build.yaml
+++ b/.github/workflows/trigger-nightly-bundle-build.yaml
@@ -11,9 +11,11 @@ on:
       - 'rhoai-3.[0-9]+' # Trigger the workflow on pushes to any rhoai-3.x branch
 permissions:
   contents: write
+
 env:
   GITHUB_ORG: red-hat-data-services
-  GITHUB_RKA_ORG: rhoai-rhtap
+  LOG_FILE_NAME: bundle-processor.log
+
 jobs:
   process-bundle:
     if: ${{ github.ref_name != 'main' }}
@@ -33,7 +35,7 @@ jobs:
       - name: Git checkout utils
         uses: actions/checkout@v4
         with:
-          repository: ${{ env.GITHUB_RKA_ORG }}/RHOAI-Konflux-Automation
+          repository: ${{ env.GITHUB_ORG }}/RHOAI-Konflux-Automation
           ref: main
           path: utils
       - name: Install dependencies
@@ -48,13 +50,20 @@ jobs:
           ln -s $yq_filename yq
           cp $yq_filename /usr/local/bin/yq
   
-          pip install --default-timeout=100 -r utils/utils/bundle-processor/requirements.txt
+          pip install --default-timeout=100 -r utils/utils/processors/requirements.txt
+
       - name: Process Operator Bundle
         env:
           BRANCH: ${{ steps.get_branch.outputs.branch }}
           OC_TOKEN: ${{ secrets.KONFLUX_INTERNAL_OC_TOKEN }}
           CLUSTER: p02
           RHOAI_QUAY_API_TOKEN: ${{ secrets.RHOAI_QUAY_API_TOKEN }}
+          # NOTE: LOG_FILE_DIR is set at step level (not workflow level) for container jobs.
+          # At workflow level, ${{ github.workspace }} resolves to the HOST path (e.g., /home/runner/work/REPO/REPO),
+          # which doesn't exist inside the container. Using '.' writes to the current working directory,
+          # which is correctly set to the container's mounted workspace.
+          LOG_FILE_DIR: .
+          LOG_FILE_NAME: ${{ env.LOG_FILE_NAME }}
         run: |
           #Declare basic variables
           OPENSHIFT_VERSION=v4.13
@@ -66,26 +75,42 @@ jobs:
           RAW_INPUTS_DIR=utils/tmp/bundle
           mkdir -p $RAW_INPUTS_DIR
           cp -r ${BRANCH}/to-be-processed/bundle/* $RAW_INPUTS_DIR
-          
+
           #Declare Bundle processing variables
           BUILD_CONFIG_PATH=${BRANCH}/config/build-config.yaml
           BUNDLE_CSV_PATH=${RAW_INPUTS_DIR}/manifests/rhods-operator.clusterserviceversion.yaml
           PATCH_YAML_PATH=${BRANCH}/bundle/bundle-patch.yaml
-          SINGLE_BUNDLE_PATH=utils/utils/single_bundle_catalog_semver.yaml
           OUTPUT_FILE_PATH=${RAW_INPUTS_DIR}/manifests/rhods-operator.clusterserviceversion.yaml
-          SNAPSHOT_JSON_PATH=${BRANCH}/config/snapshot.json
           ANNOTATION_YAML_PATH=${RAW_INPUTS_DIR}/metadata/annotations.yaml
           PUSH_PIPELINE_PATH=${BRANCH}/.tekton/${OPERATOR_BUNDLE_COMPONENT_NAME}-push.yaml
-          
+
           #Invoke Bundle processor to patch the catalog
-          python3 utils/utils/bundle-processor/bundle-processor.py -op bundle-patch -b ${BUILD_CONFIG_PATH} -c ${BUNDLE_CSV_PATH} -p ${PATCH_YAML_PATH} -sn ${SNAPSHOT_JSON_PATH} -o ${OUTPUT_FILE_PATH} -v ${BRANCH} -a ${ANNOTATION_YAML_PATH} --push-pipeline-yaml-path ${PUSH_PIPELINE_PATH} --push-pipeline-operation disable --build-type nightly
+          python3 utils/utils/processors/bundle-processor.py \
+            -op bundle-patch \
+            -b ${BUILD_CONFIG_PATH} \
+            -c ${BUNDLE_CSV_PATH} \
+            -p ${PATCH_YAML_PATH} \
+            -o ${OUTPUT_FILE_PATH} \
+            -v ${BRANCH} \
+            -a ${ANNOTATION_YAML_PATH} \
+            -y ${PUSH_PIPELINE_PATH} \
+            -x disable \
+            -t nightly
+
           cp -r ${RAW_INPUTS_DIR}/* ${BRANCH}/bundle
-          
-          # Update the schedule file to trigger the nightly build 
+
+          # Update the schedule file to trigger the nightly build
           echo $(date +'%d-%m-%Y %H:%M:%S:%3N') > ${BRANCH}/schedule/bundle-tekton-trigger.txt
-          
-          #disable CI builds while nightly runs
-          
+
+      - name: Print debug logs
+        if: always()
+        run: |
+          if [ -f "${{ env.LOG_FILE_NAME }}" ]; then
+            echo "=== Bundle processor log ==="
+            cat "${{ env.LOG_FILE_NAME }}"
+          else
+            echo "Log file not found: ${{ env.LOG_FILE_NAME }}"
+          fi
 
       - name: Commit and push the changes to release branch
         uses: actions-js/push@master


### PR DESCRIPTION
## Changes

1. **Refactored processor** — Both workflows now use the refactored bundle processor from `red-hat-data-services/RHOAI-Konflux-Automation` (`utils/utils/processors/`).

2. **Print debug step** — A "Print debug logs" step was added before commit and push. It runs with `if: always()` and prints the processor log file so failures can be debugged from the run output.

3. **Variables no longer passed** — `SNAPSHOT_JSON_PATH` and `SINGLE_BUNDLE_PATH` are no longer set or passed. The old bundle-patch code never used the snapshot (it was commented out in the constructor), and the refactored bundle-patch path doesn't take a snapshot. `SINGLE_BUNDLE_PATH` was only defined in the workflow and never passed to the script. Dropping them is a cleanup only; behavior is unchanged.

Refactoring PR: https://github.com/red-hat-data-services/RHOAI-Konflux-Automation/pull/16