### PR TITLE
Update skipRange and add replaces in catalog-patch for 3.3.3

### DIFF
--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -22,7 +22,8 @@ patch:
       schema: olm.channel
       entries:
       - name: rhods-operator.3.3.3
-        skipRange: '>=2.25.4 <2.26.0'
+        replaces: rhods-operator.3.3.2
+        skipRange: '>=2.25.5 <2.26.0 || >=3.3.2 <3.3.3'
 
   olm.bundle:
     - quay.io/rhoai/odh-operator-bundle@sha256:7c68671ea73e9cde4759a4b2e3acff1ab932157e44f48e9400c3b8a90b793177


### PR DESCRIPTION
wrt 2.x --> 3.x migration, there is a direction to support this with each new release of 2.25.z and 3.3.z

The channel head should be moved to 3.3.3