### PR TITLE
[Test] [Do not merge] Inject vLLM version

### DIFF
--- a/.github/workflows/process-operator-bundle.yaml
+++ b/.github/workflows/process-operator-bundle.yaml
@@ -57,6 +57,12 @@ jobs:
   
           pip install --default-timeout=100 -r utils/utils/processors/requirements.txt
 
+          microdnf install -y skopeo golang && \
+              microdnf clean all && rm -rf /var/cache/dnf/*
+
+          # cosign v3.0.5 (commit 479147a4df05f31be48aeb2b3a9d32dfc35ba877)
+          GOBIN=/usr/local/bin go install github.com/sigstore/cosign/v3/cmd/cosign@479147a4df05f31be48aeb2b3a9d32dfc35ba877
+
       - name: Process Operator Bundle
         env:
           BRANCH: ${{ steps.get_branch.outputs.branch }}
@@ -102,6 +108,20 @@ jobs:
             -x enable
 
           cp -r ${RAW_INPUTS_DIR}/* ${BRANCH}/bundle
+
+      - name: Inject vLLM versions from SBOMs
+        env:
+          BRANCH: ${{ steps.get_branch.outputs.branch }}
+          RHOAI_CATALOG_SA_USERNAME: ${{ secrets.RHOAI_CATALOG_SA_USERNAME }}
+          RHOAI_CATALOG_SA_TOKEN: ${{ secrets.RHOAI_CATALOG_SA_TOKEN }}
+        run: |
+          skopeo login registry.redhat.io \
+            -u "${RHOAI_CATALOG_SA_USERNAME}" \
+            -p "${RHOAI_CATALOG_SA_TOKEN}"
+
+          chmod +x "${BRANCH}/bundle/inject-vllm-versions.sh"
+          bash "${BRANCH}/bundle/inject-vllm-versions.sh" \
+            "${BRANCH}/bundle/manifests/rhods-operator.clusterserviceversion.yaml"
 
       - name: Print debug logs
         if: always()

--- a/bundle/inject-vllm-versions.sh
+++ b/bundle/inject-vllm-versions.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# inject-vllm-versions.sh
+#
+# Extracts the upstream vLLM version from container image SBOMs (via cosign)
+# for each RHAIIS vLLM image found in the operator CSV, and injects
+# corresponding _UPSTREAM_VERSION env vars back into the CSV.
+#
+# The script uses sed for surgical edits to avoid reformatting the YAML.
+#
+# Usage:
+#   ./inject-vllm-versions.sh <csv-path>
+#
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <csv-path>" >&2
+  exit 1
+fi
+
+CSV_PATH="$1"
+
+if [[ ! -f "$CSV_PATH" ]]; then
+  echo "ERROR: CSV not found: $CSV_PATH" >&2
+  exit 1
+fi
+
+ERRORS=0
+INJECTED=0
+
+# extract_vllm_version <image-ref>
+#
+# Downloads the SBOM for a multi-arch image index, finds the first
+# per-architecture image digest, then downloads that arch-specific SBOM
+# and extracts the vLLM Python package version.
+extract_vllm_version() {
+  local image_ref="$1"
+
+  # Step 1: Get a per-arch digest from the index-level SBOM.
+  # The index SBOM only lists image variants; actual packages are in per-arch SBOMs.
+  local arch_digest
+  arch_digest=$(cosign download sbom "$image_ref" 2>/dev/null | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for pkg in data.get('packages', []):
+    for ref in pkg.get('externalRefs', []):
+        loc = ref.get('referenceLocator', '')
+        if ref.get('referenceType') == 'purl' and 'arch=' in loc:
+            import re
+            m = re.search(r'sha256:[a-f0-9]+', loc)
+            if m:
+                print(m.group(0))
+                sys.exit(0)
+sys.exit(1)
+") || return 1
+
+  # Build the per-arch image reference (same repo, arch-specific digest)
+  local repo
+  repo="${image_ref%%@*}"
+  local arch_ref="${repo}@${arch_digest}"
+
+  # Step 2: Download the per-arch SBOM and extract the vLLM package version.
+  cosign download sbom "$arch_ref" 2>/dev/null | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for pkg in data.get('packages', []):
+    if pkg.get('name') == 'vllm':
+        print(pkg.get('versionInfo', ''))
+        sys.exit(0)
+sys.exit(1)
+" || return 1
+}
+
+# Read RELATED_IMAGE_RHAII[S]_VLLM_*_IMAGE entries directly from the CSV
+while IFS= read -r line; do
+  # Extract the env var name (e.g. RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE or RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE)
+  name=$(echo "$line" | sed -n 's/.*- name: \(RELATED_IMAGE_RHAII[S]\?_VLLM_[A-Z_]*_IMAGE\)$/\1/p')
+  [[ -z "$name" ]] && continue
+
+  # Read the next line to get the value
+  value_line=$(grep -A1 "name: ${name}$" "$CSV_PATH" | tail -1)
+  value=$(echo "$value_line" | sed 's/.*value: //')
+
+  version_name="${name}_UPSTREAM_VERSION"
+  echo "-> Inspecting SBOM for ${name}..."
+
+  # Image values may have the format: registry/org/repo:tag@sha256:digest
+  # cosign needs: registry/org/repo@sha256:digest
+  image_ref="${value}"
+  if [[ "$image_ref" == *:*@* ]]; then
+    image_ref="${image_ref%%@*}"
+    image_ref="${image_ref%:*}@${value#*@}"
+  fi
+
+  version=$(extract_vllm_version "$image_ref") || true
+
+  if [[ -z "$version" ]]; then
+    echo "ERROR: Failed to extract vLLM version from SBOM for ${name} (${image_ref})" >&2
+    ERRORS=$((ERRORS + 1))
+    continue
+  fi
+
+  echo "   ${version_name} = ${version}"
+
+  # Remove any existing _UPSTREAM_VERSION entry for this image (if re-running)
+  sed -i "/- name: ${version_name}$/{N;d;}" "$CSV_PATH"
+
+  # Detect the indentation from the _IMAGE line
+  indent=$(grep "name: ${name}$" "$CSV_PATH" | sed 's/\(^[[:space:]]*\).*/\1/')
+
+  # Insert _UPSTREAM_VERSION entry right after the _IMAGE value line
+  sed -i "/- name: ${name}$/{N;a\\
+${indent}- name: ${version_name}\n${indent}  value: \"${version}\"
+}" "$CSV_PATH"
+
+  INJECTED=$((INJECTED + 1))
+done < <(grep -E "RELATED_IMAGE_RHAIIS?_VLLM_.*_IMAGE$" "$CSV_PATH")
+
+if [[ $INJECTED -eq 0 ]]; then
+  echo "WARNING: No RELATED_IMAGE_RHAII[S]_VLLM_*_IMAGE entries found in $CSV_PATH" >&2
+  exit 0
+fi
+
+echo ""
+echo "=== vLLM Version Injection Summary ==="
+grep -E -A1 "RELATED_IMAGE_RHAIIS?_VLLM_.*_UPSTREAM_VERSION" "$CSV_PATH" | grep -v "^--$" | paste - - | sed 's/.*name: /  /;s/[[:space:]]*value: / = /'
+echo "======================================="
+
+if [[ $ERRORS -gt 0 ]]; then
+  echo "ERROR: Failed to extract version for $ERRORS image(s)" >&2
+  exit 1
+fi
+
+echo "Done. Injected ${INJECTED} version env var(s)."


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIRFE-1529

