### PR TITLE
Update RHAIIS Images Value

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -23,6 +23,6 @@ additionalImages:
   - name: RELATED_IMAGE_OSE_CLI_IMAGE
     value: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.18@sha256:49c07ce876ef0491b535230e78fcdd0428f634a95b7efa1f9e29108bbbe224fb"
   - name: RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.2.2-1769008654@sha256:720ebbd1f6945e47e4ad77465732eab5702cfc430658ae43d1c8f128271f81c4"
+    value: "registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.2.2-1779223654@sha256:20875433e2469960c87a66613176eeec60ecc39555e2592329a0a4c60aea06ef"
   - name: RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE
     value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.3.0@sha256:75f0ea05a92661a33b40efe2a662d976d53c767db18990b433d4a00dd6693aae"


### PR DESCRIPTION
Updated  vllm-cuda-rhel9 image as per : `registry.redhat.io/rhaiis/vllm-cuda-rhel9@sha256:20875433e2469960c87a66613176eeec60ecc39555e2592329a0a4c60aea06ef`