### PR TITLE
Update support-required-upgrade skipRange to >=2.25.6

### DIFF
--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -16,7 +16,7 @@ patch:
       entries:
       - name: rhods-operator.3.3.3
         replaces: rhods-operator.3.3.2
-        skipRange: '>=2.25.5 <2.26.0 || >=3.3.2 <3.3.3'
+        skipRange: '>=2.25.6 <2.26.0 || >=3.3.2 <3.3.3'
 
   olm.bundle:
     - quay.io/rhoai/odh-operator-bundle@sha256:00dbade4a6f67c6709fa5054d20f1ff00f5ca019d77985fd99335ea98e0daf6c


### PR DESCRIPTION
## Summary
- Narrow the `support-required-upgrade` channel skipRange from `>=2.25.5` to `>=2.25.6`

## Reason
2.25.5 had a dashboard crash bug for non-admin users. Customers on 2.25.5 should upgrade to 2.25.6 first before upgrading to 3.3.3. This aligns with the policy of supporting only 2.25.latest → 3.3.latest upgrade path.

## Changes
- `catalog/catalog-patch.yaml`: `>=2.25.5 <2.26.0` → `>=2.25.6 <2.26.0`