### PR TITLE
fix: use pull_request event for bundle-insta-merge and consolidate branch patterns

### DIFF
--- a/.github/workflows/bundle-insta-merge.yaml
+++ b/.github/workflows/bundle-insta-merge.yaml
@@ -1,12 +1,12 @@
 name: Insta Merge Bundle Nudges
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
-      - 'rhoai-3.[0-9]'  # e.g. rhoai-3.1, rhoai-3.4
-      - 'rhoai-3.[0-9][0-9]'  # e.g. rhoai-3.10, rhoai-3.22
-      - 'rhoai-3.[0-9]-ea.[0-9]'  # e.g. rhoai-3.4-ea.1, rhoai-3.5-ea.2
-      - 'rhoai-3.[0-9][0-9]-ea.[0-9]'  # e.g. rhoai-3.10-ea.3
+      - 'rhoai-[23].[0-9]'  # e.g. rhoai-2.1, rhoai-3.1, rhoai-3.4
+      - 'rhoai-[23].[0-9][0-9]'  # e.g. rhoai-2.10, rhoai-3.10, rhoai-3.22
+      - 'rhoai-[3].[0-9]-ea.[0-9]'  # e.g. rhoai-3.4-ea.1, rhoai-3.5-ea.2
+      - 'rhoai-[3].[0-9][0-9]-ea.[0-9]'  # e.g. rhoai-3.10-ea.3
     types:
       - opened
       - reopened

--- a/.github/workflows/fbc-insta-merge.yaml
+++ b/.github/workflows/fbc-insta-merge.yaml
@@ -3,10 +3,10 @@ name: Insta Merge FBC Nudges
 on:
   pull_request:
     branches:
-      - 'rhoai-3.[0-9]'  # e.g. rhoai-3.1, rhoai-3.4
-      - 'rhoai-3.[0-9][0-9]'  # e.g. rhoai-3.10, rhoai-3.22
-      - 'rhoai-3.[0-9]-ea.[0-9]'  # e.g. rhoai-3.4-ea.1, rhoai-3.5-ea.2
-      - 'rhoai-3.[0-9][0-9]-ea.[0-9]'  # e.g. rhoai-3.10-ea.3
+      - 'rhoai-[23].[0-9]'  # e.g. rhoai-2.1, rhoai-3.1, rhoai-3.4
+      - 'rhoai-[23].[0-9][0-9]'  # e.g. rhoai-2.10, rhoai-3.10, rhoai-3.22
+      - 'rhoai-[3].[0-9]-ea.[0-9]'  # e.g. rhoai-3.4-ea.1, rhoai-3.5-ea.2
+      - 'rhoai-[3].[0-9][0-9]-ea.[0-9]'  # e.g. rhoai-3.10-ea.3
     types:
       - opened
       - reopened

--- a/.github/workflows/process-fbc-fragment.yaml
+++ b/.github/workflows/process-fbc-fragment.yaml
@@ -6,10 +6,10 @@ on:
     paths:
       - catalog/catalog-patch.yaml
     branches:
-      - 'rhoai-3.[0-9]'  # e.g. rhoai-3.1, rhoai-3.4
-      - 'rhoai-3.[0-9][0-9]'  # e.g. rhoai-3.10, rhoai-3.22
-      - 'rhoai-3.[0-9]-ea.[0-9]'  # e.g. rhoai-3.4-ea.1, rhoai-3.5-ea.2
-      - 'rhoai-3.[0-9][0-9]-ea.[0-9]'  # e.g. rhoai-3.10-ea.3
+      - 'rhoai-[23].[0-9]'  # e.g. rhoai-2.1, rhoai-3.1, rhoai-3.4
+      - 'rhoai-[23].[0-9][0-9]'  # e.g. rhoai-2.10, rhoai-3.10, rhoai-3.22
+      - 'rhoai-[3].[0-9]-ea.[0-9]'  # e.g. rhoai-3.4-ea.1, rhoai-3.5-ea.2
+      - 'rhoai-[3].[0-9][0-9]-ea.[0-9]'  # e.g. rhoai-3.10-ea.3
 permissions:
   contents: write
 

