### PR TITLE
Add batch release branch commit labels to catalog Dockerfiles

### DIFF
--- a/catalog/rhoai-2.16/v4.14/Dockerfile
+++ b/catalog/rhoai-2.16/v4.14/Dockerfile
@@ -57,6 +57,10 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
+ARG RBC_RELEASE_BRANCH_COMMIT_216=
+ARG RBC_RELEASE_BRANCH_COMMIT_225=
+ARG RBC_RELEASE_BRANCH_COMMIT_32=
+ARG RBC_RELEASE_BRANCH_COMMIT_33=
 
 
 # Configure the entrypoint and command
@@ -126,6 +130,11 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
+    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-2.16/v4.15/Dockerfile
+++ b/catalog/rhoai-2.16/v4.15/Dockerfile
@@ -57,6 +57,10 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
+ARG RBC_RELEASE_BRANCH_COMMIT_216=
+ARG RBC_RELEASE_BRANCH_COMMIT_225=
+ARG RBC_RELEASE_BRANCH_COMMIT_32=
+ARG RBC_RELEASE_BRANCH_COMMIT_33=
 
 
 # Configure the entrypoint and command
@@ -126,6 +130,11 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
+    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-2.16/v4.16/Dockerfile
+++ b/catalog/rhoai-2.16/v4.16/Dockerfile
@@ -57,6 +57,10 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
+ARG RBC_RELEASE_BRANCH_COMMIT_216=
+ARG RBC_RELEASE_BRANCH_COMMIT_225=
+ARG RBC_RELEASE_BRANCH_COMMIT_32=
+ARG RBC_RELEASE_BRANCH_COMMIT_33=
 
 
 # Configure the entrypoint and command
@@ -126,6 +130,11 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
+    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-2.16/v4.17/Dockerfile
+++ b/catalog/rhoai-2.16/v4.17/Dockerfile
@@ -57,6 +57,10 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
+ARG RBC_RELEASE_BRANCH_COMMIT_216=
+ARG RBC_RELEASE_BRANCH_COMMIT_225=
+ARG RBC_RELEASE_BRANCH_COMMIT_32=
+ARG RBC_RELEASE_BRANCH_COMMIT_33=
 
 
 # Configure the entrypoint and command
@@ -126,6 +130,11 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
+    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-2.16/v4.18/Dockerfile
+++ b/catalog/rhoai-2.16/v4.18/Dockerfile
@@ -57,6 +57,10 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
+ARG RBC_RELEASE_BRANCH_COMMIT_216=
+ARG RBC_RELEASE_BRANCH_COMMIT_225=
+ARG RBC_RELEASE_BRANCH_COMMIT_32=
+ARG RBC_RELEASE_BRANCH_COMMIT_33=
 
 
 # Configure the entrypoint and command
@@ -126,6 +130,11 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
+    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-2.16/v4.19/Dockerfile
+++ b/catalog/rhoai-2.16/v4.19/Dockerfile
@@ -57,6 +57,10 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
+ARG RBC_RELEASE_BRANCH_COMMIT_216=
+ARG RBC_RELEASE_BRANCH_COMMIT_225=
+ARG RBC_RELEASE_BRANCH_COMMIT_32=
+ARG RBC_RELEASE_BRANCH_COMMIT_33=
 
 
 # Configure the entrypoint and command
@@ -126,6 +130,11 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
+    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-2.25/v4.16/Dockerfile
+++ b/catalog/rhoai-2.25/v4.16/Dockerfile
@@ -57,6 +57,10 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
+ARG RBC_RELEASE_BRANCH_COMMIT_216=
+ARG RBC_RELEASE_BRANCH_COMMIT_225=
+ARG RBC_RELEASE_BRANCH_COMMIT_32=
+ARG RBC_RELEASE_BRANCH_COMMIT_33=
 
 
 # Configure the entrypoint and command
@@ -126,6 +130,11 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
+    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-2.25/v4.17/Dockerfile
+++ b/catalog/rhoai-2.25/v4.17/Dockerfile
@@ -57,6 +57,10 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
+ARG RBC_RELEASE_BRANCH_COMMIT_216=
+ARG RBC_RELEASE_BRANCH_COMMIT_225=
+ARG RBC_RELEASE_BRANCH_COMMIT_32=
+ARG RBC_RELEASE_BRANCH_COMMIT_33=
 
 
 # Configure the entrypoint and command
@@ -126,6 +130,11 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
+    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-2.25/v4.18/Dockerfile
+++ b/catalog/rhoai-2.25/v4.18/Dockerfile
@@ -57,6 +57,10 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
+ARG RBC_RELEASE_BRANCH_COMMIT_216=
+ARG RBC_RELEASE_BRANCH_COMMIT_225=
+ARG RBC_RELEASE_BRANCH_COMMIT_32=
+ARG RBC_RELEASE_BRANCH_COMMIT_33=
 
 
 # Configure the entrypoint and command
@@ -126,6 +130,11 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
+    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-2.25/v4.19/Dockerfile
+++ b/catalog/rhoai-2.25/v4.19/Dockerfile
@@ -57,6 +57,10 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
+ARG RBC_RELEASE_BRANCH_COMMIT_216=
+ARG RBC_RELEASE_BRANCH_COMMIT_225=
+ARG RBC_RELEASE_BRANCH_COMMIT_32=
+ARG RBC_RELEASE_BRANCH_COMMIT_33=
 
 
 # Configure the entrypoint and command
