### PR TITLE
Fix onboarded-since version for v4.21

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -14,4 +14,4 @@ config:
     - version: v4.20
       onboarded-since: rhods-operator.2.25.0
     - version: v4.21
-      onboarded-since: rhods-operator.3.3.0
+      onboarded-since: rhods-operator.2.25.0


### PR DESCRIPTION
We are now onboarding 2.25.0 onto v4.21