### PR TITLE
Remove obsolete RHAIIS VLLM images from additional-images-patch.yaml

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -30,14 +30,6 @@ additionalImages:
     value: "registry.redhat.io/rhel9/postgresql-16:latest@sha256:f7bf8c0071560f5f75ef96a20a3cdb04ef020eea92cb60d77a09871c58daa6d0"
   - name: RELATED_IMAGE_OSE_PROM_LABEL_PROXY_IMAGE
     value: "registry.redhat.io/openshift4/ose-prom-label-proxy-rhel9:v4.20@sha256:5522f37104f3fac57567fa2e9ec65601f60b8cea3603b12dcda26db8c481f404"
-  - name: RELATED_IMAGE_RHAIIS_VLLM_CPU_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-cpu-rhel9:3.3.0@sha256:f05e773647dddd37ec6c2215cb14bec87e4ab5a7d37f2e110d16cd92355427d3"
-  - name: RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.3.0@sha256:ec799bb5eeb7e25b4b25a8917ab5161da6b6f1ab830cbba61bba371cffb0c34d"
-  - name: RELATED_IMAGE_RHAIIS_VLLM_ROCM_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-rocm-rhel9:3.3.0@sha256:e345cf9453afae0d3c2afe2f7fb9be8fac772f46593b873e925d38ae2b3ee537"
-  - name: RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.3.0@sha256:75f0ea05a92661a33b40efe2a662d976d53c767db18990b433d4a00dd6693aae"
   - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
     value: "registry.redhat.io/rhaii-early-access/vllm-gaudi-rhel9:3.4.0-ea.2@sha256:9743aa8b794b3fb89357aa91848ace931cecdc4cff09345d485333819b924817"
   - name: RELATED_IMAGE_ODH_PYTHON_312_IMAGE


### PR DESCRIPTION
Removed outdated RHAIIS  VLLM and renamed it to RHAII images from the patch.