### PR TITLE
Allow cross version upgrade only via dedicated channel

### DIFF
--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -19,7 +19,7 @@ patch:
       - name: rhods-operator.3.3.1
         replaces: rhods-operator.3.3.0
         skipRange: '>=3.3.0 <3.3.1'
-    - name: support-required-migration
+    - name: support-required-upgrade
       package: rhods-operator
       schema: olm.channel
       entries:

--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -10,7 +10,7 @@ patch:
       - name: rhods-operator.3.3.0
       - name: rhods-operator.3.3.1
         replaces: rhods-operator.3.3.0
-        skipRange: '>=2.25.3 <2.26.0 || >=3.3.0 <3.3.1'
+        skipRange: '>=3.3.0 <3.3.1'
     - name: stable-3.x
       package: rhods-operator
       schema: olm.channel
@@ -18,7 +18,13 @@ patch:
       - name: rhods-operator.3.3.0
       - name: rhods-operator.3.3.1
         replaces: rhods-operator.3.3.0
-        skipRange: '>=2.25.3 <2.26.0 || >=3.3.0 <3.3.1'
+        skipRange: '>=3.3.0 <3.3.1'
+    - name: support-required-migration
+      package: rhods-operator
+      schema: olm.channel
+      entries:
+      - name: rhods-operator.3.3.1
+        skipRange: '>=2.25.3 <2.26.0'
 
   olm.bundle:
     - quay.io/rhoai/odh-operator-bundle@sha256:652605a6d7a14dc786e78447322cd7bf6613840bda18e3ed4a3b7676cd0649b7


### PR DESCRIPTION
## Summary
- Introduce a new `support-required-upgrade` OLM channel to isolate the 2.25.3 → 3.3.1 upgrade path
- Removed cross-major-version upgrade path from stable channels

Reference: [Discussion on upgrade channels](https://docs.google.com/document/d/1_6dZH5Kynhjv1WiD4VSCfqr10_qdZ0imqA75-TVjOMc/edit?tab=t.rwca54v9rzw7)
