### PR TITLE
Add odh-ogx-k8s-operator to bundle-patch.yaml

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -185,8 +185,6 @@ ARG ODH_MODEL_SERVING_API_GIT_COMMIT=
 
 ARG ODH_AI_GATEWAY_PAYLOAD_PROCESSING_E2E_GIT_URL=
 ARG ODH_AI_GATEWAY_PAYLOAD_PROCESSING_E2E_GIT_COMMIT=
-ARG ODH_OGX_OPERATOR_GIT_URL=
-ARG ODH_OGX_OPERATOR_GIT_COMMIT=
 ARG ODH_KSERVE_LOCALMODELNODE_AGENT_GIT_URL=
 ARG ODH_KSERVE_LOCALMODELNODE_AGENT_GIT_COMMIT=
 ARG ODH_OGX_CORE_GIT_URL=
@@ -393,8 +391,6 @@ LABEL \
       odh-model-serving-api.git.commit="${ODH_MODEL_SERVING_API_GIT_COMMIT}" \
       odh-ai-gateway-payload-processing-e2e.git.url="${ODH_AI_GATEWAY_PAYLOAD_PROCESSING_E2E_GIT_URL}" \
       odh-ai-gateway-payload-processing-e2e.git.commit="${ODH_AI_GATEWAY_PAYLOAD_PROCESSING_E2E_GIT_COMMIT}" \
-      odh-ogx-operator.git.url="${ODH_OGX_OPERATOR_GIT_URL}" \
-      odh-ogx-operator.git.commit="${ODH_OGX_OPERATOR_GIT_COMMIT}" \
       odh-kserve-localmodelnode-agent.git.url="${ODH_KSERVE_LOCALMODELNODE_AGENT_GIT_URL}" \
       odh-kserve-localmodelnode-agent.git.commit="${ODH_KSERVE_LOCALMODELNODE_AGENT_GIT_COMMIT}" \
       odh-ogx-core.git.url="${ODH_OGX_CORE_GIT_URL}" \

--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -191,6 +191,8 @@ ARG ODH_KSERVE_LOCALMODELNODE_AGENT_GIT_URL=
 ARG ODH_KSERVE_LOCALMODELNODE_AGENT_GIT_COMMIT=
 ARG ODH_OGX_CORE_GIT_URL=
 ARG ODH_OGX_CORE_GIT_COMMIT=
+ARG ODH_OGX_K8S_OPERATOR_GIT_URL=
+ARG ODH_OGX_K8S_OPERATOR_GIT_COMMIT=
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -396,7 +398,9 @@ LABEL \
       odh-kserve-localmodelnode-agent.git.url="${ODH_KSERVE_LOCALMODELNODE_AGENT_GIT_URL}" \
       odh-kserve-localmodelnode-agent.git.commit="${ODH_KSERVE_LOCALMODELNODE_AGENT_GIT_COMMIT}" \
       odh-ogx-core.git.url="${ODH_OGX_CORE_GIT_URL}" \
-      odh-ogx-core.git.commit="${ODH_OGX_CORE_GIT_COMMIT}"
+      odh-ogx-core.git.commit="${ODH_OGX_CORE_GIT_COMMIT}" \
+      odh-ogx-k8s-operator.git.url="${ODH_OGX_K8S_OPERATOR_GIT_URL}" \
+      odh-ogx-k8s-operator.git.commit="${ODH_OGX_K8S_OPERATOR_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -217,13 +217,10 @@ patch:
       value: "quay.io/rhoai/odh-kserve-localmodel-controller-rhel9@sha256:f55b11c7bfd2ceedf0b907100bb2e65bab8f32f94dc3523bfccccc6a3b263b5b"
     - name: RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_E2E_IMAGE
       value: "quay.io/rhoai/odh-ai-gateway-payload-processing-e2e-rhel9@sha256:1b645726015586e6509d00f90ba042b81e4c170987b3c5974ec118e9bb1a05a9"
-    - name: RELATED_IMAGE_ODH_OGX_OPERATOR_IMAGE
-      value: quay.io/rhoai/odh-ogx-operator-rhel9@sha256:674209867457ff7b467a567ce3def4983a2afcaec50ad08cf5a2c72e225d023e
     - name: RELATED_IMAGE_ODH_KSERVE_LOCALMODELNODE_AGENT_IMAGE
       value: quay.io/rhoai/odh-kserve-localmodelnode-agent-rhel9@sha256:ad3dfc6cb5f33d24778ab6fc71009298cc4ab20518c66666077520c19977028c
     - name: RELATED_IMAGE_ODH_TRAINING_CUDA130_TORCH210_PY312_OPENMPI41_IMAGE
       value: "quay.io/rhoai/odh-training-cuda130-torch210-py312-openmpi41-rhel9@sha256:fab7b11d7e31fc4f430cb4dc835d23f5f7f38b4848fc35e9da48c72620f3bc29"
