### PR TITLE
Add odh-kserve-localmodel-controller to bundle-patch.yaml

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -32,6 +32,8 @@ ARG ODH_KSERVE_ROUTER_GIT_URL=
 ARG ODH_KSERVE_ROUTER_GIT_COMMIT=
 ARG ODH_KSERVE_STORAGE_INITIALIZER_GIT_URL=
 ARG ODH_KSERVE_STORAGE_INITIALIZER_GIT_COMMIT=
+ARG ODH_KSERVE_LOCALMODEL_CONTROLLER_GIT_URL=
+ARG ODH_KSERVE_LOCALMODEL_CONTROLLER_GIT_COMMIT=
 ARG ODH_KUBE_AUTH_PROXY_GIT_URL=
 ARG ODH_KUBE_AUTH_PROXY_GIT_COMMIT=
 ARG ODH_KUBE_RBAC_PROXY_GIT_URL=
@@ -227,6 +229,8 @@ LABEL \
       odh-kserve-router.git.commit="${ODH_KSERVE_ROUTER_GIT_COMMIT}" \
       odh-kserve-storage-initializer.git.url="${ODH_KSERVE_STORAGE_INITIALIZER_GIT_URL}" \
       odh-kserve-storage-initializer.git.commit="${ODH_KSERVE_STORAGE_INITIALIZER_GIT_COMMIT}" \
+      odh-kserve-localmodel-controller.git.url="${ODH_KSERVE_LOCALMODEL_CONTROLLER_GIT_URL}" \
+      odh-kserve-localmodel-controller.git.commit="${ODH_KSERVE_LOCALMODEL_CONTROLLER_GIT_COMMIT}" \
       odh-kube-auth-proxy.git.url="${ODH_KUBE_AUTH_PROXY_GIT_URL}" \
       odh-kube-auth-proxy.git.commit="${ODH_KUBE_AUTH_PROXY_GIT_COMMIT}" \
       odh-kube-rbac-proxy.git.url="${ODH_KUBE_RBAC_PROXY_GIT_URL}" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -216,7 +216,7 @@ patch:
     - name: RELATED_IMAGE_ODH_KSERVE_AUTOGLUON_SERVER_IMAGE
       value: "quay.io/rhoai/odh-kserve-autogluon-server-rhel9@sha256:a3c901e75472ce551d49a79161115faa4ee60300e5a0c5060cc2acc64fed7d96"
     - name: RELATED_IMAGE_ODH_KSERVE_LOCALMODEL_CONTROLLER_IMAGE
-      value: "quay.io/rhoai/odh-kserve-localmodel-controller@sha256:5f282757453297b4d1ba6f48235ba9a62d452efbb145dadce6e8715e7650b32c"
+      value: "quay.io/rhoai/odh-kserve-localmodel-controller-rhel9@sha256:f55b11c7bfd2ceedf0b907100bb2e65bab8f32f94dc3523bfccccc6a3b263b5b"
 
   additional-related-images:
     file: additional-images-patch.yaml

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -215,6 +215,8 @@ patch:
       value: "quay.io/rhoai/odh-model-serving-api-rhel9@sha256:0f4cd9b8306a0a077d5b9eccc755db6cb5275b1ba25def29d596c08360343703"
     - name: RELATED_IMAGE_ODH_KSERVE_AUTOGLUON_SERVER_IMAGE
       value: "quay.io/rhoai/odh-kserve-autogluon-server-rhel9@sha256:a3c901e75472ce551d49a79161115faa4ee60300e5a0c5060cc2acc64fed7d96"
+    - name: RELATED_IMAGE_ODH_KSERVE_LOCALMODEL_CONTROLLER_IMAGE
+      value: "quay.io/rhoai/odh-kserve-localmodel-controller@sha256:5f282757453297b4d1ba6f48235ba9a62d452efbb145dadce6e8715e7650b32c"
 
   additional-related-images:
     file: additional-images-patch.yaml

