### PR TITLE
Update replaces field for rhods-operator versions

### DIFF
--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -6,7 +6,7 @@ patch:
     - name: fast
       entries:
       - name: rhods-operator.2.25.6
-        replaces: rhods-operator.2.25.5
+        replaces: rhods-operator.2.25.4
         skipRange: '>=2.24.0 <2.25.6'
     - name: alpha
       entries:
@@ -16,17 +16,17 @@ patch:
     - name: stable
       entries:
       - name: rhods-operator.2.25.6
-        replaces: rhods-operator.2.25.5
+        replaces: rhods-operator.2.25.4
         skipRange: '>=2.22.0 <2.25.6'
     - name: stable-2.25
       entries:
       - name: rhods-operator.2.25.6
-        replaces: rhods-operator.2.25.5
+        replaces: rhods-operator.2.25.4
         skipRange: '>=2.22.0 <2.25.6'
     - name: eus-2.25
       entries:
       - name: rhods-operator.2.25.6
-        replaces: rhods-operator.2.25.5
+        replaces: rhods-operator.2.25.4
         skipRange: '>=2.16.0 <2.25.6'
 
   olm.bundle:


### PR DESCRIPTION
The current head is 2.25.4 which needs to be replace to 2.25.6 