### PR TITLE
Align push-to-stage PCC with per-OCP approach from multi-push-to-stage

### DIFF
--- a/.github/workflows/push-to-stage.yaml
+++ b/.github/workflows/push-to-stage.yaml
@@ -64,6 +64,7 @@ jobs:
           path: main
           sparse-checkout: |
             pcc
+            config
             catalog/${{ github.event.inputs.release_branch }}
             builds
           sparse-checkout-cone-mode: false
@@ -161,9 +162,6 @@ jobs:
       - name: Regenerate PCC Cache
         id: regenerate-pcc-cache
         if: ${{ steps.check-if-pcc-cache-valid.outputs.PCC_CACHE_VALID == 'NO' }}
-        env:
-          BRANCH: ${{ github.event.inputs.release_branch }}
-          RHOAI_VERSION: ${{ github.event.inputs.rhoai_version }}
         run: |
           #install opm cli
           os="$(uname -s | tr '[:upper:]' '[:lower:]')"
@@ -175,45 +173,38 @@ jobs:
           chmod +x "$opm_filename"
           ln -fs "$opm_filename" opm
           cp "$opm_filename" /usr/local/bin/opm
-          
+
           microdnf install -y findutils && \
               microdnf clean all && rm -rf /var/cache/dnf/*
-          
-          #Declare basic variables
-          COMPONENT_SUFFIX=${RHOAI_VERSION/./-}
-          OPERATOR_BUNDLE_COMPONENT_NAME=odh-operator-bundle
 
-          #Declare FBC processing variables
-          BUILD_CONFIG_PATH=${BRANCH}/config/build-config.yaml
-          PATCH_YAML_PATH=${BRANCH}/catalog/catalog-patch.yaml
-          
-          CATALOG_GENERATION_REF_OCP_VERSION=v4.17
+          CONFIG_PATH=main/config/config.yaml
           CSV_META_MIN_OCP_VERSION=417
-          BUNDLE_OBJECT_CATALOG_YAML_PATH=main/pcc/bundle_object_catalog.yaml
-          CSV_META_CATALOG_YAML_PATH=main/pcc/csv_meta_catalog.yaml
-          
-          opm migrate registry.redhat.io/redhat/redhat-operator-index:${CATALOG_GENERATION_REF_OCP_VERSION} ./catalog-migrate
-          opm alpha convert-template basic catalog-migrate/rhods-operator/catalog.json -o yaml > catalog-template.yaml
-          opm alpha render-template basic catalog-template.yaml -o yaml > ${BUNDLE_OBJECT_CATALOG_YAML_PATH}
-          opm alpha render-template basic catalog-template.yaml --migrate-level=bundle-object-to-csv-metadata -o yaml > ${CSV_META_CATALOG_YAML_PATH}
-          
-          #while IFS= read -r value;
-          #do
-          #    OPENSHIFT_VERSION=$value
-          #    NUMERIC_OCP_VERSION=${OPENSHIFT_VERSION/v4./4}
-          #    echo "OPENSHIFT_VERSION=$OPENSHIFT_VERSION"
-          #
-          #    CATALOG_YAML_PATH=${BUNDLE_OBJECT_CATALOG_YAML_PATH}
-          #    CATALOG_DIR=main/pcc/${OPENSHIFT_VERSION}/rhods-operator
-          #    mkdir -p ${CATALOG_DIR}
-          #
-          #    if [[ $NUMERIC_OCP_VERSION -ge $CSV_META_MIN_OCP_VERSION ]]
-          #    then
-          #      CATALOG_YAML_PATH=${CSV_META_CATALOG_YAML_PATH}
-          #    fi
-          #    cp ${CATALOG_YAML_PATH} ${CATALOG_DIR}/catalog.yaml
-          #done < <(find main/pcc/ -maxdepth 1 -mindepth 1 -type d -printf '%f\n')
-          
+          CATALOG_DIR=main/pcc
+          PREVIOUS_OCP_VERSION=
+          while IFS= read -r OCP_VERSION;
+          do
+              CATALOG_YAML_PATH=${CATALOG_DIR}/catalog-${OCP_VERSION}.yaml
+              NUMERIC_OCP_VERSION=${OCP_VERSION/v4./4}
+              CSV_META_FLAG=
+              if [[ $NUMERIC_OCP_VERSION -ge $CSV_META_MIN_OCP_VERSION ]]
+              then
+                CSV_META_FLAG="--migrate-level=bundle-object-to-csv-metadata"
+              fi
+              echo "=== Migrating ${OCP_VERSION} operator index ==="
+              opm migrate registry.redhat.io/redhat/redhat-operator-index:${OCP_VERSION} ./catalog-migrate-${OCP_VERSION}
+              if [[ -e "catalog-migrate-${OCP_VERSION}/rhods-operator/catalog.json" ]]
+              then
+                  opm alpha convert-template basic catalog-migrate-${OCP_VERSION}/rhods-operator/catalog.json -o yaml > catalog-template-${OCP_VERSION}.yaml
+                  opm alpha render-template basic catalog-template-${OCP_VERSION}.yaml ${CSV_META_FLAG} -o yaml > ${CATALOG_YAML_PATH}
+              else
+                PREVIOUS_CATALOG_YAML_PATH=${CATALOG_DIR}/catalog-${PREVIOUS_OCP_VERSION}.yaml
+                echo "${OCP_VERSION} seems to be a new OCP version being used for RHOAI for the first time, ...copying contents of catalog-${PREVIOUS_OCP_VERSION}.yaml to catalog-${OCP_VERSION}.yaml.."
+                cp -f ${PREVIOUS_CATALOG_YAML_PATH} ${CATALOG_YAML_PATH}
+              fi
+              PREVIOUS_OCP_VERSION=${OCP_VERSION}
+          done < <(yq e '.config.supported-ocp-versions[].version' ${CONFIG_PATH})
+
+          echo "=== PCC cache files ==="
           ls -l main/pcc/
 
       - name: Validate PCC Cache
@@ -257,22 +248,13 @@ jobs:
           BUILD_CONFIG_PATH=${BRANCH}/config/build-config.yaml
           PATCH_YAML_PATH=${BRANCH}/catalog/catalog-patch.yaml
 
-          PCC_BUNDLE_OBJECT_CATALOG_YAML_PATH=main/pcc/bundle_object_catalog.yaml
-          PCC_CSV_META_CATALOG_YAML_PATH=main/pcc/csv_meta_catalog.yaml
-          CSV_META_MIN_OCP_VERSION=417
-          
           while IFS= read -r value;
           do
               OPENSHIFT_VERSION=$value
               echo "OPENSHIFT_VERSION=$OPENSHIFT_VERSION"
-              NUMERIC_OCP_VERSION=${OPENSHIFT_VERSION/v4./4}
-          
-              CATALOG_YAML_PATH=${PCC_BUNDLE_OBJECT_CATALOG_YAML_PATH}
-              if [[ $NUMERIC_OCP_VERSION -ge $CSV_META_MIN_OCP_VERSION ]]
-              then
-                CATALOG_YAML_PATH=${PCC_CSV_META_CATALOG_YAML_PATH}
-              fi
-          
+
+              CATALOG_YAML_PATH=main/pcc/catalog-${OPENSHIFT_VERSION}.yaml
+
               RELEASE_CATALOG_YAML_PATH=${BRANCH}/catalog/${OPENSHIFT_VERSION}/rhods-operator/catalog.yaml
               OUTPUT_CATALOG_DIR=main/catalog/${BRANCH}/${OPENSHIFT_VERSION}/rhods-operator/
               mkdir -p ${OUTPUT_CATALOG_DIR}


### PR DESCRIPTION
## Problem

The single-branch `push-to-stage.yaml` workflow generates PCC (Pre-Computed Catalog) from a **fixed v4.17 operator index**. Since RHOAI 3.x only targets v4.19+, the v4.17 index has **no 3.x entries**. When this workflow is used for a 2.x release (e.g., 2.25.5), the output catalog for overlapping OCP versions (v4.19–v4.21) is missing all 3.x bundles and channels — including **already-shipped versions like 3.3.2**.

This caused the catalog override incident with 2.25.3/3.4EA1 where pushing 2.25.3 wiped 3.x entries from the production operator index.

### Root Cause

`push-to-stage.yaml` line 191:
```bash
CATALOG_GENERATION_REF_OCP_VERSION=v4.17  # Fixed — no 3.x entries
```

While `multi-push-to-stage.yaml` already generates per-OCP PCC from each version's actual index:
```bash
opm migrate registry.redhat.io/redhat/redhat-operator-index:${OCP_VERSION}
```

## Changes

Three targeted changes to align `push-to-stage.yaml` with the working `multi-push-to-stage.yaml`:

1. **Sparse checkout** — add `config/` (needed for global OCP version list)
2. **PCC Regeneration** — replace single v4.17 migration with per-OCP loop from `config/config.yaml`, identical to `multi-push-to-stage.yaml` lines 334–363
3. **Push To Stage step** — use `catalog-${OPENSHIFT_VERSION}.yaml` instead of `csv_meta_catalog.yaml`/`bundle_object_catalog.yaml`

## Local Test Results

### Main test: 2.25.5 push for v4.19 (the override scenario)

| PCC Source | 2.25.5 | 3.3.2 (prod) | 3.4EA2 | stable-3.x |
|---|---|---|---|---|
| **OLD** (v4.17) | ✅ 6 refs | ❌ MISSING | ❌ MISSING | ❌ MISSING |
| **NEW** (v4.19) | ✅ 6 refs | ✅ 4 refs | — (not released) | ✅ 2 channels |

### Corner cases (all using NEW per-OCP PCC)

| Scenario | 2.25.5 | 3.3.2 | 3.4EA2 | stable-3.x | Result |
|---|---|---|---|---|---|
| v4.16 — only 2.25 targets, no 3.x expected | ✅ | — | — | — | ✅ No 3.x leakage |
| v4.19 — 2.25.5 standalone | ✅ | ✅ | — | ✅ | ✅ Shipped 3.x preserved |
| v4.19 — 3.4EA2 standalone | — | ✅ | ✅ | ✅ | ✅ Shipped 2.x preserved |
| v4.20 — 2.25.5 standalone | ✅ | ✅ | — | ✅ | ✅ Same as v4.19 |
| v4.20 — 3.4EA2 standalone | — | ✅ | ✅ | ✅ | ✅ Same as v4.19 |
| v4.21 — 2.25.5 standalone | ✅ | ✅ | — | ✅ | ✅ Works on newest OCP |
| v4.22 — fallback PCC (copied from v4.21) | ✅ | ✅ | — | ✅ | ✅ Graceful fallback |
| Missing PCC file (no fallback) | — | — | — | — | ✅ Fails with clear FileNotFoundError |

### Multi-version same-day test (chained, simulating multi-push-to-stage)

| Order | 2.25.5 | 3.3.2 | 3.4EA2 | stable-3.x |
|---|---|---|---|---|
| 2.25.5 first → 3.4EA2 second | ✅ | ✅ | ✅ | ✅ |
| 3.4EA2 first → 2.25.5 second | ✅ | ✅ | ✅ | ✅ |

## Scope & Limitations

- **This fix protects shipped versions** from being wiped by single-branch pushes
- **For same-day multi-version releases** (e.g., 2.25.5 + 3.4EA2 on April 23rd), continue using `multi-push-to-stage.yaml` which chains outputs — this fix does not add chaining to `push-to-stage.yaml`
- Logic is **identical** to what's already running in production via `multi-push-to-stage.yaml`
- No changes to `stage_promoter.py` or any other script

## When to use which workflow

| Scenario | Workflow |
|---|---|
| Single release, no same-day overlap | `push-to-stage.yaml` (this PR) |
| Multiple releases same day, overlapping OCP | `multi-push-to-stage.yaml` |

Tracker: https://redhat.atlassian.net/browse/RHOAIENG-59007