### PR TITLE
Remove stable-3.x channel from rhoai-3.3 catalog

### DIFF
--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -10,13 +10,6 @@ patch:
       - name: rhods-operator.3.3.3
         replaces: rhods-operator.3.3.2
         skipRange: '>=3.3.0 <3.3.3'
-    - name: stable-3.x
-      package: rhods-operator
-      schema: olm.channel
-      entries:
-      - name: rhods-operator.3.3.3
-        replaces: rhods-operator.3.3.2
-        skipRange: '>=3.3.0 <3.3.3'
     - name: support-required-upgrade
       package: rhods-operator
       schema: olm.channel


### PR DESCRIPTION
## Summary
- Remove the `stable-3.x` channel entry from `catalog/catalog-patch.yaml`

## Reason
With the 3.4 release, the `stable-3.x` channel head will move to 3.4.0. The channel head cannot move backwards to 3.3.0