### PR TITLE
feat: add Amazon cloud manager image to xks-values-patch

### DIFF
--- a/helm/xks-values-patch.yaml
+++ b/helm/xks-values-patch.yaml
@@ -44,3 +44,7 @@ azure:
 coreweave:
   cloudManager:
     image: "registry.redhat.io/rhoai/odh-rhel9-operator@sha256:ab695c0ab6f98b98322cb98cdb8bd5ab5ea8202ff25fd568454ec0c97e57d10b"
+
+aws:
+  cloudManager:
+    image: "registry.redhat.io/rhoai/odh-rhel9-operator@sha256:ab695c0ab6f98b98322cb98cdb8bd5ab5ea8202ff25fd568454ec0c97e57d10b"


### PR DESCRIPTION
Add `aws.cloudManager.image` to `helm/xks-values-patch.yaml` for the new Amazon cloud manager provider.            
Same image as azure/coreweave — all three providers use the same operator binary, selected via CLI arg at runtime.   
 ## Related PRs                                                                                                        
                                                      
  - **Operator:** opendatahub-io/opendatahub-operator#3477 — AwsKubernetesEngine CRD, controller, tests              
  - **Helm chart:** opendatahub-io/odh-gitops#96 — Amazon provider in rhai-on-xks chart (templates, values, snapshots,
  CI)                                                                                               