### PR TITLE
Add odh-ogx-operator to bundle-patch.yaml

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -185,6 +185,8 @@ ARG ODH_MODEL_SERVING_API_GIT_COMMIT=
 
 ARG ODH_AI_GATEWAY_PAYLOAD_PROCESSING_E2E_GIT_URL=
 ARG ODH_AI_GATEWAY_PAYLOAD_PROCESSING_E2E_GIT_COMMIT=
+ARG ODH_OGX_OPERATOR_GIT_URL=
+ARG ODH_OGX_OPERATOR_GIT_COMMIT=
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -384,7 +386,9 @@ LABEL \
       odh-model-serving-api.git.url="${ODH_MODEL_SERVING_API_GIT_URL}" \
       odh-model-serving-api.git.commit="${ODH_MODEL_SERVING_API_GIT_COMMIT}" \
       odh-ai-gateway-payload-processing-e2e.git.url="${ODH_AI_GATEWAY_PAYLOAD_PROCESSING_E2E_GIT_URL}" \
-      odh-ai-gateway-payload-processing-e2e.git.commit="${ODH_AI_GATEWAY_PAYLOAD_PROCESSING_E2E_GIT_COMMIT}"
+      odh-ai-gateway-payload-processing-e2e.git.commit="${ODH_AI_GATEWAY_PAYLOAD_PROCESSING_E2E_GIT_COMMIT}" \
+      odh-ogx-operator.git.url="${ODH_OGX_OPERATOR_GIT_URL}" \
+      odh-ogx-operator.git.commit="${ODH_OGX_OPERATOR_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -218,6 +218,8 @@ patch:
     - name: RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_E2E_IMAGE
       value: "quay.io/rhoai/odh-ai-gateway-payload-processing-e2e-rhel9@sha256:1b645726015586e6509d00f90ba042b81e4c170987b3c5974ec118e9bb1a05a9"
 
+    - name: RELATED_IMAGE_ODH_OGX_OPERATOR_IMAGE
+      value: quay.io/rhoai/odh-ogx-operator-rhel9@sha256:674209867457ff7b467a567ce3def4983a2afcaec50ad08cf5a2c72e225d023e
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -110,6 +110,7 @@ config:
         rhoai/odh-kserve-autogluon-server-rhel9: rhoai/odh-kserve-autogluon-server-rhel9
         rhoai/odh-kserve-localmodel-controller-rhel9: rhoai/odh-kserve-localmodel-controller-rhel9
         rhoai/odh-ai-gateway-payload-processing-e2e-rhel9: rhoai/odh-ai-gateway-payload-processing-e2e-rhel9
+        rhoai/odh-ogx-operator-rhel9: rhoai/odh-ogx-operator-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds `odh-ogx-operator` to the RHOAI-Build-Config bundle relatedImages.

Component: odh-ogx-operator
Product context: RHOAI
Quay org: rhoai
Upstream repo: https://github.com/red-hat-data-services/ogx-k8s-operator @ rhoai-3.5-ea.1
Jira: https://redhat.atlassian.net/browse/RHOAIENG-60933

**Files changed:**
- `bundle/bundle-patch.yaml` — added `RELATED_IMAGE_ODH_OGX_OPERATOR_IMAGE` to `patch.relatedImages`
- `config/build-config.yaml` — added `rhoai/odh-ogx-operator-rhel9` to `config.replacements[0].repo_mappings` (RHOAI only)
- `bundle/Dockerfile` — added ARG `ODH_OGX_OPERATOR_GIT_URL`, ARG `ODH_OGX_OPERATOR_GIT_COMMIT`, and git label entries for `odh-ogx-operator` (RHOAI only)

> **NOTE:** The SHA256 digest for `RELATED_IMAGE_ODH_OGX_OPERATOR_IMAGE` is a **placeholder** — the image has not yet been built by Konflux.
> Before merging this PR, replace the digest with the real value:
> ```
> skopeo inspect --no-creds docker://quay.io/rhoai/odh-ogx-operator-rhel9:odh-stable | jq -r ".Digest"
> ```