### PR TITLE
Update RHAIIS vLLM Spyre image to 3.3.3

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -33,7 +33,7 @@ additionalImages:
   - name: RELATED_IMAGE_RHAIIS_VLLM_ROCM_IMAGE
     value: "registry.redhat.io/rhaiis/vllm-rocm-rhel9:3.3.3@sha256:aaab9d15a2e1c17e10c2310cccf2a19a0d52d2c3f4ee33ff17408a4c1b742dcc"
   - name: RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.3.0@sha256:75f0ea05a92661a33b40efe2a662d976d53c767db18990b433d4a00dd6693aae"
+    value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.3.3@sha256:6c5ebd89efab3057ac18911d0d52452de0f9be38e9512d66877f2919713e7e56"
   - name: RELATED_IMAGE_ODH_PYTHON_312_IMAGE
     value: "registry.redhat.io/ubi9/python-312:latest@sha256:bf2f5a3cf0c1542d2c90e729bef7e79df746e0331ab7fd19c86e3ff4792dc9f5"
   - name: RELATED_IMAGE_PERSES_IMAGE


### PR DESCRIPTION
## Summary
- Update RHAIIS vLLM Spyre image from 3.3.0 to 3.3.3 in `additional-images-patch.yaml`
- Image: `registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.3.3@sha256:6c5ebd89efab3057ac18911d0d52452de0f9be38e9512d66877f2919713e7e56`

## Context
RHAIIS 3.3.3 Spyre image is now available on the production registry. This follows the same pattern as the CUDA/ROCm updates in PR #21780.

## Changes
- `bundle/additional-images-patch.yaml`: Updated `RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE` tag 3.3.0 → 3.3.3 with updated digest

Note: No rhods-operator PR needed — Spyre is not referenced in KServe's `params.env` (modelcontroller uses upstream `quay.io/vllm/vllm:latest`).