--- a/catalog/v4.19/Dockerfile
+++ b/catalog/v4.19/Dockerfile
@@ -36,6 +36,8 @@ ARG ODH_KSERVE_ROUTER_GIT_URL=
 ARG ODH_KSERVE_ROUTER_GIT_COMMIT=
 ARG ODH_KSERVE_STORAGE_INITIALIZER_GIT_URL=
 ARG ODH_KSERVE_STORAGE_INITIALIZER_GIT_COMMIT=
+ARG ODH_KSERVE_LOCALMODEL_CONTROLLER_GIT_URL=
+ARG ODH_KSERVE_LOCALMODEL_CONTROLLER_GIT_COMMIT=
 ARG ODH_KUBE_AUTH_PROXY_GIT_URL=
 ARG ODH_KUBE_AUTH_PROXY_GIT_COMMIT=
 ARG ODH_KUBE_RBAC_PROXY_GIT_URL=
@@ -233,6 +235,8 @@ LABEL \
       odh-kserve-router.git.commit="${ODH_KSERVE_ROUTER_GIT_COMMIT}" \
       odh-kserve-storage-initializer.git.url="${ODH_KSERVE_STORAGE_INITIALIZER_GIT_URL}" \
       odh-kserve-storage-initializer.git.commit="${ODH_KSERVE_STORAGE_INITIALIZER_GIT_COMMIT}" \
+      odh-kserve-localmodel-controller.git.url="${ODH_KSERVE_LOCALMODEL_CONTROLLER_GIT_URL}" \
+      odh-kserve-localmodel-controller.git.commit="${ODH_KSERVE_LOCALMODEL_CONTROLLER_GIT_COMMIT}" \
       odh-kube-auth-proxy.git.url="${ODH_KUBE_AUTH_PROXY_GIT_URL}" \
       odh-kube-auth-proxy.git.commit="${ODH_KUBE_AUTH_PROXY_GIT_COMMIT}" \
       odh-kube-rbac-proxy.git.url="${ODH_KUBE_RBAC_PROXY_GIT_URL}" \

--- a/catalog/v4.20/Dockerfile
+++ b/catalog/v4.20/Dockerfile
@@ -36,6 +36,8 @@ ARG ODH_KSERVE_ROUTER_GIT_URL=
 ARG ODH_KSERVE_ROUTER_GIT_COMMIT=
 ARG ODH_KSERVE_STORAGE_INITIALIZER_GIT_URL=
 ARG ODH_KSERVE_STORAGE_INITIALIZER_GIT_COMMIT=
+ARG ODH_KSERVE_LOCALMODEL_CONTROLLER_GIT_URL=
+ARG ODH_KSERVE_LOCALMODEL_CONTROLLER_GIT_COMMIT=
 ARG ODH_KUBE_AUTH_PROXY_GIT_URL=
 ARG ODH_KUBE_AUTH_PROXY_GIT_COMMIT=
 ARG ODH_KUBE_RBAC_PROXY_GIT_URL=
@@ -233,6 +235,8 @@ LABEL \
       odh-kserve-router.git.commit="${ODH_KSERVE_ROUTER_GIT_COMMIT}" \
       odh-kserve-storage-initializer.git.url="${ODH_KSERVE_STORAGE_INITIALIZER_GIT_URL}" \
       odh-kserve-storage-initializer.git.commit="${ODH_KSERVE_STORAGE_INITIALIZER_GIT_COMMIT}" \
+      odh-kserve-localmodel-controller.git.url="${ODH_KSERVE_LOCALMODEL_CONTROLLER_GIT_URL}" \
+      odh-kserve-localmodel-controller.git.commit="${ODH_KSERVE_LOCALMODEL_CONTROLLER_GIT_COMMIT}" \
       odh-kube-auth-proxy.git.url="${ODH_KUBE_AUTH_PROXY_GIT_URL}" \
       odh-kube-auth-proxy.git.commit="${ODH_KUBE_AUTH_PROXY_GIT_COMMIT}" \
       odh-kube-rbac-proxy.git.url="${ODH_KUBE_RBAC_PROXY_GIT_URL}" \

