### PR TITLE
update: cleanup unnecessary images for Helm chart (llm-d use case)

### DIFF
--- a/helm/xks-values-patch.yaml
+++ b/helm/xks-values-patch.yaml
@@ -3,30 +3,20 @@ rhaiOperator:
   relatedImages:
     - name: RELATED_IMAGE_ODH_KSERVE_AGENT_IMAGE
       value: "registry.redhat.io/rhoai/odh-kserve-agent-rhel9@sha256:b593e482adc887c4cb888f9537831bb3dc0ad072282fac9352cded80d89c5817"
-    - name: RELATED_IMAGE_ODH_KSERVE_CONTROLLER_IMAGE
-      value: "registry.redhat.io/rhoai/odh-kserve-controller-rhel9@sha256:98beed91d75a639289e6c1f19026f4d4ecd40c8ddd84f1104996e9384f290741"
     - name: RELATED_IMAGE_ODH_KSERVE_LLMISVC_CONTROLLER_IMAGE
       value: "registry.redhat.io/rhoai/odh-kserve-llmisvc-controller-rhel9@sha256:ad8ce03ff23be86ea4b13fb2ab8e408e0eb2b7c6be4bde5ce30294cd11c7a583"
-    - name: RELATED_IMAGE_ODH_KSERVE_ROUTER_IMAGE
-      value: "registry.redhat.io/rhoai/odh-kserve-router-rhel9@sha256:2ab82ad32f0e064aee8b30fddc40d6d3389ea98a02ab50ee9222df96dffb3cf2"
     - name: RELATED_IMAGE_ODH_KSERVE_STORAGE_INITIALIZER_IMAGE
       value: "registry.redhat.io/rhoai/odh-kserve-storage-initializer-rhel9@sha256:f84b259d20572012abecd91bb93933c1aa0cf64dbe552c951fdb2230ec9ffdb3"
     - name: RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE
       value: "registry.redhat.io/rhaii/vllm-cuda-rhel9@sha256:d3e57d4ca13a17f4d5d1228df4fe47cfe1a9f630250a8b3d26f86d871fdb9e69"
     - name: RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE
       value: "registry.redhat.io/rhaii/vllm-rocm-rhel9@sha256:cfeac10c571206514c2876f220ce845058511185ebe8944afc32581dc45b34f3"
-    - name: RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE
-      value: "registry.redhat.io/rhaii/vllm-spyre-rhel9@sha256:5c0ed9be230a307d512fa99236b060ac2ecd86973d17c467badc7b5c2d2b5da4"
     - name: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE
       value: "registry.redhat.io/rhaii/vllm-cpu-rhel9@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
-    - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
-      value: "registry.redhat.io/rhaii/vllm-gaudi-rhel9@sha256:1adc51d99455d90f758d840cb3bb5747ed29585c1b0830c051f7fe5cca3471e6"
     - name: RELATED_IMAGE_ODH_LLM_D_INFERENCE_SCHEDULER_IMAGE
       value: "registry.redhat.io/rhoai/odh-llm-d-inference-scheduler-rhel9@sha256:0323abbb1fee434123c0f3b47f32206d3101436907ef695b472d9cda725c2332"
     - name: RELATED_IMAGE_ODH_LLM_D_ROUTING_SIDECAR_IMAGE
       value: "registry.redhat.io/rhoai/odh-llm-d-routing-sidecar-rhel9@sha256:42e0e01595b755da5788ba4518b4c9530b1c688b6308fa777385594c1dc6c2fa"
-    - name: RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE
-      value: "registry.redhat.io/rhoai/odh-kube-rbac-proxy-rhel9@sha256:b07ee1f875be4153c017780c90140e82244381497ac75209c34db70242fb109a"
     - name: RELATED_IMAGE_ODH_LLM_D_KV_CACHE_IMAGE
       value: "registry.redhat.io/rhoai/odh-llm-d-kv-cache-rhel9@sha256:82f0bcd33208744d52c46a29e498a0d537b7e358ab7952ec5da1dac0337bbb36"
     - name: RELATED_IMAGE_ODH_KSERVE_LOCALMODEL_CONTROLLER_IMAGE


### PR DESCRIPTION
# Changes
- remove rbac
- remove spyre gaudi
- kserve-controll and router

# Notes
- we only support llmisvc
- we only support cuda, cpu, maybe rocm
- we might be support localmodal in the next release
- we will need support for maas and dashboard eventually