### PR TITLE
Update VLLM images to match rhoai-3.4 branch

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -48,4 +48,4 @@ additionalImages:
   - name: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE
     value: "registry.stage.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0-1776326833@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
   - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
-    value: "registry.redhat.io/rhaii-early-access/vllm-gaudi-rhel9:3.4.0-ea.2@sha256:9743aa8b794b3fb89357aa91848ace931cecdc4cff09345d485333819b924817"
+    value: "registry.stage.redhat.io/rhaii/vllm-gaudi-rhel9:3.4.0-1776326902@sha256:1adc51d99455d90f758d840cb3bb5747ed29585c1b0830c051f7fe5cca3471e6"

--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -30,16 +30,6 @@ additionalImages:
     value: "registry.redhat.io/rhel9/postgresql-16:latest@sha256:f7bf8c0071560f5f75ef96a20a3cdb04ef020eea92cb60d77a09871c58daa6d0"
   - name: RELATED_IMAGE_OSE_PROM_LABEL_PROXY_IMAGE
     value: "registry.redhat.io/openshift4/ose-prom-label-proxy-rhel9:v4.20@sha256:5522f37104f3fac57567fa2e9ec65601f60b8cea3603b12dcda26db8c481f404"
-  - name: RELATED_IMAGE_RHAIIS_VLLM_CPU_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-cpu-rhel9:3.3.0@sha256:f05e773647dddd37ec6c2215cb14bec87e4ab5a7d37f2e110d16cd92355427d3"
-  - name: RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.3.0@sha256:ec799bb5eeb7e25b4b25a8917ab5161da6b6f1ab830cbba61bba371cffb0c34d"
-  - name: RELATED_IMAGE_RHAIIS_VLLM_ROCM_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-rocm-rhel9:3.3.0@sha256:e345cf9453afae0d3c2afe2f7fb9be8fac772f46593b873e925d38ae2b3ee537"
-  - name: RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.3.0@sha256:75f0ea05a92661a33b40efe2a662d976d53c767db18990b433d4a00dd6693aae"
-  - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
-    value: "registry.redhat.io/rhaii-early-access/vllm-gaudi-rhel9:3.4.0-ea.2@sha256:9743aa8b794b3fb89357aa91848ace931cecdc4cff09345d485333819b924817"
   - name: RELATED_IMAGE_ODH_PYTHON_312_IMAGE
     value: "registry.redhat.io/ubi9/python-312:latest@sha256:cb818db6c1dc82c70aeaa1139e33f3371f47b97b60ae6f9f23381319746f6f1d"
   - name: RELATED_IMAGE_PERSES_IMAGE
@@ -48,3 +38,14 @@ additionalImages:
     value: "registry.redhat.io/ubi9/nginx-126:latest@sha256:caf863c73852077d0e0f4c666ed0831b1893bb7ab333015fd35b87a98de43519"
   - name: RELATED_IMAGE_UBI_MINIMAL_IMAGE
     value: "registry.redhat.io/ubi9/ubi-minimal:9.7@sha256:7d4e47500f28ac3a2bff06c25eff9127ff21048538ae03ce240d57cf756acd00"
+  # RHAII images are currently in stage registry, but will be promoted to production registry soon. Using stage registry for now to allow testing with the latest images. Once the images are promoted to production registry, the image references will be updated to use registry.redhat.io instead of registry.stage.redhat.io
+  - name: RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE
+    value: "registry.stage.redhat.io/rhaii/vllm-cuda-rhel9:3.4.0-1776326705@sha256:d3e57d4ca13a17f4d5d1228df4fe47cfe1a9f630250a8b3d26f86d871fdb9e69"
+  - name: RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE
+    value: "registry.stage.redhat.io/rhaii/vllm-rocm-rhel9:3.4.0-1776333560@sha256:cfeac10c571206514c2876f220ce845058511185ebe8944afc32581dc45b34f3"
+  - name: RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE
+    value: "registry.stage.redhat.io/rhaii/vllm-spyre-rhel9:3.4.0-1776326998@sha256:5c0ed9be230a307d512fa99236b060ac2ecd86973d17c467badc7b5c2d2b5da4"
+  - name: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE
+    value: "registry.stage.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0-1776326833@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
+  - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
+    value: "registry.redhat.io/rhaii-early-access/vllm-gaudi-rhel9:3.4.0-ea.2@sha256:9743aa8b794b3fb89357aa91848ace931cecdc4cff09345d485333819b924817"