@@ -126,6 +130,11 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
+    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-2.25/v4.20/Dockerfile
+++ b/catalog/rhoai-2.25/v4.20/Dockerfile
@@ -57,6 +57,10 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
+ARG RBC_RELEASE_BRANCH_COMMIT_216=
+ARG RBC_RELEASE_BRANCH_COMMIT_225=
+ARG RBC_RELEASE_BRANCH_COMMIT_32=
+ARG RBC_RELEASE_BRANCH_COMMIT_33=
 
 
 # Configure the entrypoint and command
@@ -126,6 +130,11 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
+    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-2.25/v4.21/Dockerfile
+++ b/catalog/rhoai-2.25/v4.21/Dockerfile
@@ -57,6 +57,10 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
+ARG RBC_RELEASE_BRANCH_COMMIT_216=
+ARG RBC_RELEASE_BRANCH_COMMIT_225=
+ARG RBC_RELEASE_BRANCH_COMMIT_32=
+ARG RBC_RELEASE_BRANCH_COMMIT_33=
 
 
 # Configure the entrypoint and command
@@ -126,6 +130,11 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
+    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-3.2/v4.19/Dockerfile
+++ b/catalog/rhoai-3.2/v4.19/Dockerfile
@@ -57,6 +57,10 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
+ARG RBC_RELEASE_BRANCH_COMMIT_216=
+ARG RBC_RELEASE_BRANCH_COMMIT_225=
+ARG RBC_RELEASE_BRANCH_COMMIT_32=
+ARG RBC_RELEASE_BRANCH_COMMIT_33=
 
 
 # Configure the entrypoint and command
@@ -126,6 +130,11 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
+    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-3.2/v4.20/Dockerfile
+++ b/catalog/rhoai-3.2/v4.20/Dockerfile
@@ -57,6 +57,10 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
+ARG RBC_RELEASE_BRANCH_COMMIT_216=
+ARG RBC_RELEASE_BRANCH_COMMIT_225=
+ARG RBC_RELEASE_BRANCH_COMMIT_32=
+ARG RBC_RELEASE_BRANCH_COMMIT_33=
 
 
 # Configure the entrypoint and command
@@ -126,6 +130,11 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
+    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-3.3/v4.19/Dockerfile
+++ b/catalog/rhoai-3.3/v4.19/Dockerfile
@@ -57,6 +57,10 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
+ARG RBC_RELEASE_BRANCH_COMMIT_216=
+ARG RBC_RELEASE_BRANCH_COMMIT_225=
+ARG RBC_RELEASE_BRANCH_COMMIT_32=
+ARG RBC_RELEASE_BRANCH_COMMIT_33=
 
 
 # Configure the entrypoint and command
@@ -126,6 +130,11 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
+    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-3.3/v4.20/Dockerfile
+++ b/catalog/rhoai-3.3/v4.20/Dockerfile
@@ -57,6 +57,10 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
+ARG RBC_RELEASE_BRANCH_COMMIT_216=
+ARG RBC_RELEASE_BRANCH_COMMIT_225=
+ARG RBC_RELEASE_BRANCH_COMMIT_32=
+ARG RBC_RELEASE_BRANCH_COMMIT_33=
 
 
 # Configure the entrypoint and command
@@ -126,6 +130,11 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
+    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-3.3/v4.21/Dockerfile
+++ b/catalog/rhoai-3.3/v4.21/Dockerfile
@@ -57,6 +57,10 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
+ARG RBC_RELEASE_BRANCH_COMMIT_216=
+ARG RBC_RELEASE_BRANCH_COMMIT_225=
+ARG RBC_RELEASE_BRANCH_COMMIT_32=
+ARG RBC_RELEASE_BRANCH_COMMIT_33=
 
 
 # Configure the entrypoint and command
@@ -126,6 +130,11 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
+    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \


### PR DESCRIPTION
## Summary
- Adds `ARG RBC_RELEASE_BRANCH_COMMIT_{216,225,32,33}` and corresponding `LABEL rbc-release-branch-{216,225,32,33}.commit` to catalog Dockerfiles in rhoai-2.16, rhoai-2.25, rhoai-3.2, and rhoai-3.3
- 17 Dockerfiles updated across all OCP version variants

## Script used

```bash
for f in \
  catalog/rhoai-2.16/v4.{14,15,16,17,18,19}/Dockerfile \
  catalog/rhoai-2.25/v4.{16,17,18,19,20,21}/Dockerfile \
  catalog/rhoai-3.2/v4.{19,20}/Dockerfile \
  catalog/rhoai-3.3/v4.{19,20,21}/Dockerfile; do
  # Add new ARGs after ARG ODH_OPERATOR_BUNDLE_GIT_URL
  sed -i '' '/^ARG ODH_OPERATOR_BUNDLE_GIT_URL$/a\
ARG RBC_RELEASE_BRANCH_COMMIT_216=\
ARG RBC_RELEASE_BRANCH_COMMIT_225=\
ARG RBC_RELEASE_BRANCH_COMMIT_32=\
ARG RBC_RELEASE_BRANCH_COMMIT_33=
' "$f"
  # Add new LABEL block after the rbc-release-branch.commit line
  sed -i '' '/^      rbc-release-branch\.commit="${RBC_RELEASE_BRANCH_COMMIT}"$/a\
\
LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \\\
    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \\\
    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \\\
    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
' "$f"
done
```

## Test plan
- [x] Verify ARGs are present at end of ARG block in all 17 Dockerfiles
- [x] Verify LABEL block is placed between the git commit labels and the `com.redhat.component` label
- [x] Confirm no other Dockerfiles were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)