### PR TITLE
Integrate helm chart processing into bundle workflows

### DIFF
--- a/.github/workflows/process-operator-bundle.yaml
+++ b/.github/workflows/process-operator-bundle.yaml
@@ -8,6 +8,8 @@ on:
       - bundle/bundle-patch.yaml
       - bundle/csv-patch.yaml
       - to-be-processed/bundle/**
+      - helm/values-patch.yaml
+      - to-be-processed/helm/**
     branches:
       - 'rhoai-[23].[0-9]'  # e.g. rhoai-2.1, rhoai-3.1, rhoai-3.4
       - 'rhoai-[23].[0-9][0-9]'  # e.g. rhoai-2.10, rhoai-3.10, rhoai-3.22
@@ -75,11 +77,17 @@ jobs:
           RHOAI_VERSION=v${BRANCH/rhoai-/}
           COMPONENT_SUFFIX=${RHOAI_VERSION//./-}
           OPERATOR_BUNDLE_COMPONENT_NAME=odh-operator-bundle-${COMPONENT_SUFFIX}
+          HELM_CHART_COMPONENT_NAME=rhaii-helm-chart-${COMPONENT_SUFFIX}
 
           #copy all the raw content to tmp location
           RAW_INPUTS_DIR=utils/tmp/bundle
           mkdir -p $RAW_INPUTS_DIR
           cp -r ${BRANCH}/to-be-processed/bundle/* $RAW_INPUTS_DIR
+
+          #copy helm raw content to tmp location
+          HELM_RAW_INPUTS_DIR=utils/tmp/helm
+          mkdir -p $HELM_RAW_INPUTS_DIR
+          cp -r ${BRANCH}/to-be-processed/helm/* $HELM_RAW_INPUTS_DIR
 
           #Declare Bundle processing variables
           BUILD_CONFIG_PATH=${BRANCH}/config/build-config.yaml
@@ -87,7 +95,12 @@ jobs:
           PATCH_YAML_PATH=${BRANCH}/bundle/bundle-patch.yaml
           OUTPUT_FILE_PATH=${RAW_INPUTS_DIR}/manifests/rhods-operator.clusterserviceversion.yaml
           ANNOTATION_YAML_PATH=${RAW_INPUTS_DIR}/metadata/annotations.yaml
-          PUSH_PIPELINE_PATH=${BRANCH}/.tekton/${OPERATOR_BUNDLE_COMPONENT_NAME}-push.yaml
+          BUNDLE_PUSH_PIPELINE_PATH=${BRANCH}/.tekton/${OPERATOR_BUNDLE_COMPONENT_NAME}-push.yaml
+
+          #Declare Helm processing variables
+          HELM_PATCH_YAML_PATH=${BRANCH}/helm/values-patch.yaml
+          HELM_VALUES_YAML_PATH=${HELM_RAW_INPUTS_DIR}/rhaii-helm-chart/values.yaml
+          HELM_PUSH_PIPELINE_PATH=${BRANCH}/.tekton/${HELM_CHART_COMPONENT_NAME}-push.yaml
 
           #Invoke Bundle processor to patch the catalog
           python3 utils/utils/processors/bundle-processor.py \
@@ -98,10 +111,14 @@ jobs:
             -o ${OUTPUT_FILE_PATH} \
             -v ${BRANCH} \
             -a ${ANNOTATION_YAML_PATH} \
-            -y ${PUSH_PIPELINE_PATH} \
+            -hp ${HELM_PATCH_YAML_PATH} \
+            -hv ${HELM_VALUES_YAML_PATH} \
+            -hpp ${HELM_PUSH_PIPELINE_PATH} \
+            -y ${BUNDLE_PUSH_PIPELINE_PATH} \
             -x enable
 
           cp -r ${RAW_INPUTS_DIR}/* ${BRANCH}/bundle
+          cp -r ${HELM_RAW_INPUTS_DIR}/* ${BRANCH}/helm/
 
       - name: Print debug logs
         if: always()
@@ -118,7 +135,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ steps.get_branch.outputs.branch }}
-          message: "Updating the bundle-csv with latest images"
+          message: "Updating the bundle-csv and helm chart values with latest images"
           repository: ${{ env.GITHUB_ORG }}/RHOAI-Build-Config
           directory: ${{ steps.get_branch.outputs.branch }}
           author_name: Openshift-AI DevOps

--- a/.github/workflows/trigger-nightly-bundle-build.yaml
+++ b/.github/workflows/trigger-nightly-bundle-build.yaml
@@ -71,11 +71,17 @@ jobs:
           RHOAI_VERSION=v${BRANCH/rhoai-/}
           COMPONENT_SUFFIX=${RHOAI_VERSION//./-}
           OPERATOR_BUNDLE_COMPONENT_NAME=odh-operator-bundle-${COMPONENT_SUFFIX}
+          HELM_CHART_COMPONENT_NAME=rhaii-helm-chart-${COMPONENT_SUFFIX}
 
           #copy all the raw content to tmp location
           RAW_INPUTS_DIR=utils/tmp/bundle
           mkdir -p $RAW_INPUTS_DIR
           cp -r ${BRANCH}/to-be-processed/bundle/* $RAW_INPUTS_DIR
+
+          #copy helm raw content to tmp location
+          HELM_RAW_INPUTS_DIR=utils/tmp/helm
+          mkdir -p $HELM_RAW_INPUTS_DIR
+          cp -r ${BRANCH}/to-be-processed/helm/* $HELM_RAW_INPUTS_DIR
 
           #Declare Bundle processing variables
           BUILD_CONFIG_PATH=${BRANCH}/config/build-config.yaml
@@ -83,7 +89,12 @@ jobs:
           PATCH_YAML_PATH=${BRANCH}/bundle/bundle-patch.yaml
           OUTPUT_FILE_PATH=${RAW_INPUTS_DIR}/manifests/rhods-operator.clusterserviceversion.yaml
           ANNOTATION_YAML_PATH=${RAW_INPUTS_DIR}/metadata/annotations.yaml
-          PUSH_PIPELINE_PATH=${BRANCH}/.tekton/${OPERATOR_BUNDLE_COMPONENT_NAME}-push.yaml
+          BUNDLE_PUSH_PIPELINE_PATH=${BRANCH}/.tekton/${OPERATOR_BUNDLE_COMPONENT_NAME}-push.yaml
+
+          #Declare Helm processing variables
+          HELM_PATCH_YAML_PATH=${BRANCH}/helm/values-patch.yaml
+          HELM_VALUES_YAML_PATH=${HELM_RAW_INPUTS_DIR}/rhaii-helm-chart/values.yaml
+          HELM_PUSH_PIPELINE_PATH=${BRANCH}/.tekton/${HELM_CHART_COMPONENT_NAME}-push.yaml
 
           #Invoke Bundle processor to patch the catalog
           python3 utils/utils/processors/bundle-processor.py \
@@ -94,11 +105,15 @@ jobs:
             -o ${OUTPUT_FILE_PATH} \
             -v ${BRANCH} \
             -a ${ANNOTATION_YAML_PATH} \
-            -y ${PUSH_PIPELINE_PATH} \
+            -hp ${HELM_PATCH_YAML_PATH} \
+            -hv ${HELM_VALUES_YAML_PATH} \
+            -hpp ${HELM_PUSH_PIPELINE_PATH} \
+            -y ${BUNDLE_PUSH_PIPELINE_PATH} \
             -x disable \
             -t nightly
 
           cp -r ${RAW_INPUTS_DIR}/* ${BRANCH}/bundle
+          cp -r ${HELM_RAW_INPUTS_DIR}/* ${BRANCH}/helm/
 
           # Update the schedule file to trigger the nightly build
           echo $(date +'%d-%m-%Y %H:%M:%S:%3N') > ${BRANCH}/schedule/bundle-tekton-trigger.txt
@@ -118,7 +133,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ steps.get_branch.outputs.branch }}
-          message: "Updating the bundle-csv with latest images"
+          message: "Updating the bundle-csv and helm chart values with latest images"
           repository: ${{ env.GITHUB_ORG }}/RHOAI-Build-Config
           directory: ${{ steps.get_branch.outputs.branch }}
           author_name: Openshift-AI DevOps

--- a/.tekton/rhaii-helm-chart-v3-4-push.yaml
+++ b/.tekton/rhaii-helm-chart-v3-4-push.yaml
@@ -1,0 +1,35 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/RHOAI-Build-Config?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch == "rhoai-3.4"
+      && ( "to-be-processed/helm/**".pathChanged() || ".tekton/rhaii-helm-chart-v3-4-push.yaml".pathChanged() )
+      && !".github/workflows/**".pathChanged()
+  labels:
+    appstudio.openshift.io/application: rhoai-v3-4
+    appstudio.openshift.io/component: rhaii-helm-chart-v3-4
+    pipelines.appstudio.openshift.io/type: build
+  name: rhaii-helm-chart-v3-4-on-push
+  namespace: rhoai-tenant
+spec:
+  pipelineSpec:
+    tasks:
+    - name: hello
+      taskSpec:
+        steps:
+        - name: hello
+          image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+          script: |
+            echo "Hello from rhaii-helm-chart-v3-4 push pipeline!"
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/helm/values-patch.yaml
+++ b/helm/values-patch.yaml
@@ -1,0 +1,34 @@
+rhaiOperator:
+  image: "registry.redhat.io/rhoai/odh-rhel9-operator"
+  relatedImages:
+    - name: RELATED_IMAGE_ODH_KSERVE_AGENT_IMAGE
+      value: "registry.redhat.io/rhoai/odh-kserve-agent-rhel9"
+    - name: RELATED_IMAGE_ODH_KSERVE_CONTROLLER_IMAGE
+      value: "registry.redhat.io/rhoai/odh-kserve-controller-rhel9"
+    - name: RELATED_IMAGE_ODH_KSERVE_LLMISVC_CONTROLLER_IMAGE
+      value: "registry.redhat.io/rhoai/odh-kserve-llmisvc-controller-rhel9"
+    - name: RELATED_IMAGE_ODH_KSERVE_ROUTER_IMAGE
+      value: "registry.redhat.io/rhoai/odh-kserve-router-rhel9"
+    - name: RELATED_IMAGE_ODH_KSERVE_STORAGE_INITIALIZER_IMAGE
+      value: "registry.redhat.io/rhoai/odh-kserve-storage-initializer-rhel9"
+    - name: RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE
+      value: "registry.redhat.io/rhaiis/vllm-cuda-rhel9"
+    - name: RELATED_IMAGE_RHAIIS_VLLM_ROCM_IMAGE
+      value: "registry.redhat.io/rhaiis/vllm-rocm-rhel9"
+    - name: RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE
+      value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9"
+    - name: RELATED_IMAGE_ODH_LLM_D_INFERENCE_SCHEDULER_IMAGE
+      value: "registry.redhat.io/rhoai/odh-llm-d-inference-scheduler-rhel9"
+    - name: RELATED_IMAGE_ODH_LLM_D_ROUTING_SIDECAR_IMAGE
+      value: "registry.redhat.io/rhoai/odh-llm-d-routing-sidecar-rhel9"
+    - name: RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE
+      value: "registry.redhat.io/rhoai/odh-kube-auth-proxy-rhel9"
+    - name: RELATED_IMAGE_ODH_LLM_D_KV_CACHE_IMAGE
+      value: "registry.redhat.io/rhoai/odh-llm-d-kv-cache-rhel9"
+
+azure:
+    image: "registry.redhat.io/rhoai/odh-rhel9-operator"
+
+coreweave:
+    image: "registry.redhat.io/rhoai/odh-rhel9-operator"
+


### PR DESCRIPTION
## Summary
Extends the bundle processing pipelines to also patch the RHAII helm chart values.yaml with production image references.

The processor first updates `helm/values-patch.yaml` with latest image refences, then applies the updated patch to `values.yaml`, setting the operator image, cloud manager images, and relatedImages list with full SHA256 digests.

The final processed chart is written to `helm/rhaii-helm-chart/` from the final artifact is generated.

Helm push pipeline enable/disable is handled alongside the bundle push pipeline.

Depends on: https://github.com/red-hat-data-services/RHOAI-Konflux-Automation/pull/27
JIRA: https://redhat.atlassian.net/browse/RHOAIENG-50137