--- a/helm/rhai-on-xks-chart/values.yaml
+++ b/helm/rhai-on-xks-chart/values.yaml
@@ -28,12 +28,14 @@ rhaiOperator:
       value: "registry.redhat.io/rhoai/odh-kserve-router-rhel9@sha256:be88b983b835b88a43cea162d28dc9565daa0dc4bfef140119cf495feaa54fcc"
     - name: RELATED_IMAGE_ODH_KSERVE_STORAGE_INITIALIZER_IMAGE
       value: "registry.redhat.io/rhoai/odh-kserve-storage-initializer-rhel9@sha256:294c864d04f2ef1ba2fc2080f7eebc4d67252cce1282a46f6b416179264c8c00"
-    - name: RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE
-      value: "registry.redhat.io/rhaiis/vllm-cuda-rhel9@sha256:ec799bb5eeb7e25b4b25a8917ab5161da6b6f1ab830cbba61bba371cffb0c34d"
-    - name: RELATED_IMAGE_RHAIIS_VLLM_ROCM_IMAGE
-      value: "registry.redhat.io/rhaiis/vllm-rocm-rhel9@sha256:e345cf9453afae0d3c2afe2f7fb9be8fac772f46593b873e925d38ae2b3ee537"
-    - name: RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE
-      value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9@sha256:75f0ea05a92661a33b40efe2a662d976d53c767db18990b433d4a00dd6693aae"
+    - name: RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE
+      value: "registry.stage.redhat.io/rhaii/vllm-cuda-rhel9:3.4.0-1776326705@sha256:d3e57d4ca13a17f4d5d1228df4fe47cfe1a9f630250a8b3d26f86d871fdb9e69"
+    - name: RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE
+      value: "registry.stage.redhat.io/rhaii/vllm-rocm-rhel9:3.4.0-1776333560@sha256:cfeac10c571206514c2876f220ce845058511185ebe8944afc32581dc45b34f3"
+    - name: RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE
+      value: "registry.stage.redhat.io/rhaii/vllm-spyre-rhel9:3.4.0-1776326998@sha256:5c0ed9be230a307d512fa99236b060ac2ecd86973d17c467badc7b5c2d2b5da4"
+    - name: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE
+      value: "registry.stage.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0-1776326833@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
     - name: RELATED_IMAGE_ODH_LLM_D_INFERENCE_SCHEDULER_IMAGE
       value: "registry.redhat.io/rhoai/odh-llm-d-inference-scheduler-rhel9@sha256:f8b4d54ed266acf1ea2fff6ea0614f47fcc03031df4cff0f1f804d60c22debb0"
     - name: RELATED_IMAGE_ODH_LLM_D_ROUTING_SIDECAR_IMAGE

--- a/helm/rhai-on-xks-chart/values.yaml
+++ b/helm/rhai-on-xks-chart/values.yaml
@@ -36,6 +36,8 @@ rhaiOperator:
       value: "registry.stage.redhat.io/rhaii/vllm-spyre-rhel9:3.4.0-1776326998@sha256:5c0ed9be230a307d512fa99236b060ac2ecd86973d17c467badc7b5c2d2b5da4"
     - name: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE
       value: "registry.stage.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0-1776326833@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
+    - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
+      value: "registry.stage.redhat.io/rhaii/vllm-gaudi-rhel9:3.4.0-1776326902@sha256:1adc51d99455d90f758d840cb3bb5747ed29585c1b0830c051f7fe5cca3471e6"
     - name: RELATED_IMAGE_ODH_LLM_D_INFERENCE_SCHEDULER_IMAGE
       value: "registry.redhat.io/rhoai/odh-llm-d-inference-scheduler-rhel9@sha256:f8b4d54ed266acf1ea2fff6ea0614f47fcc03031df4cff0f1f804d60c22debb0"
     - name: RELATED_IMAGE_ODH_LLM_D_ROUTING_SIDECAR_IMAGE

