### PR TITLE
fix: add payload-processing RELATED_IMAGE to bundle-patch

### DIFF
--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -133,6 +133,8 @@ patch:
       value: "quay.io/rhoai/odh-model-performance-data-rhel9@sha256:321dfd70da52763561eb68e99f253e508e19b8dbf794b37e4ea95f5564f0534e"
     - name: RELATED_IMAGE_ODH_MAAS_API_IMAGE
       value: "quay.io/rhoai/odh-maas-api-rhel9@sha256:e94388bba3ab5003e374c2236b2d82f881abeaff70bfb45132aef0061900545e"
+    - name: RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE
+      value: "quay.io/rhoai/odh-ai-gateway-payload-processing-rhel9@sha256:dcfb5673cd8485c35a80bac34dc45576feffc6ab2dc7e8df01d28ba79aad2c00"
     - name: RELATED_IMAGE_ODH_TRAINING_CUDA121_TORCH24_PY311_IMAGE
       value: "quay.io/rhoai/odh-training-cuda121-torch24-py311-rhel9@sha256:5f7a974163856d07985b5da257688aad036427d3724194050782e58eab0cff1a"
     - name: RELATED_IMAGE_ODH_TRAINING_CUDA124_TORCH25_PY311_IMAGE


### PR DESCRIPTION
## Summary
- Add `RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE` to `bundle/bundle-patch.yaml`

## Problem
The operator deployment doesn't have the payload-processing image env var, causing it to fall back to the stale image in MaaS manifests. The stale image crashes with `"body fieldName is required"` because it predates the `field-name` → `fieldName` config change.

## Fix
Add the `RELATED_IMAGE` entry to `bundle-patch.yaml` following the same pattern as `RELATED_IMAGE_ODH_MAAS_API_IMAGE`. The DevTestOps pipeline will sync the correct RHOAI downstream digest.

Ref: RHOAIENG-57051

🤖 Generated with [Claude Code](https://claude.com/claude-code)