### PR TITLE
Release automation: automation-3.5-ea.1 → rhoai-3.5-ea.1-test

### DIFF
--- a/.tekton/odh-operator-bundle-v3-5-ea-1-push.yaml
+++ b/.tekton/odh-operator-bundle-v3-5-ea-1-push.yaml
@@ -7,16 +7,19 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    build.appstudio.openshift.io/build-nudge-files: "schedule/catalog-github-trigger.txt"
+    build.appstudio.openshift.io/build-nudge-files: "catalog/catalog-patch.yaml"
+    # Trigger on bundle/ changes (or this tekton file)
+    # No trigger if bundle/bundle-patch.yaml is the only change
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.4"
-      && "schedule/bundle-tekton-trigger.txt".pathChanged()
+      && target_branch == "rhoai-3.5-ea.1"
+      && ( "bundle/**".pathChanged() || ".tekton/odh-operator-bundle-v3-5-ea-1-push.yaml".pathChanged() )
+      && files.all.exists(p, !p.matches('^bundle/bundle-patch\\.yaml$'))
   labels:
-    appstudio.openshift.io/application: rhoai-v3-4
-    appstudio.openshift.io/component: odh-operator-bundle-v3-4
+    appstudio.openshift.io/application: rhoai-v3-5-ea-1
+    appstudio.openshift.io/component: odh-operator-bundle-v3-5-ea-1
     pipelines.appstudio.openshift.io/type: build
-  name: odh-operator-bundle-v3-4-on-schedule
+  name: odh-operator-bundle-v3-5-ea-1-on-push
   namespace: rhoai-tenant
 spec:
   params:
@@ -27,11 +30,10 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - '{{target_branch}}-nightly'
   - name: output-image
     value: quay.io/rhoai/odh-operator-bundle:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.0"
+    value: "3.5.0-ea.1"
   - name: dockerfile
     value: bundle/Dockerfile
   - name: path-context
@@ -54,7 +56,7 @@ spec:
     - name: pathInRepo
       value: pipelines/container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-operator-bundle-v3-4
+    serviceAccountName: build-pipeline-odh-operator-bundle-v3-5-ea-1
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/odh-operator-bundle-v3-5-ea-1-scheduled.yaml
+++ b/.tekton/odh-operator-bundle-v3-5-ea-1-scheduled.yaml
@@ -7,19 +7,16 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    build.appstudio.openshift.io/build-nudge-files: "catalog/catalog-patch.yaml"
-    # Trigger on bundle/ changes (or this tekton file)
-    # No trigger if bundle/bundle-patch.yaml is the only change
+    build.appstudio.openshift.io/build-nudge-files: "schedule/catalog-github-trigger.txt"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.4"
-      && ( "bundle/**".pathChanged() || ".tekton/odh-operator-bundle-v3-4-push.yaml".pathChanged() )
-      && files.all.exists(p, !p.matches('^bundle/bundle-patch\\.yaml$'))
+      && target_branch == "rhoai-3.5-ea.1"
+      && "schedule/bundle-tekton-trigger.txt".pathChanged()
   labels:
-    appstudio.openshift.io/application: rhoai-v3-4
-    appstudio.openshift.io/component: odh-operator-bundle-v3-4
+    appstudio.openshift.io/application: rhoai-v3-5-ea-1
+    appstudio.openshift.io/component: odh-operator-bundle-v3-5-ea-1
     pipelines.appstudio.openshift.io/type: build
-  name: odh-operator-bundle-v3-4-on-push
+  name: odh-operator-bundle-v3-5-ea-1-on-schedule
   namespace: rhoai-tenant
 spec:
   params:
@@ -30,10 +27,11 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
+    - '{{target_branch}}-nightly'
   - name: output-image
     value: quay.io/rhoai/odh-operator-bundle:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.0"
+    value: "3.5.0-ea.1"
   - name: dockerfile
     value: bundle/Dockerfile
   - name: path-context