--- a/.github/workflows/process-operator-bundle.yaml
+++ b/.github/workflows/process-operator-bundle.yaml
@@ -9,10 +9,10 @@ on:
       - bundle/csv-patch.yaml
       - to-be-processed/bundle/**
     branches:
-      - 'rhoai-3.[0-9]'  # e.g. rhoai-3.1, rhoai-3.4
-      - 'rhoai-3.[0-9][0-9]'  # e.g. rhoai-3.10, rhoai-3.22
-      - 'rhoai-3.[0-9]-ea.[0-9]'  # e.g. rhoai-3.4-ea.1, rhoai-3.5-ea.2
-      - 'rhoai-3.[0-9][0-9]-ea.[0-9]'  # e.g. rhoai-3.10-ea.3
+      - 'rhoai-[23].[0-9]'  # e.g. rhoai-2.1, rhoai-3.1, rhoai-3.4
+      - 'rhoai-[23].[0-9][0-9]'  # e.g. rhoai-2.10, rhoai-3.10, rhoai-3.22
+      - 'rhoai-[3].[0-9]-ea.[0-9]'  # e.g. rhoai-3.4-ea.1, rhoai-3.5-ea.2
+      - 'rhoai-[3].[0-9][0-9]-ea.[0-9]'  # e.g. rhoai-3.10-ea.3
 
 permissions:
   contents: write

--- a/.github/workflows/trigger-nightly-bundle-build.yaml
+++ b/.github/workflows/trigger-nightly-bundle-build.yaml
@@ -6,10 +6,10 @@ on:
     paths:
       - schedule/bundle-github-trigger.txt
     branches:
-      - 'rhoai-3.[0-9]'  # e.g. rhoai-3.1, rhoai-3.4
-      - 'rhoai-3.[0-9][0-9]'  # e.g. rhoai-3.10, rhoai-3.22
-      - 'rhoai-3.[0-9]-ea.[0-9]'  # e.g. rhoai-3.4-ea.1, rhoai-3.5-ea.2
-      - 'rhoai-3.[0-9][0-9]-ea.[0-9]'  # e.g. rhoai-3.10-ea.3
+      - 'rhoai-[23].[0-9]'  # e.g. rhoai-2.1, rhoai-3.1, rhoai-3.4
+      - 'rhoai-[23].[0-9][0-9]'  # e.g. rhoai-2.10, rhoai-3.10, rhoai-3.22
+      - 'rhoai-[3].[0-9]-ea.[0-9]'  # e.g. rhoai-3.4-ea.1, rhoai-3.5-ea.2
+      - 'rhoai-[3].[0-9][0-9]-ea.[0-9]'  # e.g. rhoai-3.10-ea.3
 permissions:
   contents: write
 

--- a/.github/workflows/trigger-nightly-fbc-build.yaml
+++ b/.github/workflows/trigger-nightly-fbc-build.yaml
@@ -6,10 +6,10 @@ on:
     paths:
       - schedule/catalog-github-trigger.txt
     branches:
-      - 'rhoai-3.[0-9]'  # e.g. rhoai-3.1, rhoai-3.4
-      - 'rhoai-3.[0-9][0-9]'  # e.g. rhoai-3.10, rhoai-3.22
-      - 'rhoai-3.[0-9]-ea.[0-9]'  # e.g. rhoai-3.4-ea.1, rhoai-3.5-ea.2
-      - 'rhoai-3.[0-9][0-9]-ea.[0-9]'  # e.g. rhoai-3.10-ea.3
+      - 'rhoai-[23].[0-9]'  # e.g. rhoai-2.1, rhoai-3.1, rhoai-3.4
+      - 'rhoai-[23].[0-9][0-9]'  # e.g. rhoai-2.10, rhoai-3.10, rhoai-3.22
+      - 'rhoai-[3].[0-9]-ea.[0-9]'  # e.g. rhoai-3.4-ea.1, rhoai-3.5-ea.2
+      - 'rhoai-[3].[0-9][0-9]-ea.[0-9]'  # e.g. rhoai-3.10-ea.3
 permissions:
   contents: write
 env:


### PR DESCRIPTION
## Summary

- Change `bundle-insta-merge.yaml` from `pull_request_target` to `pull_request` so the workflow reads from the PR's branch instead of the default branch (`main`). This was the root cause of [PR #15547](https://github.com/red-hat-data-services/RHOAI-Build-Config/pull/15547) not being auto-merged.
- Consolidate branch patterns across all 6 workflow files to cover `rhoai-2.x`, `rhoai-3.x`, and `rhoai-3.x-ea.y` branches.

Made with [Cursor](https://cursor.com)