### PR TITLE
feat: add RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE to helm chart

### DIFF
--- a/helm/rhai-on-xks-chart/values.yaml
+++ b/helm/rhai-on-xks-chart/values.yaml
@@ -38,8 +38,8 @@ rhaiOperator:
       value: "registry.redhat.io/rhoai/odh-llm-d-inference-scheduler-rhel9@sha256:f8b4d54ed266acf1ea2fff6ea0614f47fcc03031df4cff0f1f804d60c22debb0"
     - name: RELATED_IMAGE_ODH_LLM_D_ROUTING_SIDECAR_IMAGE
       value: "registry.redhat.io/rhoai/odh-llm-d-routing-sidecar-rhel9@sha256:b922039c37933f6ba4f91476c12a7db1d703db10066408fd949f38617406dc66"
-    - name: RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE
-      value: "registry.redhat.io/rhoai/odh-kube-auth-proxy-rhel9@sha256:046ffc4edddab0df883a138ebae963cceee4d7a77b89bbedb1bf634110a7fb84"
+    - name: RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE
+      value: "registry.redhat.io/rhoai/odh-kube-rbac-proxy-rhel9@sha256:cac4c3da24f72c7c05cfa33e50caf1d03e01f2e3fc33845f1d5f5f62a10a685d"
     - name: RELATED_IMAGE_ODH_LLM_D_KV_CACHE_IMAGE
       value: "registry.redhat.io/rhoai/odh-llm-d-kv-cache-rhel9@sha256:9d306b4c7d0a5ccddeb8c1e4d9ec56e59a414f2ad1a7f1766725d682621296a4"
 

--- a/helm/xks-values-patch.yaml
+++ b/helm/xks-values-patch.yaml
@@ -21,8 +21,8 @@ rhaiOperator:
       value: "registry.redhat.io/rhoai/odh-llm-d-inference-scheduler-rhel9@sha256:9898799b9915d93b03d59b37120647854bf9de8038e1726e99b785d75b3497c9"
     - name: RELATED_IMAGE_ODH_LLM_D_ROUTING_SIDECAR_IMAGE
       value: "registry.redhat.io/rhoai/odh-llm-d-routing-sidecar-rhel9@sha256:f183f6f87433e3dec1e2278ccf84e3339d5fa135437c4dbaaff93bd2f27196fb"
-    - name: RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE
-      value: "registry.redhat.io/rhoai/odh-kube-auth-proxy-rhel9@sha256:5f038c1eeeb8b46d595a735fdd68d642b4b9b4d4a50545854be5d05284e113d6"
+    - name: RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE
+      value: "registry.redhat.io/rhoai/odh-kube-rbac-proxy-rhel9@sha256:cac4c3da24f72c7c05cfa33e50caf1d03e01f2e3fc33845f1d5f5f62a10a685d"
     - name: RELATED_IMAGE_ODH_LLM_D_KV_CACHE_IMAGE
       value: "registry.redhat.io/rhoai/odh-llm-d-kv-cache-rhel9@sha256:e337ebd2a47709af74633878b9a3f49c2e8e1bfb64dba3758a78021cd593687d"
 


### PR DESCRIPTION
Renamed RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE to RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE.
The onboard of the image is done in #20408 