### PR TITLE
Add odh-ogx-core to bundle-patch.yaml

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -189,6 +189,8 @@ ARG ODH_OGX_OPERATOR_GIT_URL=
 ARG ODH_OGX_OPERATOR_GIT_COMMIT=
 ARG ODH_KSERVE_LOCALMODELNODE_AGENT_GIT_URL=
 ARG ODH_KSERVE_LOCALMODELNODE_AGENT_GIT_COMMIT=
+ARG ODH_OGX_CORE_GIT_URL=
+ARG ODH_OGX_CORE_GIT_COMMIT=
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -392,7 +394,9 @@ LABEL \
       odh-ogx-operator.git.url="${ODH_OGX_OPERATOR_GIT_URL}" \
       odh-ogx-operator.git.commit="${ODH_OGX_OPERATOR_GIT_COMMIT}" \
       odh-kserve-localmodelnode-agent.git.url="${ODH_KSERVE_LOCALMODELNODE_AGENT_GIT_URL}" \
-      odh-kserve-localmodelnode-agent.git.commit="${ODH_KSERVE_LOCALMODELNODE_AGENT_GIT_COMMIT}"
+      odh-kserve-localmodelnode-agent.git.commit="${ODH_KSERVE_LOCALMODELNODE_AGENT_GIT_COMMIT}" \
+      odh-ogx-core.git.url="${ODH_OGX_CORE_GIT_URL}" \
+      odh-ogx-core.git.commit="${ODH_OGX_CORE_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -224,6 +224,8 @@ patch:
     - name: RELATED_IMAGE_ODH_TRAINING_CUDA130_TORCH210_PY312_OPENMPI41_IMAGE
       value: "quay.io/rhoai/odh-training-cuda130-torch210-py312-openmpi41-rhel9@sha256:fab7b11d7e31fc4f430cb4dc835d23f5f7f38b4848fc35e9da48c72620f3bc29"
 
+    - name: RELATED_IMAGE_ODH_OGX_CORE_IMAGE
+      value: quay.io/rhoai/odh-ogx-core-rhel9@sha256:74d2497940617875aaa29a084454b6f9089e64675fd8db7e0ab60def960a7617
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -113,6 +113,7 @@ config:
         rhoai/odh-ogx-operator-rhel9: rhoai/odh-ogx-operator-rhel9
         rhoai/odh-kserve-localmodelnode-agent-rhel9: rhoai/odh-kserve-localmodelnode-agent-rhel9
         rhoai/odh-training-cuda130-torch210-py312-openmpi41-rhel9: rhoai/odh-training-cuda130-torch210-py312-openmpi41-rhel9
+        rhoai/odh-ogx-core-rhel9: rhoai/odh-ogx-core-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds 'odh-ogx-core' to the red-hat-data-services/RHOAI-Build-Config bundle relatedImages.

Component: odh-ogx-core
Product context: RHOAI
Quay org: rhoai
Upstream repo: https://github.com/red-hat-data-services/ogx-distribution @ rhoai-3.5-ea.1
Jira: https://redhat.atlassian.net/browse/RHOAIENG-61363

**Files changed:**
- `bundle/bundle-patch.yaml` — added `RELATED_IMAGE_ODH_OGX_CORE_IMAGE` to `patch.relatedImages`
- `config/build-config.yaml` — added `rhoai/odh-ogx-core-rhel9` to `config.replacements[0].repo_mappings` (RHOAI only)
- `bundle/Dockerfile` — added ARG `ODH_OGX_CORE_GIT_URL`, ARG `ODH_OGX_CORE_GIT_COMMIT`, and git label entries for `odh-ogx-core` (RHOAI only)

> **NOTE:** The SHA256 digest for `RELATED_IMAGE_ODH_OGX_CORE_IMAGE` is a **placeholder** — the image has not yet been built by Konflux.
> Before merging this PR, replace the digest with the real value:
> ```
> skopeo inspect --no-creds docker://quay.io/rhoai/odh-ogx-core:odh-stable | jq -r '.Digest'
> ```