### PR TITLE
fix(bundle): rename ubi-minimal related image key in additional images patch

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -47,5 +47,5 @@ additionalImages:
     value: "registry.stage.redhat.io/rhaii/vllm-spyre-rhel9:3.4.0-1776326998@sha256:5c0ed9be230a307d512fa99236b060ac2ecd86973d17c467badc7b5c2d2b5da4"
   - name: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE
     value: "registry.stage.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0-1776326833@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
-  - name: RELATED_IMAGE_ODH_MAAS_API_KEY_CLEANUP_IMAGE
+  - name: RELATED_IMAGE_UBI_MINIMAL_IMAGE
     value: "registry.redhat.io/ubi9/ubi-minimal:9.7@sha256:7d4e47500f28ac3a2bff06c25eff9127ff21048538ae03ce240d57cf756acd00"


### PR DESCRIPTION
## summary

corrects the related image environment variable name for the ubi-minimal image in `bundle/additional-images-patch.yaml` on the `rhoai-3.4` line.

## description

- renames `RELATED_IMAGE_ODH_MAAS_API_KEY_CLEANUP_IMAGE` to `RELATED_IMAGE_UBI_MINIMAL_IMAGE` for the `registry.redhat.io/ubi9/ubi-minimal:9.7` entry so the related image key matches the image and expected operator/bundle references.
- no change to the image reference or digest; metadata-only fix.

## how it was tested

- reviewed the diff in `bundle/additional-images-patch.yaml` for a single name change and consistent yaml structure.
- not run: bundle build or operator e2e (change is a related-image key rename only).
