### PR TITLE
RHOAI release config: automation-3.5 → rhoai-3.5

### DIFF
--- a/.tekton/odh-operator-bundle-v3-5-push.yaml
+++ b/.tekton/odh-operator-bundle-v3-5-push.yaml
@@ -7,16 +7,17 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    build.appstudio.openshift.io/build-nudge-files: "schedule/catalog-github-trigger.txt"
+    build.appstudio.openshift.io/build-nudge-files: "catalog/catalog-patch.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.4"
-      && "schedule/bundle-tekton-trigger.txt".pathChanged()
+      && target_branch == "rhoai-3.5"
+      && ( "bundle/**".pathChanged() || ".tekton/odh-operator-bundle-v3-5-push.yaml".pathChanged() )
+      && files.all.exists(p, !p.matches('^bundle/bundle-patch\\.yaml$'))
   labels:
-    appstudio.openshift.io/application: rhoai-v3-4
-    appstudio.openshift.io/component: odh-operator-bundle-v3-4
+    appstudio.openshift.io/application: rhoai-v3-5
+    appstudio.openshift.io/component: odh-operator-bundle-v3-5
     pipelines.appstudio.openshift.io/type: build
-  name: odh-operator-bundle-v3-4-on-schedule
+  name: odh-operator-bundle-v3-5-on-push
   namespace: rhoai-tenant
 spec:
   params:
@@ -27,11 +28,10 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - '{{target_branch}}-nightly'
   - name: output-image
     value: quay.io/rhoai/odh-operator-bundle:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.0"
+    value: "3.5.0"
   - name: dockerfile
     value: bundle/Dockerfile
   - name: path-context
@@ -54,7 +54,7 @@ spec:
     - name: pathInRepo
       value: pipelines/container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-operator-bundle-v3-4
+    serviceAccountName: build-pipeline-odh-operator-bundle-v3-5
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/odh-operator-bundle-v3-5-scheduled.yaml
+++ b/.tekton/odh-operator-bundle-v3-5-scheduled.yaml
@@ -7,17 +7,16 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    build.appstudio.openshift.io/build-nudge-files: "catalog/catalog-patch.yaml"
+    build.appstudio.openshift.io/build-nudge-files: "schedule/catalog-github-trigger.txt"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.4"
-      && ( "bundle/**".pathChanged() || ".tekton/odh-operator-bundle-v3-4-push.yaml".pathChanged() )
-      && files.all.exists(p, !p.matches('^bundle/bundle-patch\\.yaml$'))
+      && target_branch == "rhoai-3.5"
+      && "schedule/bundle-tekton-trigger.txt".pathChanged()
   labels:
-    appstudio.openshift.io/application: rhoai-v3-4
-    appstudio.openshift.io/component: odh-operator-bundle-v3-4
+    appstudio.openshift.io/application: rhoai-v3-5
+    appstudio.openshift.io/component: odh-operator-bundle-v3-5
     pipelines.appstudio.openshift.io/type: build
-  name: odh-operator-bundle-v3-4-on-push
+  name: odh-operator-bundle-v3-5-on-schedule
   namespace: rhoai-tenant
 spec:
   params:
@@ -28,10 +27,11 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
+    - '{{target_branch}}-nightly'
   - name: output-image
     value: quay.io/rhoai/odh-operator-bundle:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.0"
+    value: "3.5.0"
   - name: dockerfile
     value: bundle/Dockerfile
   - name: path-context
@@ -54,7 +54,7 @@ spec:
     - name: pathInRepo
       value: pipelines/container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-operator-bundle-v3-4
+    serviceAccountName: build-pipeline-odh-operator-bundle-v3-5
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhoai-fbc-fragment-v3-5-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-v3-5-push.yaml
@@ -9,14 +9,14 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.4"
-      && ( "catalog/**".pathChanged() || ".tekton/rhoai-fbc-fragment-v3-4-push.yaml".pathChanged() )
+      && target_branch == "rhoai-3.5"
+      && ( "catalog/**".pathChanged() || ".tekton/rhoai-fbc-fragment-v3-5-push.yaml".pathChanged() )
       && files.all.exists(p, !p.matches('^catalog/catalog-patch\\.yaml$'))
   labels:
