### PR TITLE
Remove deprecated RHAII VLLM images

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -30,22 +30,10 @@ additionalImages:
     value: "registry.redhat.io/rhel9/postgresql-16:latest@sha256:fc65b6cf40e09415e10b142748f42a980e6d32c978e4d4f4e988d91d1f1e9afa"
   - name: RELATED_IMAGE_OSE_PROM_LABEL_PROXY_IMAGE
     value: "registry.redhat.io/openshift4/ose-prom-label-proxy-rhel9:v4.20@sha256:5522f37104f3fac57567fa2e9ec65601f60b8cea3603b12dcda26db8c481f404"
-  - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-gaudi-rhel9:3.4.0-1776326902@sha256:1adc51d99455d90f758d840cb3bb5747ed29585c1b0830c051f7fe5cca3471e6"
   - name: RELATED_IMAGE_ODH_PYTHON_312_IMAGE
     value: "registry.redhat.io/ubi9/python-312:latest@sha256:bdc350d3a5298e2dfbb36625db5c671896c36d6ecc26ea939574d9c05c79ffc6"
   - name: RELATED_IMAGE_PERSES_IMAGE
     value: "registry.redhat.io/cluster-observability-operator/perses-rhel9:1.3.1-1765876130@sha256:e797cdb47beef40b04da7b6d645bca3dc32e6247003c45b56b38efd9e13bf01c"
   - name: RELATED_IMAGE_NGINX_126_IMAGE
     value: "registry.redhat.io/ubi9/nginx-126:latest@sha256:b152dbf5caadde0162159d33aadcc211971216faffdeff180d9d346ac09a12dd"
-  # RHAII images are currently in stage registry, but will be promoted to production registry soon. Using stage registry for now to allow testing with the latest images. Once the images are promoted to production registry, the image references will be updated to use registry.redhat.io instead of registry.stage.redhat.io
-  - name: RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-cuda-rhel9:3.4.0-1776326705@sha256:d3e57d4ca13a17f4d5d1228df4fe47cfe1a9f630250a8b3d26f86d871fdb9e69"
-  - name: RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-rocm-rhel9:3.4.0-1776333560@sha256:cfeac10c571206514c2876f220ce845058511185ebe8944afc32581dc45b34f3"
-  - name: RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-spyre-rhel9:3.4.0-1776326998@sha256:5c0ed9be230a307d512fa99236b060ac2ecd86973d17c467badc7b5c2d2b5da4"
-  - name: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0-1776326833@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
-  - name: RELATED_IMAGE_UBI_MINIMAL_IMAGE
-    value: "registry.redhat.io/ubi9/ubi-minimal:9.7@sha256:7d4e47500f28ac3a2bff06c25eff9127ff21048538ae03ce240d57cf756acd00"
+


### PR DESCRIPTION
Removed deprecated RHAII VLLM images from the YAML configuration.