### PR TITLE
Disable build-image-index for rhoai-2.16 FBC pipelines

### DIFF
--- a/.tekton/rhoai-fbc-fragment-v2-16-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-v2-16-push.yaml
@@ -40,6 +40,8 @@ spec:
     value: catalog/catalog_build_args.map
   - name: skip-checks
     value: false
+  - name: build-image-index
+    value: "false"
   - name: build-type
     value: "ci"
   - name: rhoai-version

--- a/.tekton/rhoai-fbc-fragment-v2-16-scheduled.yaml
+++ b/.tekton/rhoai-fbc-fragment-v2-16-scheduled.yaml
@@ -39,6 +39,8 @@ spec:
     value: catalog/catalog_build_args.map
   - name: skip-checks
     value: false
+  - name: build-image-index
+    value: "false"
   - name: build-type
     value: "nightly"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version


### PR DESCRIPTION
The shared pipeline in konflux-central defaults build-image-index to true, wrapping single-arch builds in an OCI image index. The stage promoter validation rejects this for versions below 2.18, causing nightly stage pushes to fail.