### PR TITLE
Release automation: automation-3.4 → rhoai-3.4-test

### DIFF
--- a/.tekton/odh-operator-bundle-v3-4-push.yaml
+++ b/.tekton/odh-operator-bundle-v3-4-push.yaml
@@ -7,20 +7,20 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    build.appstudio.openshift.io/build-nudge-files: "catalog/catalog-patch.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.4-ea.2"
-      && "schedule/catalog-tekton-trigger.txt".pathChanged()
+      && target_branch == "rhoai-3.4"
+      && ( "bundle/**".pathChanged() || ".tekton/odh-operator-bundle-v3-4-push.yaml".pathChanged() )
+      && !"bundle/bundle-patch.yaml".pathChanged()
+      && !".github/workflows/**".pathChanged()
   labels:
-    appstudio.openshift.io/application: rhoai-v3-4-ea-2
-    appstudio.openshift.io/component: rhoai-fbc-fragment-v3-4-ea-2
+    appstudio.openshift.io/application: rhoai-v3-4
+    appstudio.openshift.io/component: odh-operator-bundle-v3-4
     pipelines.appstudio.openshift.io/type: build
-  name: rhoai-fbc-fragment-v3-4-ea-2-on-schedule
+  name: odh-operator-bundle-v3-4-on-push
   namespace: rhoai-tenant
 spec:
-  timeouts:
-    pipeline: 10h
-    tasks: 8h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -29,37 +29,22 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - '{{target_branch}}-nightly'
   - name: output-image
-    value: quay.io/rhoai/rhoai-fbc-fragment:{{target_branch}}
+    value: quay.io/rhoai/odh-operator-bundle:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.0-ea.2"
-  - name: build-platforms
-    value:
-    - linux/x86_64
-    - linux/ppc64le
-    - linux/s390x
-    - linux/arm64
+    value: "3.4.0"
   - name: dockerfile
-    value: Dockerfile
+    value: bundle/Dockerfile
   - name: path-context
-    value: catalog/v4.19
+    value: .
   - name: hermetic
     value: true
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: true
-  - name: build-args-file
-    value: catalog/catalog_build_args.map
-  - name: skip-checks
     value: false
-  - name: build-type
-    value: "nightly"
-  - name: workflow_url
-    value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/conforma-reporter.yaml"
-  - name: smoke_url
-    value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/smoke-trigger.yaml"
+  - name: build-args-file
+    value: bundle/bundle_build_args.map
   pipelineRef:
     resolver: git
     params:
@@ -68,9 +53,9 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/fbc-fragment-build.yaml
+      value: pipelines/container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhoai-fbc-fragment-v3-4-ea-2
+    serviceAccountName: build-pipeline-odh-operator-bundle-v3-4
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/odh-operator-bundle-v3-4-scheduled.yaml
+++ b/.tekton/odh-operator-bundle-v3-4-scheduled.yaml
@@ -7,18 +7,16 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    build.appstudio.openshift.io/build-nudge-files: "catalog/catalog-patch.yaml"
+    build.appstudio.openshift.io/build-nudge-files: "schedule/catalog-github-trigger.txt"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.4-ea.2"
-      && ( "bundle/**".pathChanged() || ".tekton/odh-operator-bundle-v3-4-ea-2-push.yaml".pathChanged() )
-      && !"bundle/bundle-patch.yaml".pathChanged()
-      && !".github/workflows/**".pathChanged()
+      && target_branch == "rhoai-3.4"
+      && "schedule/bundle-tekton-trigger.txt".pathChanged()
   labels:
-    appstudio.openshift.io/application: rhoai-v3-4-ea-2
-    appstudio.openshift.io/component: odh-operator-bundle-v3-4-ea-2
+    appstudio.openshift.io/application: rhoai-v3-4
+    appstudio.openshift.io/component: odh-operator-bundle-v3-4
     pipelines.appstudio.openshift.io/type: build
-  name: odh-operator-bundle-v3-4-ea-2-on-push
+  name: odh-operator-bundle-v3-4-on-schedule
   namespace: rhoai-tenant
 spec:
   params:
@@ -29,10 +27,11 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
+    - '{{target_branch}}-nightly'
   - name: output-image
     value: quay.io/rhoai/odh-operator-bundle:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.0-ea.2"
+    value: "3.4.0"
   - name: dockerfile
     value: bundle/Dockerfile
   - name: path-context
@@ -55,7 +54,7 @@ spec:
     - name: pathInRepo
       value: pipelines/container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-operator-bundle-v3-4-ea-2
+    serviceAccountName: build-pipeline-odh-operator-bundle-v3-4
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhoai-fbc-fragment-v3-4-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-v3-4-push.yaml
@@ -9,15 +9,15 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.4-ea.2"
-      && ( "catalog/**".pathChanged() || ".tekton/rhoai-fbc-fragment-v3-4-ea-2-push.yaml".pathChanged() )
+      && target_branch == "rhoai-3.4"
+      && ( "catalog/**".pathChanged() || ".tekton/rhoai-fbc-fragment-v3-4-push.yaml".pathChanged() )
       && !"catalog/catalog-patch.yaml".pathChanged()
       && !".github/workflows/**".pathChanged()
   labels:
-    appstudio.openshift.io/application: rhoai-v3-4-ea-2
-    appstudio.openshift.io/component: rhoai-fbc-fragment-v3-4-ea-2
+    appstudio.openshift.io/application: rhoai-v3-4
+    appstudio.openshift.io/component: rhoai-fbc-fragment-v3-4
     pipelines.appstudio.openshift.io/type: build
