### PR TITLE
Onboard rhoai to 3.4.1 (stage pipelines)

### DIFF
--- a/.tekton/rhoai-fbc-fragment-rhoai-34-ocp-419-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-34-ocp-419-push.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "3.4.0"
+    value: "3.4.1"
   - name: ocp-version
     value: "4.19"
   - name: fbc-pipeline-branch

--- a/.tekton/rhoai-fbc-fragment-rhoai-34-ocp-420-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-34-ocp-420-push.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "3.4.0"
+    value: "3.4.1"
   - name: ocp-version
     value: "4.20"
   - name: fbc-pipeline-branch

--- a/.tekton/rhoai-fbc-fragment-rhoai-34-ocp-421-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-34-ocp-421-push.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "3.4.0"
+    value: "3.4.1"
   - name: ocp-version
     value: "4.21"
   - name: fbc-pipeline-branch


### PR DESCRIPTION
## Summary
- Bump rhoai-version from 3.4.0 to 3.4.1 in stage FBC fragment pipelines

## Files Changed
- .tekton/rhoai-fbc-fragment-rhoai-34-ocp-*-push.yaml -- rhoai-version parameter bump for OCP 4.19, 4.20, 4.21 stage pipelines