### PR TITLE
Update RHAIIS vLLM CUDA and ROCm images to 3.3.3

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -29,9 +29,9 @@ additionalImages:
   - name: RELATED_IMAGE_OSE_PROM_LABEL_PROXY_IMAGE
     value: "registry.redhat.io/openshift4/ose-prom-label-proxy-rhel9:v4.20@sha256:74c7215749e6453f3931f3411b27074d7265f7774289c572fb5b3a8ff62f7fc7"
   - name: RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.3.0@sha256:ec799bb5eeb7e25b4b25a8917ab5161da6b6f1ab830cbba61bba371cffb0c34d"
+    value: "registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.3.3@sha256:46018f418b5202b73c8da509ec665d08c19d020e795469f169a506644c6304b6"
   - name: RELATED_IMAGE_RHAIIS_VLLM_ROCM_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-rocm-rhel9:3.3.0@sha256:e345cf9453afae0d3c2afe2f7fb9be8fac772f46593b873e925d38ae2b3ee537"
+    value: "registry.redhat.io/rhaiis/vllm-rocm-rhel9:3.3.3@sha256:aaab9d15a2e1c17e10c2310cccf2a19a0d52d2c3f4ee33ff17408a4c1b742dcc"
   - name: RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE
     value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.3.0@sha256:75f0ea05a92661a33b40efe2a662d976d53c767db18990b433d4a00dd6693aae"
   - name: RELATED_IMAGE_ODH_PYTHON_312_IMAGE


### PR DESCRIPTION
## Summary
- Update `vllm-cuda-rhel9` tag from `3.3.0` to `3.3.3` with new digest
- Update `vllm-rocm-rhel9` tag from `3.3.0` to `3.3.3` with new digest
- Spyre and CPU images remain at `3.3.0` (no 3.3.3 builds available yet)

## Image Details

| Image | Old Tag | New Tag | New Digest |
|-------|---------|---------|------------|
| `rhaiis/vllm-cuda-rhel9` | `3.3.0` | `3.3.3` | `sha256:46018f41...` |
| `rhaiis/vllm-rocm-rhel9` | `3.3.0` | `3.3.3` | `sha256:aaab9d15...` |

## Notes
- Images sourced from `registry.redhat.io/rhaiis/` (production)
- The "Process Operator Bundle" workflow will auto-regenerate the CSV and catalog files after merge

Ref: [RHOAIENG-62128](https://redhat.atlassian.net/browse/RHOAIENG-62128)