--- a/catalog/v4.21/Dockerfile
+++ b/catalog/v4.21/Dockerfile
@@ -36,6 +36,8 @@ ARG ODH_KSERVE_ROUTER_GIT_URL=
 ARG ODH_KSERVE_ROUTER_GIT_COMMIT=
 ARG ODH_KSERVE_STORAGE_INITIALIZER_GIT_URL=
 ARG ODH_KSERVE_STORAGE_INITIALIZER_GIT_COMMIT=
+ARG ODH_KSERVE_LOCALMODEL_CONTROLLER_GIT_URL=
+ARG ODH_KSERVE_LOCALMODEL_CONTROLLER_GIT_COMMIT=
 ARG ODH_KUBE_AUTH_PROXY_GIT_URL=
 ARG ODH_KUBE_AUTH_PROXY_GIT_COMMIT=
 ARG ODH_KUBE_RBAC_PROXY_GIT_URL=
@@ -235,6 +237,8 @@ LABEL \
       odh-kserve-router.git.commit="${ODH_KSERVE_ROUTER_GIT_COMMIT}" \
       odh-kserve-storage-initializer.git.url="${ODH_KSERVE_STORAGE_INITIALIZER_GIT_URL}" \
       odh-kserve-storage-initializer.git.commit="${ODH_KSERVE_STORAGE_INITIALIZER_GIT_COMMIT}" \
+      odh-kserve-localmodel-controller.git.url="${ODH_KSERVE_LOCALMODEL_CONTROLLER_GIT_URL}" \
+      odh-kserve-localmodel-controller.git.commit="${ODH_KSERVE_LOCALMODEL_CONTROLLER_GIT_COMMIT}" \
       odh-kube-auth-proxy.git.url="${ODH_KUBE_AUTH_PROXY_GIT_URL}" \
       odh-kube-auth-proxy.git.commit="${ODH_KUBE_AUTH_PROXY_GIT_COMMIT}" \
       odh-kube-rbac-proxy.git.url="${ODH_KUBE_RBAC_PROXY_GIT_URL}" \

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -109,6 +109,7 @@ config:
         rhoai/odh-llm-d-batch-gateway-gc-rhel9: rhoai/odh-llm-d-batch-gateway-gc-rhel9
         rhoai/odh-model-serving-api-rhel9: rhoai/odh-model-serving-api-rhel9
         rhoai/odh-kserve-autogluon-server-rhel9: rhoai/odh-kserve-autogluon-server-rhel9
+        rhoai/odh-kserve-localmodel-controller-rhel9: rhoai/odh-kserve-localmodel-controller-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds 'odh-kserve-localmodel-controller' to the red-hat-data-services/RHOAI-Build-Config bundle relatedImages.

Component: odh-kserve-localmodel-controller
Product context: RHOAI
Quay org: rhoai
Upstream repo: https://github.com/red-hat-data-services/kserve @ rhoai-3.5-ea.1
Jira: https://redhat.atlassian.net/browse/RHOAIENG-56375

**Files changed:**
- `bundle/bundle-patch.yaml` — added `RELATED_IMAGE_ODH_KSERVE_LOCALMODEL_CONTROLLER_IMAGE` to `patch.relatedImages`
- `config/build-config.yaml` — added `rhoai/odh-kserve-localmodel-controller-rhel9` to `config.replacements[0].repo_mappings` (RHOAI only)

> **NOTE:** The SHA256 digest for `RELATED_IMAGE_ODH_KSERVE_LOCALMODEL_CONTROLLER_IMAGE` is a **placeholder** — the image has not yet been built by Konflux.
> Before merging this PR, replace the digest with the real value:
> ```
> skopeo inspect --no-creds docker://quay.io/rhoai/odh-kserve-localmodel-controller:odh-stable | jq -r '.Digest'
> ```