### PR TITLE
offboard odh-training-cuda130-torch210-py312-openmpi41 from RHOAI-3.5…

### DIFF
--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -215,8 +215,6 @@ patch:
       value: "quay.io/rhoai/odh-ai-gateway-payload-processing-e2e-rhel9@sha256:1b645726015586e6509d00f90ba042b81e4c170987b3c5974ec118e9bb1a05a9"
     - name: RELATED_IMAGE_ODH_KSERVE_LOCALMODELNODE_AGENT_IMAGE
       value: quay.io/rhoai/odh-kserve-localmodelnode-agent-rhel9@sha256:ad3dfc6cb5f33d24778ab6fc71009298cc4ab20518c66666077520c19977028c
-    - name: RELATED_IMAGE_ODH_TRAINING_CUDA130_TORCH210_PY312_OPENMPI41_IMAGE
-      value: "quay.io/rhoai/odh-training-cuda130-torch210-py312-openmpi41-rhel9@sha256:fab7b11d7e31fc4f430cb4dc835d23f5f7f38b4848fc35e9da48c72620f3bc29"
     - name: RELATED_IMAGE_ODH_OGX_CORE_IMAGE
       value: quay.io/rhoai/odh-ogx-core-rhel9@sha256:74d2497940617875aaa29a084454b6f9089e64675fd8db7e0ab60def960a7617
     - name: RELATED_IMAGE_ODH_OGX_K8S_OPERATOR_IMAGE

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -109,7 +109,6 @@ config:
         rhoai/odh-kserve-localmodel-controller-rhel9: rhoai/odh-kserve-localmodel-controller-rhel9
         rhoai/odh-ai-gateway-payload-processing-e2e-rhel9: rhoai/odh-ai-gateway-payload-processing-e2e-rhel9
         rhoai/odh-kserve-localmodelnode-agent-rhel9: rhoai/odh-kserve-localmodelnode-agent-rhel9
-        rhoai/odh-training-cuda130-torch210-py312-openmpi41-rhel9: rhoai/odh-training-cuda130-torch210-py312-openmpi41-rhel9
         rhoai/odh-ogx-core-rhel9: rhoai/odh-ogx-core-rhel9
         rhoai/odh-ogx-k8s-operator-rhel9: rhoai/odh-ogx-k8s-operator-rhel9
   supported-ocp-versions:


### PR DESCRIPTION
…-EA.1



Offboarding dh-training-cuda130-torch210-py312-openmpi41-rhel9 as per request of the following ticket: https://redhat.atlassian.net/browse/RHOAIENG-62506



Please see the following slack thread/request for more info: https://redhat.enterprise.slack.com/lists/T027F3GAJ/F07SBP17R7Z?record_id=Rec0B3QHK494N