@@ -56,7 +54,7 @@ spec:
     - name: pathInRepo
       value: pipelines/container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-operator-bundle-v3-4
+    serviceAccountName: build-pipeline-odh-operator-bundle-v3-5-ea-1
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhoai-fbc-fragment-v3-5-ea-1-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-v3-5-ea-1-push.yaml
@@ -7,15 +7,18 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    # Trigger on catalog/ changes (or this tekton file)
+    # No trigger if catalog/catalog-patch.yaml is the only change
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.4"
-      && "schedule/catalog-tekton-trigger.txt".pathChanged()
+      && target_branch == "rhoai-3.5-ea.1"
+      && ( "catalog/**".pathChanged() || ".tekton/rhoai-fbc-fragment-v3-5-ea-1-push.yaml".pathChanged() )
+      && files.all.exists(p, !p.matches('^catalog/catalog-patch\\.yaml$'))
   labels:
-    appstudio.openshift.io/application: rhoai-v3-4
-    appstudio.openshift.io/component: rhoai-fbc-fragment-v3-4
+    appstudio.openshift.io/application: rhoai-v3-5-ea-1
+    appstudio.openshift.io/component: rhoai-fbc-fragment-v3-5-ea-1
     pipelines.appstudio.openshift.io/type: build
-  name: rhoai-fbc-fragment-v3-4-on-schedule
+  name: rhoai-fbc-fragment-v3-5-ea-1-on-push
   namespace: rhoai-tenant
 spec:
   timeouts:
@@ -29,17 +32,10 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - '{{target_branch}}-nightly'
   - name: output-image
     value: quay.io/rhoai/rhoai-fbc-fragment:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.0"
-  - name: build-platforms
-    value:
-    - linux/x86_64
-    - linux/ppc64le
-    - linux/s390x
-    - linux/arm64
+    value: "3.5.0-ea.1"
   - name: dockerfile
     value: Dockerfile
   - name: path-context
@@ -50,16 +46,18 @@ spec:
     value: true
   - name: build-image-index
     value: true
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
   - name: build-args-file
     value: catalog/catalog_build_args.map
   - name: skip-checks
     value: false
   - name: build-type
-    value: "nightly"
-  - name: workflow_url
-    value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/conforma-reporter.yaml"
-  - name: smoke_url
-    value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/smoke-trigger.yaml"
+    value: "ci"
   pipelineRef:
     resolver: git
     params:
@@ -70,7 +68,7 @@ spec:
     - name: pathInRepo
       value: pipelines/fbc-fragment-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhoai-fbc-fragment-v3-4
+    serviceAccountName: build-pipeline-rhoai-fbc-fragment-v3-5-ea-1
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhoai-fbc-fragment-v3-5-ea-1-scheduled.yaml
+++ b/.tekton/rhoai-fbc-fragment-v3-5-ea-1-scheduled.yaml
@@ -7,18 +7,15 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    # Trigger on catalog/ changes (or this tekton file)
-    # No trigger if catalog/catalog-patch.yaml is the only change
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.4"
-      && ( "catalog/**".pathChanged() || ".tekton/rhoai-fbc-fragment-v3-4-push.yaml".pathChanged() )
-      && files.all.exists(p, !p.matches('^catalog/catalog-patch\\.yaml$'))
+      && target_branch == "rhoai-3.5-ea.1"
+      && "schedule/catalog-tekton-trigger.txt".pathChanged()
   labels:
-    appstudio.openshift.io/application: rhoai-v3-4
-    appstudio.openshift.io/component: rhoai-fbc-fragment-v3-4
+    appstudio.openshift.io/application: rhoai-v3-5-ea-1
+    appstudio.openshift.io/component: rhoai-fbc-fragment-v3-5-ea-1
     pipelines.appstudio.openshift.io/type: build
-  name: rhoai-fbc-fragment-v3-4-on-push
+  name: rhoai-fbc-fragment-v3-5-ea-1-on-schedule
   namespace: rhoai-tenant
 spec:
   timeouts:
@@ -32,10 +29,17 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
+    - '{{target_branch}}-nightly'
   - name: output-image
     value: quay.io/rhoai/rhoai-fbc-fragment:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.0"
+    value: "3.5.0-ea.1"
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
   - name: dockerfile
     value: Dockerfile
   - name: path-context
@@ -46,18 +50,16 @@ spec:
     value: true
   - name: build-image-index
     value: true
-  - name: build-platforms
-    value:
-    - linux/x86_64
-    - linux/ppc64le
-    - linux/s390x
-    - linux/arm64
   - name: build-args-file
     value: catalog/catalog_build_args.map
   - name: skip-checks
     value: false
   - name: build-type
-    value: "ci"
+    value: "nightly"
+  - name: workflow_url
+    value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/conforma-reporter.yaml"
+  - name: smoke_url
+    value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/smoke-trigger.yaml"
   pipelineRef:
     resolver: git
     params:
@@ -68,7 +70,7 @@ spec:
     - name: pathInRepo
       value: pipelines/fbc-fragment-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhoai-fbc-fragment-v3-4
+    serviceAccountName: build-pipeline-rhoai-fbc-fragment-v3-5-ea-1
   workspaces:
   - name: git-auth
     secret:

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -1,5 +1,5 @@
 patch:
-  version: 3.4.0
+  version: 3.5.0-ea.1
   relatedImages:
     - name: RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE
       value: "quay.io/rhoai/odh-kf-notebook-controller-rhel9@sha256:8fdab8122b0433dfa1045f22074c891d2b84fd21a073f406d12d5bcbe9b9b805"

--- a/bundle/csv-patch.yaml
+++ b/bundle/csv-patch.yaml
@@ -28,4 +28,4 @@ spec:
     email: managed-open-data-hub@redhat.com
   links:
   - name: Red Hat OpenShift AI
-    url: https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4
+    url: https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5


### PR DESCRIPTION
### Goal

Merge automation commits on **`automation-3.5-ea.1`** **into** **`rhoai-3.5-ea.1-test`** (PR base = the release line that should receive the bump). Version strings and Tekton/bundle updates only touch a small set of paths.

**Default flow:** **`{base_branch}`** is **staging** (logical `argv[2]` + `RBC_STAGING_BRANCH_SUFFIX`, e.g. `rhoai-3.4-test`), first pushed at the same tip as `previous_branch`. **Head** is `automation-*` built from `previous_branch` only.

**Scope:** Release branches only (not `main`). Repo: `RBC_MAIN_REPO`.

### Branches

- **PR base (`rhoai-3.5-ea.1-test`):** staging branch on `origin` (logical argv[2] + suffix).
- **PR head (`automation-3.5-ea.1`):** automation branch (`automation-<train>`).

### Why GitHub says “merge … **into** `rhoai-3.5-ea.1-test` **from** `automation-3.5-ea.1`”

GitHub **always** phrases pull requests as: **merge [head] into [base]**.
- **head** = branch with the new commits (`automation-3.5-ea.1`)
- **base** = target if you merge (`rhoai-3.5-ea.1-test`)

That is **not** reversed history: **old → new**. **Files changed** = what differs on head vs base.

**Different PR base:** set `RBC_PR_BASE` to another branch name that exists on `origin` (usually still a **release** branch, not `main`, unless you have a special case).

[Compare view](https://github.com/red-hat-data-services/RHOAI-Build-Config/compare/rhoai-3.5-ea.1-test...automation-3.5-ea.1)

---

**Automation scope:** four Tekton YAMLs under `.tekton` (odh + rhoai), `bundle/bundle-patch.yaml`; `bundle/csv-patch.yaml` is skipped only for EA on the same x.y train. Verify images when needed.

Commit uses `[skip ci]` by default (`RBC_SKIP_CI=0` to allow CI). Set `RBC_SKIP_PR_BASE_PUSH=1` if the PR base must already exist on the remote (refuse to push base).