### PR TITLE
Sync RHAII vLLM Gaudi image entry to additional-images-patch

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -38,6 +38,8 @@ additionalImages:
     value: "registry.redhat.io/rhaiis/vllm-rocm-rhel9:3.3.0@sha256:e345cf9453afae0d3c2afe2f7fb9be8fac772f46593b873e925d38ae2b3ee537"
   - name: RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE
     value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.3.0@sha256:75f0ea05a92661a33b40efe2a662d976d53c767db18990b433d4a00dd6693aae"
+  - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
+    value: "registry.redhat.io/rhaii-early-access/vllm-gaudi-rhel9:3.4.0-ea.2@sha256:9743aa8b794b3fb89357aa91848ace931cecdc4cff09345d485333819b924817"
   - name: RELATED_IMAGE_ODH_PYTHON_312_IMAGE
     value: "registry.redhat.io/ubi9/python-312:latest@sha256:46f883684d02cef2a7abb0c4124f18308ad920018d76c5c56f130dae02bfed05"
   - name: RELATED_IMAGE_PERSES_IMAGE


### PR DESCRIPTION
## Add RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE to rhoai-3.4 branch

Syncs the Intel Gaudi vLLM image entry from the `rhoai-3.4-ea.2` branch to `rhoai-3.4`. The entry was added to EA2 before code freeze but was not merged back.

Entry added:

    - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
      value: "registry.redhat.io/rhaii-early-access/vllm-gaudi-rhel9:3.4.0-ea.2@sha256:9743aa8b794b3fb89357aa91848ace931cecdc4cff09345d485333819b924817"

This is needed for the Intel Gaudi accelerator LLMInferenceServiceConfig work:
- kserve: opendatahub-io/kserve#1331 (RHOAIENG-56358)
- operator: opendatahub-io/opendatahub-operator#3370 (RHOAIENG-56360)
- ODH-Build-Config: opendatahub-io/ODH-Build-Config#1039

Image digest verified via `skopeo inspect`. Entry name matches the confirmed convention (`RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE`) and the existing modelcontroller mapping.