--- a/helm/xks-values-patch.yaml
+++ b/helm/xks-values-patch.yaml
@@ -11,12 +11,14 @@ rhaiOperator:
       value: "registry.redhat.io/rhoai/odh-kserve-router-rhel9@sha256:ed29df52c41dbee714310a7cbd0199c67f26a719d5276ec1456c15d0b6c75717"
     - name: RELATED_IMAGE_ODH_KSERVE_STORAGE_INITIALIZER_IMAGE
       value: "registry.redhat.io/rhoai/odh-kserve-storage-initializer-rhel9@sha256:294c864d04f2ef1ba2fc2080f7eebc4d67252cce1282a46f6b416179264c8c00"
-    - name: RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE
-      value: "registry.redhat.io/rhaiis/vllm-cuda-rhel9@sha256:ec799bb5eeb7e25b4b25a8917ab5161da6b6f1ab830cbba61bba371cffb0c34d"
-    - name: RELATED_IMAGE_RHAIIS_VLLM_ROCM_IMAGE
-      value: "registry.redhat.io/rhaiis/vllm-rocm-rhel9@sha256:e345cf9453afae0d3c2afe2f7fb9be8fac772f46593b873e925d38ae2b3ee537"
-    - name: RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE
-      value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9@sha256:75f0ea05a92661a33b40efe2a662d976d53c767db18990b433d4a00dd6693aae"
+    - name: RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE
+      value: "registry.stage.redhat.io/rhaii/vllm-cuda-rhel9:3.4.0-1776326705@sha256:d3e57d4ca13a17f4d5d1228df4fe47cfe1a9f630250a8b3d26f86d871fdb9e69"
+    - name: RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE
+      value: "registry.stage.redhat.io/rhaii/vllm-rocm-rhel9:3.4.0-1776333560@sha256:cfeac10c571206514c2876f220ce845058511185ebe8944afc32581dc45b34f3"
+    - name: RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE
+      value: "registry.stage.redhat.io/rhaii/vllm-spyre-rhel9:3.4.0-1776326998@sha256:5c0ed9be230a307d512fa99236b060ac2ecd86973d17c467badc7b5c2d2b5da4"
+    - name: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE
+      value: "registry.stage.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0-1776326833@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
     - name: RELATED_IMAGE_ODH_LLM_D_INFERENCE_SCHEDULER_IMAGE
       value: "registry.redhat.io/rhoai/odh-llm-d-inference-scheduler-rhel9@sha256:9898799b9915d93b03d59b37120647854bf9de8038e1726e99b785d75b3497c9"
     - name: RELATED_IMAGE_ODH_LLM_D_ROUTING_SIDECAR_IMAGE

--- a/helm/xks-values-patch.yaml
+++ b/helm/xks-values-patch.yaml
@@ -19,6 +19,8 @@ rhaiOperator:
       value: "registry.stage.redhat.io/rhaii/vllm-spyre-rhel9:3.4.0-1776326998@sha256:5c0ed9be230a307d512fa99236b060ac2ecd86973d17c467badc7b5c2d2b5da4"
     - name: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE
       value: "registry.stage.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0-1776326833@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
+    - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
+      value: "registry.stage.redhat.io/rhaii/vllm-gaudi-rhel9:3.4.0-1776326902@sha256:1adc51d99455d90f758d840cb3bb5747ed29585c1b0830c051f7fe5cca3471e6"
     - name: RELATED_IMAGE_ODH_LLM_D_INFERENCE_SCHEDULER_IMAGE
       value: "registry.redhat.io/rhoai/odh-llm-d-inference-scheduler-rhel9@sha256:9898799b9915d93b03d59b37120647854bf9de8038e1726e99b785d75b3497c9"
     - name: RELATED_IMAGE_ODH_LLM_D_ROUTING_SIDECAR_IMAGE


### PR DESCRIPTION
Update VLLM image names from RHAIIS to RHAII, point to the stage registry, update image tags to 3.4.0, and include the CPU image across bundle and helm files to match the rhoai-3.4 configuration.

Not 100% sure about the helm files...those still appear to refer to RHAIIS on the 3.4 branch.