### PR TITLE
Update skip-bundles in config.yaml for EA1

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -11,9 +11,14 @@ config:
     - version: v4.18
       discontinued-from: rhods-operator.3.0.0
     - version: v4.19
+      skip-bundles:
+        - rhods-operator.3.4.0-ea.1
     - version: v4.20
       onboarded-since: rhods-operator.2.25.0
+      skip-bundles:
+        - rhods-operator.3.4.0-ea.1
     - version: v4.21
       onboarded-since: rhods-operator.2.25.0
       skip-bundles:
         - rhods-operator.3.2.1
+        - rhods-operator.3.4.0-ea.1


### PR DESCRIPTION
Added rhods-operator.3.4.0-ea.1 skip-bundles for versions v4.19 v4.20 and v4.21.