-
     - name: RELATED_IMAGE_ODH_OGX_CORE_IMAGE
       value: quay.io/rhoai/odh-ogx-core-rhel9@sha256:74d2497940617875aaa29a084454b6f9089e64675fd8db7e0ab60def960a7617
     - name: RELATED_IMAGE_ODH_OGX_K8S_OPERATOR_IMAGE

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -226,6 +226,8 @@ patch:
 
     - name: RELATED_IMAGE_ODH_OGX_CORE_IMAGE
       value: quay.io/rhoai/odh-ogx-core-rhel9@sha256:74d2497940617875aaa29a084454b6f9089e64675fd8db7e0ab60def960a7617
+    - name: RELATED_IMAGE_ODH_OGX_K8S_OPERATOR_IMAGE
+      value: quay.io/rhoai/odh-ogx-k8s-operator-rhel9@sha256:83a1e268edddc1095e0f9f574a0f46eff1462e96511acc5d8e5696cad0fffdf4
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -110,7 +110,6 @@ config:
         rhoai/odh-kserve-autogluon-server-rhel9: rhoai/odh-kserve-autogluon-server-rhel9
         rhoai/odh-kserve-localmodel-controller-rhel9: rhoai/odh-kserve-localmodel-controller-rhel9
         rhoai/odh-ai-gateway-payload-processing-e2e-rhel9: rhoai/odh-ai-gateway-payload-processing-e2e-rhel9
-        rhoai/odh-ogx-operator-rhel9: rhoai/odh-ogx-operator-rhel9
         rhoai/odh-kserve-localmodelnode-agent-rhel9: rhoai/odh-kserve-localmodelnode-agent-rhel9
         rhoai/odh-training-cuda130-torch210-py312-openmpi41-rhel9: rhoai/odh-training-cuda130-torch210-py312-openmpi41-rhel9
         rhoai/odh-ogx-core-rhel9: rhoai/odh-ogx-core-rhel9

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -114,6 +114,7 @@ config:
         rhoai/odh-kserve-localmodelnode-agent-rhel9: rhoai/odh-kserve-localmodelnode-agent-rhel9
         rhoai/odh-training-cuda130-torch210-py312-openmpi41-rhel9: rhoai/odh-training-cuda130-torch210-py312-openmpi41-rhel9
         rhoai/odh-ogx-core-rhel9: rhoai/odh-ogx-core-rhel9
+        rhoai/odh-ogx-k8s-operator-rhel9: rhoai/odh-ogx-k8s-operator-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds 'odh-ogx-k8s-operator' to the red-hat-data-services/RHOAI-Build-Config bundle relatedImages.

Component: odh-ogx-k8s-operator
Product context: RHOAI
Quay org: rhoai
Upstream repo: https://github.com/red-hat-data-services/ogx-k8s-operator @ rhoai-3.5-ea.1
Jira: https://redhat.atlassian.net/browse/RHOAIENG-60933

**Files changed:**
- `bundle/bundle-patch.yaml` — added `RELATED_IMAGE_ODH_OGX_K8S_OPERATOR_IMAGE` to `patch.relatedImages`
- `config/build-config.yaml` — added `rhoai/odh-ogx-k8s-operator-rhel9` to `config.replacements[0].repo_mappings` (RHOAI only)
- `bundle/Dockerfile` — added ARG `ODH_OGX_K8S_OPERATOR_GIT_URL`, ARG `ODH_OGX_K8S_OPERATOR_GIT_COMMIT`, and git label entries for `odh-ogx-k8s-operator` (RHOAI only)

> **NOTE:** The SHA256 digest for `RELATED_IMAGE_ODH_OGX_K8S_OPERATOR_IMAGE` is a **placeholder** — the image has not yet been built by Konflux.
> Before merging this PR, replace the digest with the real value:
> ```
> skopeo inspect --no-creds docker://quay.io/rhoai/odh-ogx-k8s-operator:odh-stable | jq -r '.Digest'
> ```