### PR TITLE
Onboard rhoai to 3.4.1

### DIFF
--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -1,5 +1,5 @@
 patch:
-  version: 3.4.0
+  version: 3.4.1
   relatedImages:
     - name: RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE
       value: "quay.io/rhoai/odh-kf-notebook-controller-rhel9@sha256:8fdab8122b0433dfa1045f22074c891d2b84fd21a073f406d12d5bcbe9b9b805"

--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -7,16 +7,16 @@ patch:
       package: rhods-operator
       schema: olm.channel
       entries:
-        - name: rhods-operator.3.4.0
-          replaces: rhods-operator.3.3.2
-          skipRange: '>=3.3.0 <3.4.0'
+        - name: rhods-operator.3.4.1
+          replaces: rhods-operator.3.4.0
+          skipRange: '>=3.3.0 <3.4.1'
     - name: stable-3.x
       package: rhods-operator
       schema: olm.channel
       entries:
-        - name: rhods-operator.3.4.0
-          replaces: rhods-operator.3.3.2
-          skipRange: '>=3.3.0 <3.4.0'
+        - name: rhods-operator.3.4.1
+          replaces: rhods-operator.3.4.0
+          skipRange: '>=3.3.0 <3.4.1'
 
   olm.bundle:
     - quay.io/rhoai/odh-operator-bundle@sha256:80ed8b82ae0caa32394abe7207f0a3ea878b592e653f55083e758265377a4d2e


### PR DESCRIPTION
## Summary
- Update bundle-patch version from 3.4.0 to 3.4.1
- Update catalog-patch OLM channels (name, replaces, skipRange)

## Files Changed
- bundle/bundle-patch.yaml -- version field
- catalog/catalog-patch.yaml -- OLM channel entries

## Note
Tekton pipeline changes are managed via konflux-central (already applied to rhoai-3.4 branch).