### PR TITLE
fix multi stage build to work with pre-3.0 builds

### DIFF
--- a/.github/workflows/multi-push-to-stage.yaml
+++ b/.github/workflows/multi-push-to-stage.yaml
@@ -3,6 +3,9 @@ run-name: Batch Stage Push
 on:
   workflow_dispatch:
     inputs:
+      common_version:
+        description: 'release branch which targets all the affected ocp versions'
+        required: true
       release_branches:
         description: 'Comma separated list of release branches'
         required: true
@@ -36,7 +39,7 @@ permissions:
 env:
   GITHUB_ORG: red-hat-data-services
   GITHUB_RKA_ORG: rhoai-rhtap
-  COMMON_VERSION: rhoai-2.19
+  COMMON_VERSION: ${{ github.event.inputs.common_version }}
 
 jobs:
   show-info:
@@ -52,7 +55,7 @@ jobs:
           echo "### force_build: ${{ github.event.inputs.force_build }}" >> $GITHUB_STEP_SUMMARY          
 
   push-to-stage:
-    if: ${{ github.ref_name == 'main' }}
+    # if: ${{ github.ref_name == 'main' }}
     runs-on: ubuntu-22.04
     container:
       image: quay.io/rhoai/rhoai-task-toolset:latest
@@ -187,7 +190,7 @@ jobs:
         id: regenerate-pcc-cache
         if: ${{ steps.check-if-pcc-cache-valid.outputs.PCC_CACHE_VALID == 'NO' }}
         env:
-          BRANCH: ${{ github.event.inputs.release_branches }}
+          BRANCH: ${{ github.event.inputs.common_version }}
           RHOAI_VERSION: ${{ github.event.inputs.rhoai_versions }}
         run: |
           #install opm cli
@@ -245,7 +248,7 @@ jobs:
         id: validate-pcc-cache
         if: ${{ steps.check-if-pcc-cache-valid.outputs.PCC_CACHE_VALID == 'NO' }}
         env:
-          BRANCH: ${{ github.event.inputs.release_branches }}
+          BRANCH: ${{ github.event.inputs.common_version }}
         run: |
           #Declare basic variables
           BUILD_CONFIG_PATH=${BRANCH}/config/build-config.yaml
@@ -352,7 +355,7 @@ jobs:
       - name: Validate Catalogs
         id: validate-catalogs
         env:
-          BRANCH: ${{ github.event.inputs.release_branches }}
+          BRANCH: ${{ github.event.inputs.common_version }}
         run: |
           #Declare basic variables
 

--- a/.github/workflows/multi-push-to-stage.yaml
+++ b/.github/workflows/multi-push-to-stage.yaml
@@ -169,20 +169,20 @@ jobs:
               microdnf clean all && rm -rf /var/cache/dnf/*
           PCC_CACHE_VALID=YES
           skopeo login registry.redhat.io -u "${RHOAI_CATALOG_SA_USERNAME}" -p "${RHOAI_CATALOG_SA_TOKEN}"
-          skopeo list-tags docker://registry.redhat.io/rhoai/odh-operator-bundle | jq -r '.Tags | .[] | select(. | startswith ("v"))' | sort > latest_shipped_rhoai_versions.txt
+          skopeo list-tags docker://registry.redhat.io/rhoai/odh-operator-bundle | jq -r '.Tags | .[] | select(. | startswith ("v"))' | sort > latest_shipped_rhoai_versions_granular.txt
           echo "latest_shipped_rhoai_versions = "
-          cat latest_shipped_rhoai_versions.txt
+          cat latest_shipped_rhoai_versions_granular.txt
           echo "shipped_rhoai_versions = "
-          cat main/pcc/shipped_rhoai_versions.txt
+          cat main/pcc/shipped_rhoai_versions_granular.txt
 
-          #diff=$(cmp --silent latest_shipped_rhoai_versions.txt main/pcc/shipped_rhoai_versions.txt || echo "files are different")
-          diff=$(python -c 'print(list(set(open("latest_shipped_rhoai_versions.txt").readlines()) - set(open("main/pcc/shipped_rhoai_versions.txt").readlines())).__len__())')
+          #diff=$(cmp --silent latest_shipped_rhoai_versions_granular.txt main/pcc/shipped_rhoai_versions_granular.txt || echo "files are different")
+          diff=$(python -c 'print(list(set(open("latest_shipped_rhoai_versions_granular.txt").readlines()) - set(open("main/pcc/shipped_rhoai_versions_granular.txt").readlines())).__len__())')
 
           if [[ $diff -gt 0 ]]
           then
-            diff=$(python -c 'print(list(set(open("latest_shipped_rhoai_versions.txt").readlines()) - set(open("main/pcc/shipped_rhoai_versions.txt").readlines())))')
+            diff=$(python -c 'print(list(set(open("latest_shipped_rhoai_versions_granular.txt").readlines()) - set(open("main/pcc/shipped_rhoai_versions_granular.txt").readlines())))')
             echo "following new versions are shipped - $diff"
-            cp latest_shipped_rhoai_versions.txt main/pcc/shipped_rhoai_versions.txt
+            cp latest_shipped_rhoai_versions_granular.txt main/pcc/shipped_rhoai_versions_granular.txt
             PCC_CACHE_VALID=NO
           fi
           echo "PCC_CACHE_VALID=${PCC_CACHE_VALID}" >> $GITHUB_OUTPUT
@@ -252,7 +252,7 @@ jobs:
         run: |
           #Declare basic variables
           BUILD_CONFIG_PATH=${BRANCH}/config/build-config.yaml
-          SHIPPED_RHOAI_VERSIONS_PATH=main/pcc/shipped_rhoai_versions.txt
+          SHIPPED_RHOAI_VERSIONS_PATH=main/pcc/shipped_rhoai_versions_granular.txt
           PCC_FOLDER_PATH=main/pcc
 
           #Validate PCC
@@ -359,7 +359,7 @@ jobs:
         run: |
           #Declare basic variables
 
-          SHIPPED_RHOAI_VERSIONS_PATH=main/pcc/shipped_rhoai_versions.txt
+          SHIPPED_RHOAI_VERSIONS_PATH=main/pcc/shipped_rhoai_versions_granular.txt
           CATALOG_FOLDER_PATH=main/catalog/${COMMON_VERSION}
 
           release_branches="${{ github.event.inputs.release_branches }}"


### PR DESCRIPTION
Replace hardcoded COMMON_VERSION with the new common_version workflow input
parameter, and update BRANCH env vars in PCC and validation steps to
reference common_version instead of release_branches.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Christopher Kodama <ckodama@redhat.com>