this produces this diff

```
[pierdipi] RHOAI-Build-Config (inject-vllm-version) (k8s:default/api-pierdipi-osp-rh-ods-com:6443/htpasswd-cluster-admin-user)
-> $ ./bundle/inject-vllm-versions.sh bundle/manifests/rhods-operator.clusterserviceversion.yaml
-> Inspecting SBOM for RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE...
   RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE_UPSTREAM_VERSION = 0.14.1+rhai4
-> Inspecting SBOM for RELATED_IMAGE_RHAIIS_VLLM_ROCM_IMAGE...
   RELATED_IMAGE_RHAIIS_VLLM_ROCM_IMAGE_UPSTREAM_VERSION = 0.14.1+rhai4
-> Inspecting SBOM for RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE...
   RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE_UPSTREAM_VERSION = 0.14.1+rhai4
-> Inspecting SBOM for RELATED_IMAGE_RHAIIS_VLLM_CPU_IMAGE...
   RELATED_IMAGE_RHAIIS_VLLM_CPU_IMAGE_UPSTREAM_VERSION = 0.14.1+rhai4

=== vLLM Version Injection Summary ===
  RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE_UPSTREAM_VERSION = "0.14.1+rhai4"
  RELATED_IMAGE_RHAIIS_VLLM_ROCM_IMAGE_UPSTREAM_VERSION = "0.14.1+rhai4"
  RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE_UPSTREAM_VERSION = "0.14.1+rhai4"
  RELATED_IMAGE_RHAIIS_VLLM_CPU_IMAGE_UPSTREAM_VERSION = "0.14.1+rhai4"
=======================================
Done. Injected 4 version env var(s).
[pierdipi] RHOAI-Build-Config (inject-vllm-version) (k8s:default/api-pierdipi-osp-rh-ods-com:6443/htpasswd-cluster-admin-user)
```

