### PR TITLE
Onboard 2.25.6

### DIFF
--- a/.tekton/odh-operator-bundle-v2-25-push.yaml
+++ b/.tekton/odh-operator-bundle-v2-25-push.yaml
@@ -42,7 +42,7 @@ spec:
   - name: build-image-index
     value: false
   - name: rhoai-version
-    value: "2.25.5"
+    value: "2.25.6"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-operator-bundle-v2-25-scheduled.yaml
+++ b/.tekton/odh-operator-bundle-v2-25-scheduled.yaml
@@ -41,7 +41,7 @@ spec:
   - name: build-image-index
     value: false
   - name: rhoai-version
-    value: "2.25.5"
+    value: "2.25.6"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/rhoai-fbc-fragment-v2-25-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-v2-25-push.yaml
@@ -47,7 +47,7 @@ spec:
   - name: build-type
     value: "ci"
   - name: rhoai-version
-    value: "2.25.5"
+    value: "2.25.6"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/rhoai-fbc-fragment-v2-25-scheduled.yaml
+++ b/.tekton/rhoai-fbc-fragment-v2-25-scheduled.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-type
     value: "nightly"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "2.25.5"
+    value: "2.25.6"
   - name: workflow_url
     value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/conforma-reporter.yaml"
   - name: smoke_url

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -1,5 +1,5 @@
 patch:
-  version: 2.25.5
+  version: 2.25.6
   relatedImages:
     - name: RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE
       value: "quay.io/rhoai/odh-kf-notebook-controller-rhel9@sha256:8fdab8122b0433dfa1045f22074c891d2b84fd21a073f406d12d5bcbe9b9b805"

--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -3,31 +3,31 @@ patch:
     name: rhods-operator
     defaultChannel: stable
   olm.channels:
-    - name: alpha
-      entries:
-      - name: rhods-operator.2.25.5
-        replaces: rhods-operator.2.25.4
-        skipRange: '>=2.24.0 <2.25.5'
     - name: fast
       entries:
-      - name: rhods-operator.2.25.4
-        replaces: rhods-operator.2.25.3
-        skipRange: '>=2.24.0 <2.25.4'
+      - name: rhods-operator.2.25.6
+        replaces: rhods-operator.2.25.5
+        skipRange: '>=2.24.0 <2.25.6'
+    - name: alpha
+      entries:
+      - name: rhods-operator.2.25.6
+        replaces: rhods-operator.2.25.5
+        skipRange: '>=2.24.0 <2.25.6'
     - name: stable
       entries:
-      - name: rhods-operator.2.25.4
-        replaces: rhods-operator.2.25.3
-        skipRange: '>=2.22.0 <2.25.4'
+      - name: rhods-operator.2.25.6
+        replaces: rhods-operator.2.25.5
+        skipRange: '>=2.22.0 <2.25.6'
     - name: stable-2.25
       entries:
-      - name: rhods-operator.2.25.4
-        replaces: rhods-operator.2.25.3
-        skipRange: '>=2.22.0 <2.25.4'
+      - name: rhods-operator.2.25.6
+        replaces: rhods-operator.2.25.5
+        skipRange: '>=2.22.0 <2.25.6'
     - name: eus-2.25
       entries:
-      - name: rhods-operator.2.25.4
-        replaces: rhods-operator.2.25.3
-        skipRange: '>=2.16.0 <2.25.4'
+      - name: rhods-operator.2.25.6
+        replaces: rhods-operator.2.25.5
+        skipRange: '>=2.16.0 <2.25.6'
 
   olm.bundle:
     - quay.io/rhoai/odh-operator-bundle@sha256:38a3c141097853cf480962c4237568cf2cf72d6aea79de842d6688ea76c947cc

--- a/config/modelmesh-pig-build-config.yaml
+++ b/config/modelmesh-pig-build-config.yaml
@@ -1,4 +1,4 @@
-#!productVersion=2.25.5
+#!productVersion=2.25.6
 #!scmRevision=rhoai-2.25
 
 

--- a/config/trustyai-pig-build-config.yaml
+++ b/config/trustyai-pig-build-config.yaml
@@ -1,4 +1,4 @@
-#!productVersion=2.25.5
+#!productVersion=2.25.6
 #!scmRevision=rhoai-2.25
 
 


### PR DESCRIPTION
## Summary
- Bump rhoai-version from 2.25.5 to 2.25.6 in Tekton pipelines
- Update bundle-patch version
- Update catalog-patch OLM channels (name, replaces, skipRange)
- Update PIG build configs (modelmesh, trustyai)

## Files Changed
- `.tekton/odh-operator-bundle-v2-25-push.yaml` — rhoai-version 2.25.5 → 2.25.6
- `.tekton/odh-operator-bundle-v2-25-scheduled.yaml` — same
- `.tekton/rhoai-fbc-fragment-v2-25-push.yaml` — same
- `.tekton/rhoai-fbc-fragment-v2-25-scheduled.yaml` — same
- `bundle/bundle-patch.yaml` — version field
- `catalog/catalog-patch.yaml` — OLM channel entries (name, replaces, skipRange)
- `config/modelmesh-pig-build-config.yaml` — productVersion
- `config/trustyai-pig-build-config.yaml` — productVersion