### PR TITLE
bump zstream main

### DIFF
--- a/.tekton/rhoai-fbc-fragment-rhoai-216-ocp-414-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-216-ocp-414-push.yaml
@@ -43,7 +43,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "2.16.4"
+    value: "2.16.5"
   - name: ocp-version
     value: "4.14"
   - name: fbc-pipeline-branch

--- a/.tekton/rhoai-fbc-fragment-rhoai-216-ocp-416-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-216-ocp-416-push.yaml
@@ -43,7 +43,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "2.16.4"
+    value: "2.16.5"
   - name: ocp-version
     value: "4.16"
   - name: fbc-pipeline-branch

--- a/.tekton/rhoai-fbc-fragment-rhoai-216-ocp-417-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-216-ocp-417-push.yaml
@@ -43,7 +43,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "2.16.4"
+    value: "2.16.5"
   - name: ocp-version
     value: "4.17"
   - name: fbc-pipeline-branch

--- a/.tekton/rhoai-fbc-fragment-rhoai-216-ocp-418-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-216-ocp-418-push.yaml
@@ -43,7 +43,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "2.16.4"
+    value: "2.16.5"
   - name: ocp-version
     value: "4.18"
   - name: fbc-pipeline-branch

--- a/.tekton/rhoai-fbc-fragment-rhoai-216-ocp-419-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-216-ocp-419-push.yaml
@@ -43,7 +43,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "2.16.4"
+    value: "2.16.5"
   - name: ocp-version
     value: "4.19"
   - name: fbc-pipeline-branch

--- a/.tekton/rhoai-fbc-fragment-rhoai-32-ocp-419-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-32-ocp-419-push.yaml
@@ -1,0 +1,69 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/RHOAI-Build-Config?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: '3'
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ("catalog/rhoai-3.2/v4.19/rhods-operator/catalog.yaml".pathChanged() || "builds/force-trigger-rhoai-3.2.txt".pathChanged())
+  labels:
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-419
+    appstudio.openshift.io/component: rhoai-fbc-fragment-ocp-419
+    pipelines.appstudio.openshift.io/type: build
+  name: rhoai-fbc-fragment-rhoai-32-ocp-419-on-push
+  namespace: rhoai-tenant
+spec:
+  timeouts:
+    pipeline: 8h
+    tasks: 6h
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: additional-tags
+    value:
+    - 'ocp-4.19-rhoai-3.2'
+  - name: output-image
+    value: quay.io/rhoai/rhoai-fbc-fragment:ocp-4.19-rhoai-3.2-{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: catalog/rhoai-3.2/v4.19
+  - name: build-args-file
+    value: catalog/rhoai-3.2/catalog_build_args.map
+  - name: skip-checks
+    value: false
+  - name: build-source-image
+    value: true
+  - name: build-type
+    value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
+  - name: rhoai-version
+    value: "3.2.1"
+  - name: ocp-version
+    value: "4.19"
+  - name: fbc-pipeline-branch
+    value: "rhoai-3.2"
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: "$(params.fbc-pipeline-branch)"
+    - name: pathInRepo
+      value: pipelines/fbc-fragment-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-rhoai-fbc-fragment-ocp-419
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/rhoai-fbc-fragment-rhoai-32-ocp-420-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-32-ocp-420-push.yaml
@@ -1,0 +1,67 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/RHOAI-Build-Config?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: '3'
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ("catalog/rhoai-3.2/v4.20/rhods-operator/catalog.yaml".pathChanged() || "builds/force-trigger-rhoai-3.2.txt".pathChanged())
+  labels:
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-420
+    appstudio.openshift.io/component: rhoai-fbc-fragment-ocp-420
+    pipelines.appstudio.openshift.io/type: build
+  name: rhoai-fbc-fragment-rhoai-32-ocp-420-on-push
+  namespace: rhoai-tenant
+spec:
+  timeouts:
+    pipeline: 8h
+    tasks: 6h
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: additional-tags
+    value:
+    - 'ocp-4.20-rhoai-3.2'
+  - name: output-image
+    value: quay.io/rhoai/rhoai-fbc-fragment:ocp-4.20-rhoai-3.2-{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: catalog/rhoai-3.2/v4.20
+  - name: build-args-file
+    value: catalog/rhoai-3.2/catalog_build_args.map
+  - name: skip-checks
+    value: false
+  - name: build-type
+    value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
+  - name: rhoai-version
+    value: "3.2.1"
+  - name: ocp-version
+    value: "4.20"
+  - name: fbc-pipeline-branch
+    value: "rhoai-3.2"
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: "$(params.fbc-pipeline-branch)"
+    - name: pathInRepo
+      value: pipelines/fbc-fragment-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-rhoai-fbc-fragment-ocp-420
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
- **resurrect 3.2 stage pipelines and bump to 3.2.1**
- **bump 2.16 pipelines to 2.16.5**

3.2 pipelines were found using

```
 git log --all -- rhoai-fbc-fragment-rhoai-32-ocp-419-push.yaml

# one commit before they were deleted
git ls-tree 214e6120654ceb3b2b64404e62d61ead453361e9~ 
git checkout 214e6120654ceb3b2b64404e62d61ead453361e9~  rhoai-fbc-fragment-rhoai-32-ocp-419-push.yaml rhoai-fbc-fragment-rhoai-32-ocp-420-push.yaml
```