-  name: rhoai-fbc-fragment-v3-4-ea-2-on-push
+  name: rhoai-fbc-fragment-v3-4-on-push
   namespace: rhoai-tenant
 spec:
   timeouts:
@@ -34,7 +34,7 @@ spec:
   - name: output-image
     value: quay.io/rhoai/rhoai-fbc-fragment:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.0-ea.2"
+    value: "3.4.0"
   - name: dockerfile
     value: Dockerfile
   - name: path-context
@@ -67,7 +67,7 @@ spec:
     - name: pathInRepo
       value: pipelines/fbc-fragment-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhoai-fbc-fragment-v3-4-ea-2
+    serviceAccountName: build-pipeline-rhoai-fbc-fragment-v3-4
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhoai-fbc-fragment-v3-4-scheduled.yaml
+++ b/.tekton/rhoai-fbc-fragment-v3-4-scheduled.yaml
@@ -7,18 +7,20 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    build.appstudio.openshift.io/build-nudge-files: "schedule/catalog-github-trigger.txt"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.4-ea.2"
-      && "schedule/bundle-tekton-trigger.txt".pathChanged()
+      && target_branch == "rhoai-3.4"
+      && "schedule/catalog-tekton-trigger.txt".pathChanged()
   labels:
-    appstudio.openshift.io/application: rhoai-v3-4-ea-2
-    appstudio.openshift.io/component: odh-operator-bundle-v3-4-ea-2
+    appstudio.openshift.io/application: rhoai-v3-4
+    appstudio.openshift.io/component: rhoai-fbc-fragment-v3-4
     pipelines.appstudio.openshift.io/type: build
-  name: odh-operator-bundle-v3-4-ea-2-on-schedule
+  name: rhoai-fbc-fragment-v3-4-on-schedule
   namespace: rhoai-tenant
 spec:
+  timeouts:
+    pipeline: 10h
+    tasks: 8h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -29,21 +31,35 @@ spec:
     - '{{target_branch}}-{{revision}}'
     - '{{target_branch}}-nightly'
   - name: output-image
-    value: quay.io/rhoai/odh-operator-bundle:{{target_branch}}
+    value: quay.io/rhoai/rhoai-fbc-fragment:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.0-ea.2"
+    value: "3.4.0"
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
   - name: dockerfile
-    value: bundle/Dockerfile
+    value: Dockerfile
   - name: path-context
-    value: .
+    value: catalog/v4.19
   - name: hermetic
     value: true
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-args-file
-    value: bundle/bundle_build_args.map
+    value: catalog/catalog_build_args.map
+  - name: skip-checks
+    value: false
+  - name: build-type
+    value: "nightly"
+  - name: workflow_url
+    value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/conforma-reporter.yaml"
+  - name: smoke_url
+    value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/smoke-trigger.yaml"
   pipelineRef:
     resolver: git
     params:
@@ -52,9 +68,9 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/fbc-fragment-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-operator-bundle-v3-4-ea-2
+    serviceAccountName: build-pipeline-rhoai-fbc-fragment-v3-4
   workspaces:
   - name: git-auth
     secret:

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -1,5 +1,5 @@
 patch:
-  version: 3.4.0-ea.2
+  version: 3.4.0
   relatedImages:
     - name: RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE
       value: "quay.io/rhoai/odh-kf-notebook-controller-rhel9@sha256:8fdab8122b0433dfa1045f22074c891d2b84fd21a073f406d12d5bcbe9b9b805"


### PR DESCRIPTION
### Goal

Merge automation commits on **`automation-3.4`** **into** **`rhoai-3.4-test`** (PR base = the release line that should receive the bump). Version strings and Tekton/bundle updates only touch a small set of paths.

**Default flow:** **`{base_branch}`** is **staging** (logical `argv[2]` + `RBC_STAGING_BRANCH_SUFFIX`, e.g. `rhoai-3.4-test`), first pushed at the same tip as `previous_branch`. **Head** is `automation-*` built from `previous_branch` only.

**Scope:** Release branches only (not `main`). Repo: `RBC_MAIN_REPO`.

### Branches

- **PR base (`rhoai-3.4-test`):** staging branch on `origin` (logical argv[2] + suffix).
- **PR head (`automation-3.4`):** automation branch (`automation-<train>`).

### Why GitHub says “merge … **into** `rhoai-3.4-test` **from** `automation-3.4`”

GitHub **always** phrases pull requests as: **merge [head] into [base]**.
- **head** = branch with the new commits (`automation-3.4`)
- **base** = target if you merge (`rhoai-3.4-test`)

That is **not** reversed history: **old → new**. **Files changed** = what differs on head vs base.

**Different PR base:** set `RBC_PR_BASE` to another branch name that exists on `origin` (usually still a **release** branch, not `main`, unless you have a special case).

[Compare view](https://github.com/red-hat-data-services/RHOAI-Build-Config/compare/rhoai-3.4-test...automation-3.4)

---

**Automation scope:** four Tekton YAMLs under `.tekton` (odh + rhoai), `bundle/bundle-patch.yaml`; `bundle/csv-patch.yaml` is skipped only for EA on the same x.y train. Verify images when needed.

Commit uses `[skip ci]` by default (`RBC_SKIP_CI=0` to allow CI). Set `RBC_SKIP_PR_BASE_PUSH=1` if the PR base must already exist on the remote (refuse to push base).