### PR TITLE
Add odh-ai-sixth-demo to bundle-patch.yaml

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -185,6 +185,8 @@ ARG ODH_MODEL_SERVING_API_GIT_COMMIT=
 
 ARG ODH_AI_GATEWAY_PAYLOAD_PROCESSING_E2E_GIT_URL=
 ARG ODH_AI_GATEWAY_PAYLOAD_PROCESSING_E2E_GIT_COMMIT=
+ARG ODH_AI_SIXTH_DEMO_GIT_URL=
+ARG ODH_AI_SIXTH_DEMO_GIT_COMMIT=
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -384,7 +386,9 @@ LABEL \
       odh-model-serving-api.git.url="${ODH_MODEL_SERVING_API_GIT_URL}" \
       odh-model-serving-api.git.commit="${ODH_MODEL_SERVING_API_GIT_COMMIT}" \
       odh-ai-gateway-payload-processing-e2e.git.url="${ODH_AI_GATEWAY_PAYLOAD_PROCESSING_E2E_GIT_URL}" \
-      odh-ai-gateway-payload-processing-e2e.git.commit="${ODH_AI_GATEWAY_PAYLOAD_PROCESSING_E2E_GIT_COMMIT}"
+      odh-ai-gateway-payload-processing-e2e.git.commit="${ODH_AI_GATEWAY_PAYLOAD_PROCESSING_E2E_GIT_COMMIT}" \
+      odh-ai-sixth-demo.git.url="${ODH_AI_SIXTH_DEMO_GIT_URL}" \
+      odh-ai-sixth-demo.git.commit="${ODH_AI_SIXTH_DEMO_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -218,6 +218,8 @@ patch:
     - name: RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_E2E_IMAGE
       value: "quay.io/rhoai/odh-ai-gateway-payload-processing-e2e-rhel9@sha256:1b645726015586e6509d00f90ba042b81e4c170987b3c5974ec118e9bb1a05a9"
 
+    - name: RELATED_IMAGE_ODH_AI_SIXTH_DEMO_IMAGE
+      value: quay.io/rhoai/odh-ai-sixth-demo-rhel9@sha256:188fb138bce262d5a135ce083a13816957ddf959ccaf70ae38b6dc0d612be2e7
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -110,6 +110,7 @@ config:
         rhoai/odh-kserve-autogluon-server-rhel9: rhoai/odh-kserve-autogluon-server-rhel9
         rhoai/odh-kserve-localmodel-controller-rhel9: rhoai/odh-kserve-localmodel-controller-rhel9
         rhoai/odh-ai-gateway-payload-processing-e2e-rhel9: rhoai/odh-ai-gateway-payload-processing-e2e-rhel9
+        rhoai/odh-ai-sixth-demo-rhel9: rhoai/odh-ai-sixth-demo-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds 'odh-ai-sixth-demo' to the red-hat-data-services/RHOAI-Build-Config bundle relatedImages.

Component: odh-ai-sixth-demo
Product context: RHOAI
Quay org: rhoai
Upstream repo: https://github.com/rhoai-rhtap/odh-ai-sixth-demo @ rhoai-3.5-ea.1
Jira: https://redhat.atlassian.net/browse/RHODS-14227

**Files changed:**
- `bundle/bundle-patch.yaml` — added `RELATED_IMAGE_ODH_AI_SIXTH_DEMO_IMAGE` to `patch.relatedImages`
- `config/build-config.yaml` — added `rhoai/odh-ai-sixth-demo-rhel9` to `config.replacements[0].repo_mappings` (RHOAI only)
- `bundle/Dockerfile` — added ARG `ODH_AI_SIXTH_DEMO_GIT_URL`, ARG `ODH_AI_SIXTH_DEMO_GIT_COMMIT`, and git label entries for `odh-ai-sixth-demo` (RHOAI only)

> **NOTE:** The SHA256 digest for `RELATED_IMAGE_ODH_AI_SIXTH_DEMO_IMAGE` is a **placeholder** — the image has not yet been built by Konflux.
> Before merging this PR, replace the digest with the real value:
> ```
> skopeo inspect --no-creds docker://quay.io/rhoai/odh-ai-sixth-demo:odh-stable | jq -r '.Digest'
> ```