```diff
diff --git a/bundle/manifests/rhods-operator.clusterserviceversion.yaml b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
index fbdffacb6..cd810e6c4 100644
--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -2092,16 +2092,24 @@ spec:
                   value: registry.redhat.io/openshift4/ose-prom-label-proxy-rhel9@sha256:2adfbbc4205be3d161063234991aae3f34ab6e0557207d9cfa4a498711a922b4
                 - name: RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE
                   value: registry.redhat.io/rhaii-early-access/vllm-cuda-rhel9@sha256:0fdc98bf2fc0f1a552a028d34ef0c0fa9b98e0792772effe5b3410b31486267a
+                - name: RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE_UPSTREAM_VERSION
+                  value: "0.14.1+rhai4"
                 - name: RELATED_IMAGE_RHAIIS_VLLM_ROCM_IMAGE
                   value: registry.redhat.io/rhaii-early-access/vllm-rocm-rhel9@sha256:e450131a29f25ec0483bdebf5d9420e1089290dd636c7a2586ddd47a052b8eb5
+                - name: RELATED_IMAGE_RHAIIS_VLLM_ROCM_IMAGE_UPSTREAM_VERSION
+                  value: "0.14.1+rhai4"
                 - name: RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE
                   value: registry.redhat.io/rhaii-early-access/vllm-spyre-rhel9@sha256:f8d996baa88d1e799c7e951b1f686f6b20e4ae150895413c82903d613e8e679b
+                - name: RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE_UPSTREAM_VERSION
+                  value: "0.14.1+rhai4"
                 - name: RELATED_IMAGE_ODH_PYTHON_312_IMAGE
                   value: registry.redhat.io/ubi9/python-312@sha256:b0637633ec1e249fcc47a28b1587a715721783681437e9d5536714c98e03ad6d
                 - name: RELATED_IMAGE_PERSES_IMAGE
                   value: registry.redhat.io/cluster-observability-operator/perses-rhel9@sha256:e797cdb47beef40b04da7b6d645bca3dc32e6247003c45b56b38efd9e13bf01c
                 - name: RELATED_IMAGE_RHAIIS_VLLM_CPU_IMAGE
                   value: registry.redhat.io/rhaii-early-access/vllm-cpu-rhel9@sha256:2da77e06d0c017fe99a9cff155583a566dec7cf40bb7408ccf1821f5ff18c5d0
+                - name: RELATED_IMAGE_RHAIIS_VLLM_CPU_IMAGE_UPSTREAM_VERSION
+                  value: "0.14.1+rhai4"
                 - name: RELATED_IMAGE_NGINX_126_IMAGE
                   value: registry.redhat.io/ubi9/nginx-126@sha256:40b10417e440b554c15ce05d289e3931be6266a724aa534a52ae7b92a1a3024e
                 image: "registry.redhat.io/rhoai/odh-rhel9-operator@sha256:3ccc9e34afcfd8cad31754fde908a8ecde82527777499ccbafb0865cc8112266"
```