-    appstudio.openshift.io/application: rhoai-v3-4
-    appstudio.openshift.io/component: rhoai-fbc-fragment-v3-4
+    appstudio.openshift.io/application: rhoai-v3-5
+    appstudio.openshift.io/component: rhoai-fbc-fragment-v3-5
     pipelines.appstudio.openshift.io/type: build
-  name: rhoai-fbc-fragment-v3-4-on-push
+  name: rhoai-fbc-fragment-v3-5-on-push
   namespace: rhoai-tenant
 spec:
   timeouts:
@@ -33,7 +33,7 @@ spec:
   - name: output-image
     value: quay.io/rhoai/rhoai-fbc-fragment:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.0"
+    value: "3.5.0"
   - name: dockerfile
     value: Dockerfile
   - name: path-context
@@ -66,7 +66,7 @@ spec:
     - name: pathInRepo
       value: pipelines/fbc-fragment-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhoai-fbc-fragment-v3-4
+    serviceAccountName: build-pipeline-rhoai-fbc-fragment-v3-5
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhoai-fbc-fragment-v3-5-scheduled.yaml
+++ b/.tekton/rhoai-fbc-fragment-v3-5-scheduled.yaml
@@ -9,13 +9,13 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.4"
+      && target_branch == "rhoai-3.5"
       && "schedule/catalog-tekton-trigger.txt".pathChanged()
   labels:
-    appstudio.openshift.io/application: rhoai-v3-4
-    appstudio.openshift.io/component: rhoai-fbc-fragment-v3-4
+    appstudio.openshift.io/application: rhoai-v3-5
+    appstudio.openshift.io/component: rhoai-fbc-fragment-v3-5
     pipelines.appstudio.openshift.io/type: build
-  name: rhoai-fbc-fragment-v3-4-on-schedule
+  name: rhoai-fbc-fragment-v3-5-on-schedule
   namespace: rhoai-tenant
 spec:
   timeouts:
@@ -33,7 +33,7 @@ spec:
   - name: output-image
     value: quay.io/rhoai/rhoai-fbc-fragment:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.0"
+    value: "3.5.0"
   - name: build-platforms
     value:
     - linux/x86_64
@@ -70,7 +70,7 @@ spec:
     - name: pathInRepo
       value: pipelines/fbc-fragment-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhoai-fbc-fragment-v3-4
+    serviceAccountName: build-pipeline-rhoai-fbc-fragment-v3-5
   workspaces:
   - name: git-auth
     secret:

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -1,5 +1,5 @@
 patch:
-  version: 3.4.0
+  version: 3.5.0
   relatedImages:
     - name: RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE
       value: "quay.io/rhoai/odh-kf-notebook-controller-rhel9@sha256:8fdab8122b0433dfa1045f22074c891d2b84fd21a073f406d12d5bcbe9b9b805"

--- a/bundle/csv-patch.yaml
+++ b/bundle/csv-patch.yaml
@@ -28,4 +28,4 @@ spec:
     email: managed-open-data-hub@redhat.com
   links:
   - name: Red Hat OpenShift AI
-    url: https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4
+    url: https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5


### PR DESCRIPTION
## Summary

Automated updates for the release line: merge changes from the automation branch into the target release branch.

## Branches

- **Target:** `rhoai-3.5`
- **Source:** `automation-3.5`

## Changes

Release-line configuration only (not `main`): Tekton definitions under `.tekton`, `bundle/bundle-patch.yaml`, and `bundle/csv-patch.yaml` when applicable for this release step.

## Review

Please verify image references and bundle metadata for the intended release.

[View diff (compare)](https://github.com/red-hat-data-services/RHOAI-Build-Config/compare/rhoai-3.5...automation-3.5)