### PR TITLE
Add RHOAI 3.3.3 release artifacts

### DIFF
--- a/release/3.3.3/prod/prod-release-1779281517/release-components/prod-release-components-rhoai-v3-3-1779281517.yaml
+++ b/release/3.3.3/prod/prod-release-1779281517/release-components/prod-release-components-rhoai-v3-3-1779281517.yaml
@@ -1,0 +1,689 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-v3-3-prod-1779281517
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: bcf0c204331a152d220dedec61ec73765eb6f8da
+    konflux-release-data/artifact-type: components
+    konflux-release-data/environment: prod
+    appstudio.openshift.io/application: rhoai-v3-3
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-3-components-prod
+  snapshot: rhoai-v3-3-1779210391
+  data:
+    version: 3.3.3
+    releaseNotes:
+      cves:
+        - key: 'CVE-2026-40895' # https://redhat.atlassian.net/browse/RHOAIENG-59719
+          component: 'odh-mod-arch-gen-ai-v3-3'
+        - key: 'CVE-2026-40895' # https://redhat.atlassian.net/browse/RHOAIENG-59715
+          component: 'odh-mod-arch-model-registry-v3-3'
+        - key: 'CVE-2026-40895' # https://redhat.atlassian.net/browse/RHOAIENG-59713
+          component: 'odh-dashboard-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59310
+          component: 'odh-training-cuda128-torch29-py312-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59302
+          component: 'odh-mlflow-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59300
+          component: 'odh-kserve-storage-initializer-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59296
+          component: 'odh-feature-server-v3-3'
+        - key: 'CVE-2026-28684' # https://redhat.atlassian.net/browse/RHOAIENG-59258
+          component: 'odh-vllm-gaudi-v3-3'
+        - key: 'CVE-2026-28684' # https://redhat.atlassian.net/browse/RHOAIENG-59255
+          component: 'odh-training-cuda128-torch29-py312-v3-3'
+        - key: 'CVE-2026-28684' # https://redhat.atlassian.net/browse/RHOAIENG-59249
+          component: 'odh-mlserver-v3-3'
+        - key: 'CVE-2026-28684' # https://redhat.atlassian.net/browse/RHOAIENG-59242
+          component: 'odh-feature-server-v3-3'
+        - key: 'CVE-2026-40192' # https://redhat.atlassian.net/browse/RHOAIENG-58615
+          component: 'odh-workbench-jupyter-trustyai-cpu-py312-v3-3'
+        - key: 'CVE-2026-40192' # https://redhat.atlassian.net/browse/RHOAIENG-58614
+          component: 'odh-workbench-jupyter-tensorflow-rocm-py312-v3-3'
+        - key: 'CVE-2026-40192' # https://redhat.atlassian.net/browse/RHOAIENG-58613
+          component: 'odh-workbench-jupyter-tensorflow-cuda-py312-v3-3'
+        - key: 'CVE-2026-40192' # https://redhat.atlassian.net/browse/RHOAIENG-58612
+          component: 'odh-workbench-jupyter-pytorch-rocm-py312-v3-3'
+        - key: 'CVE-2026-40192' # https://redhat.atlassian.net/browse/RHOAIENG-58610
+          component: 'odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3'
+        - key: 'CVE-2026-40192' # https://redhat.atlassian.net/browse/RHOAIENG-58609
+          component: 'odh-workbench-jupyter-pytorch-cuda-py312-v3-3'
+        - key: 'CVE-2026-40192' # https://redhat.atlassian.net/browse/RHOAIENG-58608
+          component: 'odh-workbench-jupyter-datascience-cpu-py312-v3-3'
+        - key: 'CVE-2026-40192' # https://redhat.atlassian.net/browse/RHOAIENG-58607
+          component: 'odh-workbench-codeserver-datascience-cpu-py312-v3-3'
+        - key: 'CVE-2026-40192' # https://redhat.atlassian.net/browse/RHOAIENG-58603
+          component: 'odh-training-rocm64-torch29-py312-v3-3'
+        - key: 'CVE-2026-40192' # https://redhat.atlassian.net/browse/RHOAIENG-58602
+          component: 'odh-training-cuda128-torch29-py312-v3-3'
+        - key: 'CVE-2026-40192' # https://redhat.atlassian.net/browse/RHOAIENG-58601
+          component: 'odh-pipeline-runtime-tensorflow-rocm-py312-v3-3'
+        - key: 'CVE-2026-40192' # https://redhat.atlassian.net/browse/RHOAIENG-58600
+          component: 'odh-pipeline-runtime-tensorflow-cuda-py312-v3-3'
+        - key: 'CVE-2026-40192' # https://redhat.atlassian.net/browse/RHOAIENG-58599
+          component: 'odh-pipeline-runtime-pytorch-rocm-py312-v3-3'
+        - key: 'CVE-2026-40192' # https://redhat.atlassian.net/browse/RHOAIENG-58598
+          component: 'odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-3'
+        - key: 'CVE-2026-40192' # https://redhat.atlassian.net/browse/RHOAIENG-58597
+          component: 'odh-pipeline-runtime-pytorch-cuda-py312-v3-3'
+        - key: 'CVE-2026-40192' # https://redhat.atlassian.net/browse/RHOAIENG-58596
+          component: 'odh-pipeline-runtime-datascience-cpu-py312-v3-3'
+        - key: 'CVE-2026-40175' # https://redhat.atlassian.net/browse/RHOAIENG-57814
+          component: 'odh-mod-arch-model-registry-v3-3'
+        - key: 'CVE-2026-40175' # https://redhat.atlassian.net/browse/RHOAIENG-57813
+          component: 'odh-mod-arch-maas-v3-3'
+        - key: 'CVE-2026-40175' # https://redhat.atlassian.net/browse/RHOAIENG-57812
+          component: 'odh-mod-arch-gen-ai-v3-3'
+        - key: 'CVE-2026-40175' # https://redhat.atlassian.net/browse/RHOAIENG-57811
+          component: 'odh-dashboard-v3-3'
+        - key: 'CVE-2025-62718' # https://redhat.atlassian.net/browse/RHOAIENG-57655
+          component: 'odh-mod-arch-model-registry-v3-3'
+        - key: 'CVE-2025-62718' # https://redhat.atlassian.net/browse/RHOAIENG-57654
+          component: 'odh-mod-arch-model-registry-v3-3'
+        - key: 'CVE-2025-62718' # https://redhat.atlassian.net/browse/RHOAIENG-57651
+          component: 'odh-mod-arch-gen-ai-v3-3'
+        - key: 'CVE-2025-62718' # https://redhat.atlassian.net/browse/RHOAIENG-57650
+          component: 'odh-dashboard-v3-3'
+        - key: 'CVE-2026-34986' # https://redhat.atlassian.net/browse/RHOAIENG-56859
+          component: 'odh-model-controller-v3-3'
+        - key: 'CVE-2026-34986' # https://redhat.atlassian.net/browse/RHOAIENG-56827
+          component: 'odh-kube-auth-proxy-v3-3'
+        - key: 'CVE-2026-4800' # https://redhat.atlassian.net/browse/RHOAIENG-56420
+          component: 'odh-mod-arch-model-registry-v3-3'
+        - key: 'CVE-2026-4800' # https://redhat.atlassian.net/browse/RHOAIENG-56418
+          component: 'odh-mod-arch-gen-ai-v3-3'
+        - key: 'CVE-2026-4800' # https://redhat.atlassian.net/browse/RHOAIENG-56416
+          component: 'odh-dashboard-v3-3'
+        - key: 'CVE-2026-27893' # https://redhat.atlassian.net/browse/RHOAIENG-55685
+          component: 'odh-vllm-gaudi-v3-3'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55310
+          component: 'odh-llm-d-routing-sidecar-v3-3'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55309
+          component: 'odh-llm-d-inference-scheduler-v3-3'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55308
+          component: 'odh-kube-auth-proxy-v3-3'
+        - key: 'CVE-2026-29063' # https://redhat.atlassian.net/browse/RHOAIENG-55006
+          component: 'odh-mod-arch-model-registry-v3-3'
+        - key: 'CVE-2026-29063' # https://redhat.atlassian.net/browse/RHOAIENG-55004
+          component: 'odh-mod-arch-gen-ai-v3-3'
+        - key: 'CVE-2026-29063' # https://redhat.atlassian.net/browse/RHOAIENG-55002
+          component: 'odh-dashboard-v3-3'
+        - key: 'CVE-2026-33236' # https://redhat.atlassian.net/browse/RHOAIENG-54743
+          component: 'odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3'
+        - key: 'CVE-2026-33236' # https://redhat.atlassian.net/browse/RHOAIENG-54742
+          component: 'odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-3'
+        - key: 'CVE-2026-33231' # https://redhat.atlassian.net/browse/RHOAIENG-54651
+          component: 'odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3'
+        - key: 'CVE-2026-33231' # https://redhat.atlassian.net/browse/RHOAIENG-54649
+          component: 'odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-3'
+        - key: 'CVE-2026-30922' # https://redhat.atlassian.net/browse/RHOAIENG-54247
+          component: 'odh-kserve-storage-initializer-v3-3'
+        - key: 'CVE-2026-32829' # https://redhat.atlassian.net/browse/RHOAIENG-54142
+          component: 'odh-llm-d-inference-scheduler-v3-3'
+        - key: 'CVE-2026-32981' # https://redhat.atlassian.net/browse/RHOAIENG-54044
+          component: 'odh-workbench-jupyter-trustyai-cpu-py312-v3-3'
+        - key: 'CVE-2026-32981' # https://redhat.atlassian.net/browse/RHOAIENG-54043
+          component: 'odh-workbench-jupyter-tensorflow-rocm-py312-v3-3'
+        - key: 'CVE-2026-32981' # https://redhat.atlassian.net/browse/RHOAIENG-54042
+          component: 'odh-workbench-jupyter-tensorflow-cuda-py312-v3-3'
+        - key: 'CVE-2026-32981' # https://redhat.atlassian.net/browse/RHOAIENG-54041
+          component: 'odh-workbench-jupyter-pytorch-rocm-py312-v3-3'
+        - key: 'CVE-2026-32981' # https://redhat.atlassian.net/browse/RHOAIENG-54040
+          component: 'odh-workbench-jupyter-pytorch-cuda-py312-v3-3'
+        - key: 'CVE-2026-32981' # https://redhat.atlassian.net/browse/RHOAIENG-54039
+          component: 'odh-workbench-jupyter-datascience-cpu-py312-v3-3'
+        - key: 'CVE-2026-32981' # https://redhat.atlassian.net/browse/RHOAIENG-54037
+          component: 'odh-pipeline-runtime-tensorflow-rocm-py312-v3-3'
+        - key: 'CVE-2026-32981' # https://redhat.atlassian.net/browse/RHOAIENG-54036
+          component: 'odh-pipeline-runtime-tensorflow-cuda-py312-v3-3'
+        - key: 'CVE-2026-32981' # https://redhat.atlassian.net/browse/RHOAIENG-54035
+          component: 'odh-pipeline-runtime-pytorch-rocm-py312-v3-3'
+        - key: 'CVE-2026-32981' # https://redhat.atlassian.net/browse/RHOAIENG-54034
+          component: 'odh-pipeline-runtime-pytorch-cuda-py312-v3-3'
+        - key: 'CVE-2026-32981' # https://redhat.atlassian.net/browse/RHOAIENG-54033
+          component: 'odh-pipeline-runtime-datascience-cpu-py312-v3-3'
+        - key: 'CVE-2026-29074' # https://redhat.atlassian.net/browse/RHOAIENG-53355
+          component: 'odh-mod-arch-model-registry-v3-3'
+        - key: 'CVE-2026-29074' # https://redhat.atlassian.net/browse/RHOAIENG-53354
+          component: 'odh-mod-arch-gen-ai-v3-3'
+        - key: 'CVE-2026-29074' # https://redhat.atlassian.net/browse/RHOAIENG-53353
+          component: 'odh-dashboard-v3-3'
+        - key: 'CVE-2026-32597' # https://redhat.atlassian.net/browse/RHOAIENG-53165
+          component: 'odh-vllm-gaudi-v3-3'
+        - key: 'CVE-2026-32597' # https://redhat.atlassian.net/browse/RHOAIENG-53164
+          component: 'odh-vllm-cpu-v3-3'
+        - key: 'CVE-2026-31812' # https://redhat.atlassian.net/browse/RHOAIENG-52524
+          component: 'odh-model-registry-job-async-upload-v3-3'
+        - key: 'CVE-2026-0847' # https://redhat.atlassian.net/browse/RHOAIENG-52412
+          component: 'odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3'
+        - key: 'CVE-2026-0847' # https://redhat.atlassian.net/browse/RHOAIENG-52410
+          component: 'odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-3'
+        - key: 'CVE-2026-0846' # https://redhat.atlassian.net/browse/RHOAIENG-52402
+          component: 'odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3'
+        - key: 'CVE-2026-0846' # https://redhat.atlassian.net/browse/RHOAIENG-52400
+          component: 'odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-3'
+        - key: 'CVE-2025-69873' # https://redhat.atlassian.net/browse/RHOAIENG-49702
+          component: 'odh-mod-arch-model-registry-v3-3'
+        - key: 'CVE-2025-69873' # https://redhat.atlassian.net/browse/RHOAIENG-49701
+          component: 'odh-mod-arch-gen-ai-v3-3'
+        - key: 'CVE-2025-69873' # https://redhat.atlassian.net/browse/RHOAIENG-49700
+          component: 'odh-dashboard-v3-3'
+        - key: 'CVE-2026-25990' # https://redhat.atlassian.net/browse/RHOAIENG-49476
+          component: 'odh-vllm-gaudi-v3-3'
+        - key: 'CVE-2026-25990' # https://redhat.atlassian.net/browse/RHOAIENG-49475
+          component: 'odh-vllm-cpu-v3-3'
+        - key: 'CVE-2026-25639' # https://redhat.atlassian.net/browse/RHOAIENG-49369
+          component: 'odh-mod-arch-model-registry-v3-3'
+        - key: 'CVE-2026-25639' # https://redhat.atlassian.net/browse/RHOAIENG-49368
+          component: 'odh-mod-arch-gen-ai-v3-3'
+        - key: 'CVE-2026-25639' # https://redhat.atlassian.net/browse/RHOAIENG-49367
+          component: 'odh-dashboard-v3-3'
+        - key: 'CVE-2025-61726' # https://redhat.atlassian.net/browse/RHOAIENG-48623
+          component: 'odh-llm-d-routing-sidecar-v3-3'
+        - key: 'CVE-2025-61726' # https://redhat.atlassian.net/browse/RHOAIENG-48622
+          component: 'odh-llm-d-inference-scheduler-v3-3'
+        - key: 'CVE-2025-61726' # https://redhat.atlassian.net/browse/RHOAIENG-48621
+          component: 'odh-llama-stack-k8s-operator-v3-3'
+        - key: 'CVE-2025-61726' # https://redhat.atlassian.net/browse/RHOAIENG-48615
+          component: 'odh-data-science-pipelines-argo-workflowcontroller-v3-3'
+        - key: 'CVE-2025-61726' # https://redhat.atlassian.net/browse/RHOAIENG-48614
+          component: 'odh-data-science-pipelines-argo-argoexec-v3-3'
+        - key: 'CVE-2026-22778' # https://redhat.atlassian.net/browse/RHOAIENG-48365
+          component: 'odh-vllm-cpu-v3-3'
+        - key: 'CVE-2026-24779' # https://redhat.atlassian.net/browse/RHOAIENG-47856
+          component: 'odh-vllm-cpu-v3-3'
+        - key: 'CVE-2026-24486' # https://redhat.atlassian.net/browse/RHOAIENG-47666
+          component: 'odh-vllm-cpu-v3-3'
+        - key: 'CVE-2025-13465' # https://redhat.atlassian.net/browse/RHOAIENG-47557
+          component: 'odh-mod-arch-model-registry-v3-3'
+        - key: 'CVE-2025-13465' # https://redhat.atlassian.net/browse/RHOAIENG-47556
+          component: 'odh-mod-arch-gen-ai-v3-3'
+        - key: 'CVE-2025-13465' # https://redhat.atlassian.net/browse/RHOAIENG-47555
+          component: 'odh-dashboard-v3-3'
+        - key: 'CVE-2026-24049' # https://redhat.atlassian.net/browse/RHOAIENG-47045
+          component: 'odh-guardrails-detector-huggingface-runtime-v3-3'
+        - key: 'CVE-2026-24049' # https://redhat.atlassian.net/browse/RHOAIENG-46990
+          component: 'odh-built-in-detector-v3-3'
+        - key: 'CVE-2026-23745' # https://redhat.atlassian.net/browse/RHOAIENG-46377
+          component: 'odh-dashboard-v3-3'
+        - key: 'CVE-2025-59057' # https://redhat.atlassian.net/browse/RHOAIENG-45130
+          component: 'odh-mod-arch-model-registry-v3-3'
+        - key: 'CVE-2025-59057' # https://redhat.atlassian.net/browse/RHOAIENG-45129
+          component: 'odh-mod-arch-gen-ai-v3-3'
+        - key: 'CVE-2025-59057' # https://redhat.atlassian.net/browse/RHOAIENG-45128
+          component: 'odh-dashboard-v3-3'
+        - key: 'CVE-2026-21884' # https://redhat.atlassian.net/browse/RHOAIENG-45124
+          component: 'odh-mod-arch-model-registry-v3-3'
+        - key: 'CVE-2026-21884' # https://redhat.atlassian.net/browse/RHOAIENG-45123
+          component: 'odh-mod-arch-gen-ai-v3-3'
+        - key: 'CVE-2026-21884' # https://redhat.atlassian.net/browse/RHOAIENG-45122
+          component: 'odh-dashboard-v3-3'
+        - key: 'CVE-2026-22029' # https://redhat.atlassian.net/browse/RHOAIENG-45104
+          component: 'odh-mod-arch-model-registry-v3-3'
+        - key: 'CVE-2026-22029' # https://redhat.atlassian.net/browse/RHOAIENG-45103
+          component: 'odh-mod-arch-gen-ai-v3-3'
+        - key: 'CVE-2026-22029' # https://redhat.atlassian.net/browse/RHOAIENG-45102
+          component: 'odh-dashboard-v3-3'
+        - key: 'CVE-2026-21441' # https://redhat.atlassian.net/browse/RHOAIENG-45076
+          component: 'odh-built-in-detector-v3-3'
+        - key: 'CVE-2026-21441' # https://redhat.atlassian.net/browse/RHOAIENG-45048
+          component: 'odh-vllm-cpu-v3-3'
+        - key: 'CVE-2026-21441' # https://redhat.atlassian.net/browse/RHOAIENG-44980
+          component: 'odh-llm-d-routing-sidecar-v3-3'
+        - key: 'CVE-2026-21441' # https://redhat.atlassian.net/browse/RHOAIENG-44968
+          component: 'odh-guardrails-detector-huggingface-runtime-v3-3'
+        - key: 'CVE-2025-61729' # https://redhat.atlassian.net/browse/RHOAIENG-44787
+          component: 'odh-llm-d-routing-sidecar-v3-3'
+        - key: 'CVE-2025-61729' # https://redhat.atlassian.net/browse/RHOAIENG-44786
+          component: 'odh-llm-d-inference-scheduler-v3-3'
+        - key: 'CVE-2025-66471' # https://redhat.atlassian.net/browse/RHOAIENG-44373
+          component: 'odh-vllm-cpu-v3-3'
+        - key: 'CVE-2025-66471' # https://redhat.atlassian.net/browse/RHOAIENG-44350
+          component: 'odh-llm-d-routing-sidecar-v3-3'
+        - key: 'CVE-2025-69223' # https://redhat.atlassian.net/browse/RHOAIENG-43657
+          component: 'odh-vllm-cpu-v3-3'
+        - key: 'CVE-2025-15284' # https://redhat.atlassian.net/browse/RHOAIENG-43343
+          component: 'odh-mod-arch-gen-ai-v3-3'
+        - key: 'CVE-2025-15284' # https://redhat.atlassian.net/browse/RHOAIENG-43306
+          component: 'odh-mod-arch-model-registry-v3-3'
+        - key: 'CVE-2025-15284' # https://redhat.atlassian.net/browse/RHOAIENG-43304
+          component: 'odh-dashboard-v3-3'
+        - key: 'CVE-2025-66418' # https://redhat.atlassian.net/browse/RHOAIENG-42120
+          component: 'odh-vllm-cpu-v3-3'
+        - key: 'CVE-2025-66418' # https://redhat.atlassian.net/browse/RHOAIENG-42098
+          component: 'odh-llm-d-routing-sidecar-v3-3'
+        - key: 'CVE-2025-12816' # https://redhat.atlassian.net/browse/RHOAIENG-41815
+          component: 'odh-mod-arch-gen-ai-v3-3'
+        - key: 'CVE-2025-12816' # https://redhat.atlassian.net/browse/RHOAIENG-41778
+          component: 'odh-mod-arch-model-registry-v3-3'
+        - key: 'CVE-2025-12816' # https://redhat.atlassian.net/browse/RHOAIENG-41776
+          component: 'odh-dashboard-v3-3'
+        - key: 'CVE-2025-66448' # https://redhat.atlassian.net/browse/RHOAIENG-41418
+          component: 'odh-vllm-cpu-v3-3'
+        - key: 'CVE-2025-6242' # https://redhat.atlassian.net/browse/RHOAIENG-41403
+          component: 'odh-vllm-cpu-v3-3'
+        - key: 'CVE-2025-66031' # https://redhat.atlassian.net/browse/RHOAIENG-41217
+          component: 'odh-mod-arch-model-registry-v3-3'
+        - key: 'CVE-2025-66031' # https://redhat.atlassian.net/browse/RHOAIENG-41216
+          component: 'odh-mod-arch-gen-ai-v3-3'
+        - key: 'CVE-2025-66031' # https://redhat.atlassian.net/browse/RHOAIENG-41215
+          component: 'odh-dashboard-v3-3'
+        - key: 'CVE-2025-64756' # https://redhat.atlassian.net/browse/RHOAIENG-41114
+          component: 'odh-dashboard-v3-3'
+        - key: 'CVE-2025-62164' # https://redhat.atlassian.net/browse/RHOAIENG-39660
+          component: 'odh-vllm-cpu-v3-3'
+      issues:
+          fixed:
+            - id: RHOAIENG-63021
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-60518
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59679
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59203
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-58983
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-53865
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-41618
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-37048
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59719
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59715
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59713
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59310
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59302
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59300
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59296
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59258
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59255
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59249
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59242
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-58615
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-58614
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-58613
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-58612
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-58610
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-58609
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-58608
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-58607
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-58603
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-58602
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-58601
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-58600
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-58599
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-58598
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-58597
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-58596
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-57814
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-57813
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-57812
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-57811
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-57655
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-57654
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-57651
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-57650
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56859
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56827
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56420
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56418
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56416
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55685
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55310
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55309
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55308
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55006
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55004
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55002
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54743
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54742
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54651
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54649
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54247
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54142
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54044
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54043
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54042
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54041
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54040
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54039
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54037
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54036
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54035
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54034
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54033
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-53355
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-53354
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-53353
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-53165
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-53164
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52524
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52412
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52410
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52402
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52400
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-49702
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-49701
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-49700
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-49476
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-49475
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-49369
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-49368
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-49367
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-48623
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-48622
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-48621
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-48615
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-48614
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-48365
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-47856
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-47666
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-47557
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-47556
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-47555
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-47045
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-46990
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-46377
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-45130
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-45129
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-45128
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-45124
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-45123
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-45122
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-45104
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-45103
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-45102
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-45076
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-45048
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-44980
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-44968
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-44787
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-44786
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-44373
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-44350
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-43657
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-43343
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-43306
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-43304
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-42120
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-42098
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-41815
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-41778
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-41776
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-41418
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-41403
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-41217
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-41216
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-41215
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-41114
+              public: True
+              source: redhat.atlassian.net
+            - id: RHOAIENG-39660
+              public: True
+              source: redhat.atlassian.net

--- a/release/3.3.3/prod/prod-release-1779281517/release-fbc/prod-release-fbc-ocp-419-rhoai-v3-3-1779281517.yaml
+++ b/release/3.3.3/prod/prod-release-1779281517/release-fbc/prod-release-fbc-ocp-419-rhoai-v3-3-1779281517.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-419-prod-1779281517
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: bcf0c204331a152d220dedec61ec73765eb6f8da
+    konflux-release-data/ocp-version: ocp-419
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: prod
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-419
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-3-ocp-419-fbc-prod
+  snapshot: rhoai-fbc-fragment-ocp-419-1779221507
+  data:
+    version: 3.3.3

--- a/release/3.3.3/prod/prod-release-1779281517/release-fbc/prod-release-fbc-ocp-420-rhoai-v3-3-1779281517.yaml
+++ b/release/3.3.3/prod/prod-release-1779281517/release-fbc/prod-release-fbc-ocp-420-rhoai-v3-3-1779281517.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-420-prod-1779281517
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: bcf0c204331a152d220dedec61ec73765eb6f8da
+    konflux-release-data/ocp-version: ocp-420
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: prod
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-420
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-3-ocp-420-fbc-prod
+  snapshot: rhoai-fbc-fragment-ocp-420-1779221507
+  data:
+    version: 3.3.3

--- a/release/3.3.3/prod/prod-release-1779281517/release-fbc/prod-release-fbc-ocp-421-rhoai-v3-3-1779281517.yaml
+++ b/release/3.3.3/prod/prod-release-1779281517/release-fbc/prod-release-fbc-ocp-421-rhoai-v3-3-1779281517.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-421-prod-1779281517
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: bcf0c204331a152d220dedec61ec73765eb6f8da
+    konflux-release-data/ocp-version: ocp-421
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: prod
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-421
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-3-ocp-421-fbc-prod
+  snapshot: rhoai-fbc-fragment-ocp-421-1779221507
+  data:
+    version: 3.3.3

--- a/release/3.3.3/stage/RC1/release-components/release-components-stage-rhoai-v3-3-1778763951.yaml
+++ b/release/3.3.3/stage/RC1/release-components/release-components-stage-rhoai-v3-3-1778763951.yaml
@@ -1,0 +1,16 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    appstudio.openshift.io/application: rhoai-v3-3
+    konflux-release-data/artifact-type: components
+    konflux-release-data/environment: stage
+    konflux-release-data/rbc-release-commit: 0f855757d9c2429f5d6201c3d6104d514eb18629
+  name: rhoai-v3-3-stage-1778763951
+  namespace: rhoai-tenant
+spec:
+  data:
+    version: 3.3.3
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-3-components-stage
+  snapshot: rhoai-v3-3-1778763951

--- a/release/3.3.3/stage/RC1/release-fbc/release-fbc-stage-ocp-419-rhoai-v3-3-1778776387.yaml
+++ b/release/3.3.3/stage/RC1/release-fbc/release-fbc-stage-ocp-419-rhoai-v3-3-1778776387.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-419-stage-1778776387
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 0f855757d9c2429f5d6201c3d6104d514eb18629
+    konflux-release-data/ocp-version: ocp-419
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-419
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-3-ocp-419-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-419-1778776387
+  data:
+    version: 3.3.3

--- a/release/3.3.3/stage/RC1/release-fbc/release-fbc-stage-ocp-420-rhoai-v3-3-1778776387.yaml
+++ b/release/3.3.3/stage/RC1/release-fbc/release-fbc-stage-ocp-420-rhoai-v3-3-1778776387.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-420-stage-1778776387
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 0f855757d9c2429f5d6201c3d6104d514eb18629
+    konflux-release-data/ocp-version: ocp-420
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-420
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-3-ocp-420-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-420-1778776387
+  data:
+    version: 3.3.3

--- a/release/3.3.3/stage/RC1/release-fbc/release-fbc-stage-ocp-421-rhoai-v3-3-1778776387.yaml
+++ b/release/3.3.3/stage/RC1/release-fbc/release-fbc-stage-ocp-421-rhoai-v3-3-1778776387.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-421-stage-1778776387
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 0f855757d9c2429f5d6201c3d6104d514eb18629
+    konflux-release-data/ocp-version: ocp-421
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-421
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-3-ocp-421-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-421-1778776387
+  data:
+    version: 3.3.3

--- a/release/3.3.3/stage/RC1/snapshot-components/snapshot-components-stage-rhoai-v3-3-1778763951.yaml
+++ b/release/3.3.3/stage/RC1/snapshot-components/snapshot-components-stage-rhoai-v3-3-1778763951.yaml
@@ -1,0 +1,510 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  labels:
+    konflux-release-data/artifact-type: components
+    konflux-release-data/rbc-release-commit: 0f855757d9c2429f5d6201c3d6104d514eb18629
+    test.appstudio.openshift.io/type: override
+  name: rhoai-v3-3-1778763951
+  namespace: rhoai-tenant
+spec:
+  application: rhoai-v3-3
+  components:
+  - containerImage: quay.io/rhoai/odh-operator-bundle@sha256:9f72c0cfb3fced1f5747354421225b9fc1dea93add7342794d69c41c066874a7
+    name: odh-operator-bundle-v3-3
+    source:
+      git:
+        revision: 0ab52d3288306f2a7142b6b66b8982e8e43dea75
+        url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+  - containerImage: quay.io/rhoai/odh-built-in-detector-rhel9@sha256:80419a1412820b42b3cc202e8d3d7a268873625f238b62fb93d019e6e9a118e9
+    name: odh-built-in-detector-v3-3
+    source:
+      git:
+        revision: 21c370b09764435d9b1000c4e2d141336563e1a6
+        url: https://github.com/red-hat-data-services/guardrails-detectors
+  - containerImage: quay.io/rhoai/odh-cli-rhel9@sha256:d36c9a68f4bc1710ecf6e8684e0091797a2b23a066494ceaaaeed34b1c7674a6
+    name: odh-cli-v3-3
+    source:
+      git:
+        revision: b9ffcf9464b96c324b95a6f9a4916ebf7c76daf4
+        url: https://github.com/red-hat-data-services/odh-cli
+  - containerImage: quay.io/rhoai/odh-dashboard-rhel9@sha256:b8c2ecc96b9d55568eac91d6accc03762ef5b45d09f35e93b24eea48ff9e08a3
+    name: odh-dashboard-v3-3
+    source:
+      git:
+        revision: 5e1107caef3f42a610f565a00987b1a5389299fe
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-data-science-pipelines-argo-argoexec-rhel9@sha256:ce13f729263f4174442f82cbc9fc4b6d0f93f4e2b382be51dc3a3bd656e2be97
+    name: odh-data-science-pipelines-argo-argoexec-v3-3
+    source:
+      git:
+        revision: bcb521f8a8f4cbcb453d045c9c162efb59184a7f
+        url: https://github.com/red-hat-data-services/argo-workflows
+  - containerImage: quay.io/rhoai/odh-data-science-pipelines-argo-workflowcontroller-rhel9@sha256:d56393b4999c9c20f6d72088d76a57fbcf986463f7f5848c757efb90533df014
+    name: odh-data-science-pipelines-argo-workflowcontroller-v3-3
+    source:
+      git:
+        revision: bcb521f8a8f4cbcb453d045c9c162efb59184a7f
+        url: https://github.com/red-hat-data-services/argo-workflows
+  - containerImage: quay.io/rhoai/odh-data-science-pipelines-operator-controller-rhel9@sha256:2ba900e8c5e129a963939b06fe43d40fb3e78007efe7aaf2bcc6f1bbe3b4ad08
+    name: odh-data-science-pipelines-operator-controller-v3-3
+    source:
+      git:
+        revision: 49e210d034fc39847c6553f7837d75a7d8f7ba5e
+        url: https://github.com/red-hat-data-services/data-science-pipelines-operator
+  - containerImage: quay.io/rhoai/odh-feast-operator-rhel9@sha256:d09fb6c8683d37f6d9f2eca05e876dd408d3616a29a9d2f9e4dcc612c856c0c5
+    name: odh-feast-operator-v3-3
+    source:
+      git:
+        revision: 63d047fcda93da7edf0aeefc73af19fb0644b092
+        url: https://github.com/red-hat-data-services/feast
+  - containerImage: quay.io/rhoai/odh-feature-server-rhel9@sha256:6d71b3f660bdcb92e63cfef813c451a339d25adca45a84a8e9f53262821f8343
+    name: odh-feature-server-v3-3
+    source:
+      git:
+        revision: 63d047fcda93da7edf0aeefc73af19fb0644b092
+        url: https://github.com/red-hat-data-services/feast
+  - containerImage: quay.io/rhoai/odh-fms-guardrails-orchestrator-rhel9@sha256:95bbc913025afb00f5062cfc8b5859ba78a655a4fa2159253ad1c3ed14ac37d9
+    name: odh-fms-guardrails-orchestrator-v3-3
+    source:
+      git:
+        revision: f54e5f3259bda2d636d0dfb25dc5a44eb7655da4
+        url: https://github.com/red-hat-data-services/fms-guardrails-orchestrator
+  - containerImage: quay.io/rhoai/odh-guardrails-detector-huggingface-runtime-rhel9@sha256:fdd97cbc59fe03d7ce3af526245ed790843c9efeb750035e2b8498fe98847452
+    name: odh-guardrails-detector-huggingface-runtime-v3-3
+    source:
+      git:
+        revision: 21c370b09764435d9b1000c4e2d141336563e1a6
+        url: https://github.com/red-hat-data-services/guardrails-detectors
+  - containerImage: quay.io/rhoai/odh-kf-notebook-controller-rhel9@sha256:b68584db374f71de5ff1253fe9929f621afa6b1a42616dc76b7b4172e0dfea7c
+    name: odh-kf-notebook-controller-v3-3
+    source:
+      git:
+        revision: 7f61fded2907f95d7611a981303c987082aee2cf
+        url: https://github.com/red-hat-data-services/kubeflow
+  - containerImage: quay.io/rhoai/odh-kserve-agent-rhel9@sha256:258d2450404223acd6ae58bad334a41634fea4c5d311c2b498492bb1ff3fdc2c
+    name: odh-kserve-agent-v3-3
+    source:
+      git:
+        revision: 1f78fb51617878d2307a04cd40d81d0ae033d192
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kserve-controller-rhel9@sha256:c637756a86f4b23fc3844677a1a20b642f72c116b8c8ee88bc70b9c5f9026ce0
+    name: odh-kserve-controller-v3-3
+    source:
+      git:
+        revision: 1f78fb51617878d2307a04cd40d81d0ae033d192
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kserve-router-rhel9@sha256:dc5a371f7041d1dbaa131613e9bf610e66aab1017e83fb5c0eb162ac1e986675
+    name: odh-kserve-router-v3-3
+    source:
+      git:
+        revision: 1f78fb51617878d2307a04cd40d81d0ae033d192
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kserve-storage-initializer-rhel9@sha256:1d2dce3a253efe6595a180466701817a9d6366bb9e0c9e6c777ff81da76c3756
+    name: odh-kserve-storage-initializer-v3-3
+    source:
+      git:
+        revision: 1f78fb51617878d2307a04cd40d81d0ae033d192
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kube-auth-proxy-rhel9@sha256:71d271b23e1d1a43b850a8ae2450bd60c4d01e8b2a463a0dbb41b53d18bf1863
+    name: odh-kube-auth-proxy-v3-3
+    source:
+      git:
+        revision: 35d29e12652c0a446939f2bb6cc36cb076176ecf
+        url: https://github.com/red-hat-data-services/kube-auth-proxy
+  - containerImage: quay.io/rhoai/odh-kube-auth-proxy-rhel9@sha256:71d271b23e1d1a43b850a8ae2450bd60c4d01e8b2a463a0dbb41b53d18bf1863
+    name: odh-kube-auth-proxy-v3-3
+    source:
+      git:
+        revision: 35d29e12652c0a446939f2bb6cc36cb076176ecf
+        url: https://github.com/red-hat-data-services/kube-auth-proxy
+  - containerImage: quay.io/rhoai/odh-kuberay-operator-controller-rhel9@sha256:c45fc232e3b1dd5680c427692d566a9b38bb73cd07e3939a627e728a4d9a5edb
+    name: odh-kuberay-operator-controller-v3-3
+    source:
+      git:
+        revision: 937aba3e2ee7abe3962db0436e4959add325e187
+        url: https://github.com/red-hat-data-services/kuberay
+  - containerImage: quay.io/rhoai/odh-llama-stack-core-rhel9@sha256:a4455fdd452796db420e1523e81dba891546eeacfbe23d790663410ca2a04ec1
+    name: odh-llama-stack-core-v3-3
+    source:
+      git:
+        revision: b605fe003ef9853652f4c19565a3d02a11ea1221
+        url: https://github.com/red-hat-data-services/ogx-distribution
+  - containerImage: quay.io/rhoai/odh-llama-stack-k8s-operator-rhel9@sha256:b2ceed273b441dca882678c10b7268f5e64fd439d136edbab4d18a5dd93d6d6f
+    name: odh-llama-stack-k8s-operator-v3-3
+    source:
+      git:
+        revision: 242850d7a5ecc60d2e4389f95294c3e463f61e22
+        url: https://github.com/red-hat-data-services/ogx-k8s-operator
+  - containerImage: quay.io/rhoai/odh-llm-d-inference-scheduler-rhel9@sha256:bff0094004b438ac21825f3e1828641c271cadb600f6495ed646e9abab0d145b
+    name: odh-llm-d-inference-scheduler-v3-3
+    source:
+      git:
+        revision: d15070aa03f6a4a43dbb04328f1a50ee18eaad48
+        url: https://github.com/red-hat-data-services/llm-d-inference-scheduler
+  - containerImage: quay.io/rhoai/odh-llm-d-routing-sidecar-rhel9@sha256:6cfc1658304d660d38dffed08bfdd628bbf0fb1a21f0c441d7ad84a61ceea931
+    name: odh-llm-d-routing-sidecar-v3-3
+    source:
+      git:
+        revision: d15070aa03f6a4a43dbb04328f1a50ee18eaad48
+        url: https://github.com/red-hat-data-services/llm-d-inference-scheduler
+  - containerImage: quay.io/rhoai/odh-maas-api-rhel9@sha256:6c3ff356b9374c0c11c1970bb7bd9b555024f09e2ec71e6e152043373ce1b67d
+    name: odh-maas-api-v3-3
+    source:
+      git:
+        revision: a6a8dd5d0cb6930e58e8db81eebcdad89b41a5d1
+        url: https://github.com/red-hat-data-services/models-as-a-service
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-api-server-v2-rhel9@sha256:063d62cc96e8064c5e4e6ba47e65540d64cc2b6a6bdf7ec6499e76fecb4c7982
+    name: odh-ml-pipelines-api-server-v2-v3-3
+    source:
+      git:
+        revision: 29b164e386d0776bc010bbcbd2358a2af1b98a9b
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-driver-rhel9@sha256:2ce0ac6dbbcce6a23f37607f778f0ba11371e11f09c21b1618a46347fbc1b9d8
+    name: odh-ml-pipelines-driver-v3-3
+    source:
+      git:
+        revision: 29b164e386d0776bc010bbcbd2358a2af1b98a9b
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-launcher-rhel9@sha256:e22467eb348ae4ebfeeaf42fda06f3f6f7361ab4d72410c7f4623bab5e2809bc
+    name: odh-ml-pipelines-launcher-v3-3
+    source:
+      git:
+        revision: 29b164e386d0776bc010bbcbd2358a2af1b98a9b
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-persistenceagent-v2-rhel9@sha256:9d73671fd4e42edab3e947bde4952c8bea4ed9ef29f14dcc9cad4918501077be
+    name: odh-ml-pipelines-persistenceagent-v2-v3-3
+    source:
+      git:
+        revision: 29b164e386d0776bc010bbcbd2358a2af1b98a9b
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-scheduledworkflow-v2-rhel9@sha256:c6f182d5b2131cb0d66c10fd1b848993bc3b8cd3330c9a71c93adea0e93596ac
+    name: odh-ml-pipelines-scheduledworkflow-v2-v3-3
+    source:
+      git:
+        revision: 29b164e386d0776bc010bbcbd2358a2af1b98a9b
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-mlflow-operator-rhel9@sha256:3987b502ddd7e202ef276d10256c757ce80490a0b5b277ff46bf383f6483a578
+    name: odh-mlflow-operator-v3-3
+    source:
+      git:
+        revision: 167e02be20b09b86b92346be69f6fc03828a7e9a
+        url: https://github.com/red-hat-data-services/mlflow-operator
+  - containerImage: quay.io/rhoai/odh-mlflow-rhel9@sha256:8187415f7365d91f30951213191db9ae4f818be7755b5015b3b3f1b6fdf5efa2
+    name: odh-mlflow-v3-3
+    source:
+      git:
+        revision: efaf5bc130ee7a1beafb8ee55d68af1537aa4797
+        url: https://github.com/red-hat-data-services/mlflow
+  - containerImage: quay.io/rhoai/odh-mlmd-grpc-server-rhel9@sha256:07bf762a8b0355f0204c8e003abf5a9ec5a288b0dedb71e21c557c8d857baaa8
+    name: odh-mlmd-grpc-server-v3-3
+    source:
+      git:
+        revision: c27238776462001309afc4efb8eb017a8eb271b0
+        url: https://github.com/red-hat-data-services/ml-metadata
+  - containerImage: quay.io/rhoai/odh-mlserver-rhel9@sha256:31448b3610d168388bf5af404fc54feb0e8a2a8bdf910acaa06b608abe7ed41a
+    name: odh-mlserver-v3-3
+    source:
+      git:
+        revision: 6de7e0c33c2d5b9809275c3f55095624e3c4e91d
+        url: https://github.com/red-hat-data-services/MLServer
+  - containerImage: quay.io/rhoai/odh-mod-arch-gen-ai-rhel9@sha256:08692d5858df641300debdba704caaab5bf0b9168c7e1db8bd44131558a04136
+    name: odh-mod-arch-gen-ai-v3-3
+    source:
+      git:
+        revision: 3025316c5d457da81c4cf494cd6753ef06f33be5
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-mod-arch-maas-rhel9@sha256:77b9f1d2deb513ec892de8402ca0f32a1cbeffe5c9b33f012a2d6a8aab01f8d7
+    name: odh-mod-arch-maas-v3-3
+    source:
+      git:
+        revision: 5e1107caef3f42a610f565a00987b1a5389299fe
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-mod-arch-model-registry-rhel9@sha256:8fdbb4338140c27a46884d6839b6bc786cba4fab9b6c2372950946db7a5e76e4
+    name: odh-mod-arch-model-registry-v3-3
+    source:
+      git:
+        revision: 5e1107caef3f42a610f565a00987b1a5389299fe
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-model-controller-rhel9@sha256:7a943ac16bba3501610c2dc3810d8983a625fd1089ee4777229964527941803f
+    name: odh-model-controller-v3-3
+    source:
+      git:
+        revision: b30219e073ec59ccef4077353a3d35a0579932d4
+        url: https://github.com/red-hat-data-services/odh-model-controller
+  - containerImage: quay.io/rhoai/odh-model-metadata-collection-rhel9@sha256:b99817b3f3dbb1c0fdbb084d67dd6c1ae5084989df14900707820fe5e31c704f
+    name: odh-model-metadata-collection-v3-3
+    source:
+      git:
+        revision: 44593072fba6eaeee50310503405925441415707
+        url: https://github.com/red-hat-data-services/model-metadata-collection
+  - containerImage: quay.io/rhoai/odh-model-performance-data-rhel9@sha256:e6d74bf267220ae2bd4f62a4ec642db50724af281f04a90db9c4bf52532dc14d
+    name: odh-model-performance-data-v3-3
+    source:
+      git:
+        revision: ebf52c5ab1da52e4cc18d654210ce839dd07d362
+        url: https://github.com/red-hat-data-services/models-perf-benchmark-data
+  - containerImage: quay.io/rhoai/odh-model-registry-job-async-upload-rhel9@sha256:fc3c3c8ab77535001c77021d4cb421144440f9beeb8baecf235cb529ef79577d
+    name: odh-model-registry-job-async-upload-v3-3
+    source:
+      git:
+        revision: 8d988edfcec3f4c7ae40c195fd1a4d1144932b81
+        url: https://github.com/red-hat-data-services/model-registry
+  - containerImage: quay.io/rhoai/odh-model-registry-operator-rhel9@sha256:1c55dc6541779a5822b0708fd5bc0bf6c04462a3620d8066ed6b0bed7136839a
+    name: odh-model-registry-operator-v3-3
+    source:
+      git:
+        revision: 7a3d212cfb4f51abf4c47f921592a1e4690335ea
+        url: https://github.com/red-hat-data-services/model-registry-operator
+  - containerImage: quay.io/rhoai/odh-model-registry-rhel9@sha256:1027a32a10f97e9049385bb3437db62077f34b9daeaff12e05cf7be5227af3eb
+    name: odh-model-registry-v3-3
+    source:
+      git:
+        revision: a7b935c317232972b59adf5ddc3cff54de6cc475
+        url: https://github.com/red-hat-data-services/model-registry
+  - containerImage: quay.io/rhoai/odh-must-gather-rhel9@sha256:cd0815e753f4eb929aefbda25044d40789cbb38e09408986fcddc45daa0082a7
+    name: odh-must-gather-v3-3
+    source:
+      git:
+        revision: a4ef16509e158a59c05ea87ece6e93f2698ff9f8
+        url: https://github.com/red-hat-data-services/must-gather
+  - containerImage: quay.io/rhoai/odh-notebook-controller-rhel9@sha256:c8936147d99e2fdbf3f2ea84c3c6fa6800400e3048a11517c9dbacec3e770dcd
+    name: odh-notebook-controller-v3-3
+    source:
+      git:
+        revision: 7f61fded2907f95d7611a981303c987082aee2cf
+        url: https://github.com/red-hat-data-services/kubeflow
+  - containerImage: quay.io/rhoai/odh-openvino-model-server-rhel9@sha256:d1277d8f47c266d4172b2078ed18ae7ccbb2f16ca7fee4ad3be3a8ba0105cff4
+    name: odh-openvino-model-server-v3-3
+    source:
+      git:
+        revision: 4851705714a58be6c87e30b9baeb911ceabbc607
+        url: https://github.com/red-hat-data-services/openvino_model_server
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-datascience-cpu-py312-rhel9@sha256:5b759aaec5c33392533269b58a40d704e447e4999f8916513e1927d31d5c249d
+    name: odh-pipeline-runtime-datascience-cpu-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-minimal-cpu-py312-rhel9@sha256:d735633d09b3a65c747e50c19e862d79f63369003f382224341f28794c643a0f
+    name: odh-pipeline-runtime-minimal-cpu-py312-v3-3
+    source:
+      git:
+        revision: 0b50975c2583f7fca29cc25b6f35dddbbf0c085d
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-pytorch-cuda-py312-rhel9@sha256:4dd0b9097749d6d24f4ae79e124a2199960ccc58e274b0e3a70fade09e979d44
+    name: odh-pipeline-runtime-pytorch-cuda-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9@sha256:f3a8f7e069f6d66ef5368cf16bc4a23ff08a9cc9246398f0051c00fc6f9cec8e
+    name: odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-3
+    source:
+      git:
+        revision: b72cfd5c0ea1d10ee17c5f12a27fcbfa6c75f223
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9@sha256:3eff6a961fdc910b51318be6c7b6199b09ff254ce02b6c804236df912fda3529
+    name: odh-pipeline-runtime-pytorch-rocm-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9@sha256:11fd4cb35218cf8c0716a655c1542052636c9ed0382d58135af5bbd2f6ecb42a
+    name: odh-pipeline-runtime-tensorflow-cuda-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9@sha256:cbd76f205d51e18772bd9998d3067174ff5c0a261aab2eef6a73100f7b254fab
+    name: odh-pipeline-runtime-tensorflow-rocm-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-rhel9-operator@sha256:7569075836cb5c00a0d619744ba91d5a2ce95d434e0376ef5f62b4880af608ac
+    name: odh-operator-v3-3
+    source:
+      git:
+        revision: 3db8a8a4fd8737e6fd35cc73a1305f53330783f6
+        url: https://github.com/red-hat-data-services/rhods-operator
+  - containerImage: quay.io/rhoai/odh-ta-lmes-driver-rhel9@sha256:592830f3e955b73aa90fb85f75722ec9a3ca8127b6411d8c522e7eebbf3bec6d
+    name: odh-ta-lmes-driver-v3-3
+    source:
+      git:
+        revision: 9c44fbca03515948a2f9aa4f4ad20244a20e5609
+        url: https://github.com/red-hat-data-services/trustyai-service-operator
+  - containerImage: quay.io/rhoai/odh-ta-lmes-job-rhel9@sha256:60c5f080975de1bb8fc6be6ee1f413da4e200ee55fc57174184fcdc7d9352ab7
+    name: odh-ta-lmes-job-v3-3
+    source:
+      git:
+        revision: 037e7af23ca843200fae6235c4bf7102a1ee320f
+        url: https://github.com/red-hat-data-services/lm-evaluation-harness
+  - containerImage: quay.io/rhoai/odh-trainer-rhel9@sha256:e7dd23f5a76404e5d6e3040e63ab6bcdc4fd1976a0e85c4d3daa89dc154dcc23
+    name: odh-trainer-v3-3
+    source:
+      git:
+        revision: 184dd31ca6dd36d37c9fe3badc0a8b1ddb64a218
+        url: https://github.com/red-hat-data-services/trainer
+  - containerImage: quay.io/rhoai/odh-training-cuda121-torch24-py311-rhel9@sha256:3ae0b3c03ef52ac4141add10e399dc8abc6ca37772042915a1521eda93947702
+    name: odh-training-cuda121-torch24-py311-v3-3
+    source:
+      git:
+        revision: d037aa566684f4a60039ff0f226d5e2134a63351
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-cuda124-torch25-py311-rhel9@sha256:8e5a5b25689c3585cec863a933ce2dc9368dd19b0e6422203ffb107b112d0a8d
+    name: odh-training-cuda124-torch25-py311-v3-3
+    source:
+      git:
+        revision: d037aa566684f4a60039ff0f226d5e2134a63351
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-cuda128-torch28-py312-rhel9@sha256:689de9349fe3dc8592a7879331aee4a17d937e6aeac33f069fa5721deb421cfa
+    name: odh-training-cuda128-torch28-py312-v3-3
+    source:
+      git:
+        revision: d037aa566684f4a60039ff0f226d5e2134a63351
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-cuda128-torch29-py312-rhel9@sha256:0867aaf389cc0cb9364ae35cdedbe9ef21d35ee325cd3108813128c412902bd7
+    name: odh-training-cuda128-torch29-py312-v3-3
+    source:
+      git:
+        revision: d037aa566684f4a60039ff0f226d5e2134a63351
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-operator-rhel9@sha256:db799863f740028708b6aedab781e142cbb378c4b435d19873f5baeac858649e
+    name: odh-training-operator-v3-3
+    source:
+      git:
+        revision: c993c276f3b5dfa73d1eaaa22c0fd1cfc85e03c4
+        url: https://github.com/red-hat-data-services/training-operator
+  - containerImage: quay.io/rhoai/odh-training-rocm62-torch24-py311-rhel9@sha256:d78958ce1128eee6282ca2894b416d0733dcbcf910942e78cbbce73a8326f97b
+    name: odh-training-rocm62-torch24-py311-v3-3
+    source:
+      git:
+        revision: d037aa566684f4a60039ff0f226d5e2134a63351
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-rocm62-torch25-py311-rhel9@sha256:a8421c2e1138247919222d4cf34c4692dcd3d17e79f58d8e40e31d1bdfb2c208
+    name: odh-training-rocm62-torch25-py311-v3-3
+    source:
+      git:
+        revision: d037aa566684f4a60039ff0f226d5e2134a63351
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-rocm64-torch28-py312-rhel9@sha256:079c5d668bd058ff9048d158834485065dfa0a037593c12435c210f7873cf642
+    name: odh-training-rocm64-torch28-py312-v3-3
+    source:
+      git:
+        revision: d037aa566684f4a60039ff0f226d5e2134a63351
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-rocm64-torch29-py312-rhel9@sha256:234e03c21a89193bc0422befa56f466e2ee648621063c2a677f9795db1450b55
+    name: odh-training-rocm64-torch29-py312-v3-3
+    source:
+      git:
+        revision: d037aa566684f4a60039ff0f226d5e2134a63351
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-trustyai-garak-lls-provider-dsp-rhel9@sha256:cfe033c776d3a0ff66d2e3a43566154f51b239b7efb4a87975ec971c5fd38d7e
+    name: odh-trustyai-garak-lls-provider-dsp-v3-3
+    source:
+      git:
+        revision: 454a69547faf0ea0b19dc8177571592ca8ba7f71
+        url: https://github.com/red-hat-data-services/llama-stack-provider-trustyai-garak
+  - containerImage: quay.io/rhoai/odh-trustyai-nemo-guardrails-server-rhel9@sha256:be29a76bdd20fe96371fa4ec23601e501b988bec9392103a6f4911f762880b78
+    name: odh-trustyai-nemo-guardrails-server-v3-3
+    source:
+      git:
+        revision: 9113afccf1c568afaf81d625b8c432722129c630
+        url: https://github.com/red-hat-data-services/NeMo-Guardrails
+  - containerImage: quay.io/rhoai/odh-trustyai-service-operator-rhel9@sha256:7057fb413e972162e0d9af02ddcbd4397da1b7d58dd0226bae44ba2af0cfba93
+    name: odh-trustyai-service-operator-v3-3
+    source:
+      git:
+        revision: 9c44fbca03515948a2f9aa4f4ad20244a20e5609
+        url: https://github.com/red-hat-data-services/trustyai-service-operator
+  - containerImage: quay.io/rhoai/odh-trustyai-service-rhel9@sha256:b8d43194390a496e4b95533292a3ab94fadb848f33c95ed22fb9038825531d7f
+    name: odh-trustyai-service-v3-3
+    source:
+      git:
+        revision: 1061070ff78bbd86518956622aa0e812e1368f17
+        url: https://github.com/red-hat-data-services/trustyai-explainability
+  - containerImage: quay.io/rhoai/odh-trustyai-vllm-orchestrator-gateway-rhel9@sha256:3698b1d53d425b1b5b9b7bd9c56c642a35cd16f69d620089cb0c1b1ac337a65a
+    name: odh-trustyai-vllm-orchestrator-gateway-v3-3
+    source:
+      git:
+        revision: d0adf9928d0c4d3d1c6643218b7eba2af9f61782
+        url: https://github.com/red-hat-data-services/vllm-orchestrator-gateway
+  - containerImage: quay.io/rhoai/odh-vllm-cpu-rhel9@sha256:ae35844b296e080849724430f054dd6e601f02566ac1c0bf12143123b874f1a4
+    name: odh-vllm-cpu-v3-3
+    source:
+      git:
+        revision: 7e7f1af5b6c67407d566dae082dd58643e7587ac
+        url: https://github.com/red-hat-data-services/vllm-cpu
+  - containerImage: quay.io/rhoai/odh-vllm-gaudi-rhel9@sha256:8987b6a78b20e8dca669b3816f7615f1b901c76efb4ea96cf61b7dcb37f2f315
+    name: odh-vllm-gaudi-v3-3
+    source:
+      git:
+        revision: 8aef930cb5de87aa86c9cb796341ce4384a5328a
+        url: https://github.com/red-hat-data-services/vllm-gaudi
+  - containerImage: quay.io/rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9@sha256:70bb8ac76b43a98e976aa357fcc0ee13ed974eb6ea17d11cc5cd9ba4700b5661
+    name: odh-workbench-codeserver-datascience-cpu-py312-v3-3
+    source:
+      git:
+        revision: 0b50975c2583f7fca29cc25b6f35dddbbf0c085d
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9@sha256:7bac6c402ae4e6376bb8f109b8bdee67cbcd323d7d487cf8caf469e625857901
+    name: odh-workbench-jupyter-datascience-cpu-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9@sha256:5ed6025cf10c3c681ca637e4437d2f8ac7aa90da940db2c9433c0926c09a6dd6
+    name: odh-workbench-jupyter-minimal-cpu-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9@sha256:1f2d8fc70730845eac14446bce7bb7e0600d128168187f7145453e62a65f6816
+    name: odh-workbench-jupyter-minimal-cuda-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9@sha256:2e88f6dcd82c71399d50f2f6aba86436090b90f6ebc22c4413f31ce0f5871422
+    name: odh-workbench-jupyter-minimal-rocm-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9@sha256:c9fa628a33164335b72ac2fcc3f80ce2ae9c64167358edf1ca2712b86fea1cb5
+    name: odh-workbench-jupyter-pytorch-cuda-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9@sha256:24ca88c5657c99afeb9245afb2d4b5d8dcc9094c6b6f6dec534d36b1fc4eaaa6
+    name: odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3
+    source:
+      git:
+        revision: b72cfd5c0ea1d10ee17c5f12a27fcbfa6c75f223
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9@sha256:1f4f4c0eae2da3c2942387bc3e146696beb8ee59d82099210289b337da7003c9
+    name: odh-workbench-jupyter-pytorch-rocm-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9@sha256:8cd14c14143f574669388a7e905426baa62caa40d51af52931aac05ce0326b0b
+    name: odh-workbench-jupyter-tensorflow-cuda-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9@sha256:0568dddd961c5ac9fb7cf2a0c30838ac9e83cfc8e4d4571edbd80b643c8f39a0
+    name: odh-workbench-jupyter-tensorflow-rocm-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9@sha256:4dc985503b1254716528a1a4574dbb26f6c97857a77c8dddda3e2c58bc0585cb
+    name: odh-workbench-jupyter-trustyai-cpu-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks

--- a/release/3.3.3/stage/RC1/snapshot-fbc/snapshot-fbc-stage-ocp-419-rhoai-v3-3-1778776387.yaml
+++ b/release/3.3.3/stage/RC1/snapshot-fbc/snapshot-fbc-stage-ocp-419-rhoai-v3-3-1778776387.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-419-1778776387
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 0f855757d9c2429f5d6201c3d6104d514eb18629
+    konflux-release-data/ocp-version: ocp-419
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-419
+  components:
+    - name: rhoai-fbc-fragment-ocp-419
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:042a88cc79c69352ce8962a9047453985fa5d42293d6f043dfac7a152cc6cf25
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: ea15393cb9095d09ebba7b833cec5697459c5878

--- a/release/3.3.3/stage/RC1/snapshot-fbc/snapshot-fbc-stage-ocp-420-rhoai-v3-3-1778776387.yaml
+++ b/release/3.3.3/stage/RC1/snapshot-fbc/snapshot-fbc-stage-ocp-420-rhoai-v3-3-1778776387.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-420-1778776387
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 0f855757d9c2429f5d6201c3d6104d514eb18629
+    konflux-release-data/ocp-version: ocp-420
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-420
+  components:
+    - name: rhoai-fbc-fragment-ocp-420
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:1ea308dd2ec8ebe06d85b7fa50e143fc4df14ee7cf1b7f27e4f7ba4dc803a1d2
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: ea15393cb9095d09ebba7b833cec5697459c5878

--- a/release/3.3.3/stage/RC1/snapshot-fbc/snapshot-fbc-stage-ocp-421-rhoai-v3-3-1778776387.yaml
+++ b/release/3.3.3/stage/RC1/snapshot-fbc/snapshot-fbc-stage-ocp-421-rhoai-v3-3-1778776387.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-421-1778776387
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 0f855757d9c2429f5d6201c3d6104d514eb18629
+    konflux-release-data/ocp-version: ocp-421
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-421
+  components:
+    - name: rhoai-fbc-fragment-ocp-421
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:777b6dd3d582dbe40db7df1087948920689b4f4661eba68b4933bfcdf3033ead
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: ea15393cb9095d09ebba7b833cec5697459c5878

--- a/release/3.3.3/stage/RC2/release-components/release-components-stage-rhoai-v3-3-1779210391.yaml
+++ b/release/3.3.3/stage/RC2/release-components/release-components-stage-rhoai-v3-3-1779210391.yaml
@@ -1,0 +1,16 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    appstudio.openshift.io/application: rhoai-v3-3
+    konflux-release-data/artifact-type: components
+    konflux-release-data/environment: stage
+    konflux-release-data/rbc-release-commit: bcf0c204331a152d220dedec61ec73765eb6f8da
+  name: rhoai-v3-3-stage-1779210391-1
+  namespace: rhoai-tenant
+spec:
+  data:
+    version: 3.3.3
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-3-components-stage
+  snapshot: rhoai-v3-3-1779210391

--- a/release/3.3.3/stage/RC2/release-fbc/release-fbc-stage-ocp-419-rhoai-v3-3-1779221507.yaml
+++ b/release/3.3.3/stage/RC2/release-fbc/release-fbc-stage-ocp-419-rhoai-v3-3-1779221507.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-419-stage-1779221507
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: bcf0c204331a152d220dedec61ec73765eb6f8da
+    konflux-release-data/ocp-version: ocp-419
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-419
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-3-ocp-419-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-419-1779221507
+  data:
+    version: 3.3.3

--- a/release/3.3.3/stage/RC2/release-fbc/release-fbc-stage-ocp-420-rhoai-v3-3-1779221507.yaml
+++ b/release/3.3.3/stage/RC2/release-fbc/release-fbc-stage-ocp-420-rhoai-v3-3-1779221507.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-420-stage-1779221507
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: bcf0c204331a152d220dedec61ec73765eb6f8da
+    konflux-release-data/ocp-version: ocp-420
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-420
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-3-ocp-420-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-420-1779221507
+  data:
+    version: 3.3.3

--- a/release/3.3.3/stage/RC2/release-fbc/release-fbc-stage-ocp-421-rhoai-v3-3-1779221507.yaml
+++ b/release/3.3.3/stage/RC2/release-fbc/release-fbc-stage-ocp-421-rhoai-v3-3-1779221507.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-421-stage-1779221507
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: bcf0c204331a152d220dedec61ec73765eb6f8da
+    konflux-release-data/ocp-version: ocp-421
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-421
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-3-ocp-421-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-421-1779221507
+  data:
+    version: 3.3.3

--- a/release/3.3.3/stage/RC2/snapshot-components/snapshot-components-stage-rhoai-v3-3-1779210391.yaml
+++ b/release/3.3.3/stage/RC2/snapshot-components/snapshot-components-stage-rhoai-v3-3-1779210391.yaml
@@ -1,0 +1,510 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  labels:
+    konflux-release-data/artifact-type: components
+    konflux-release-data/rbc-release-commit: bcf0c204331a152d220dedec61ec73765eb6f8da
+    test.appstudio.openshift.io/type: override
+  name: rhoai-v3-3-1779210391
+  namespace: rhoai-tenant
+spec:
+  application: rhoai-v3-3
+  components:
+  - containerImage: quay.io/rhoai/odh-operator-bundle@sha256:9eefecc83d41a8f5b34745f38f1fec41f8d447882440eca22850866a7429be74
+    name: odh-operator-bundle-v3-3
+    source:
+      git:
+        revision: b8e0ffbef7ad20f8fa19ed491d2a12b140e47d2f
+        url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+  - containerImage: quay.io/rhoai/odh-built-in-detector-rhel9@sha256:80419a1412820b42b3cc202e8d3d7a268873625f238b62fb93d019e6e9a118e9
+    name: odh-built-in-detector-v3-3
+    source:
+      git:
+        revision: 21c370b09764435d9b1000c4e2d141336563e1a6
+        url: https://github.com/red-hat-data-services/guardrails-detectors
+  - containerImage: quay.io/rhoai/odh-cli-rhel9@sha256:d36c9a68f4bc1710ecf6e8684e0091797a2b23a066494ceaaaeed34b1c7674a6
+    name: odh-cli-v3-3
+    source:
+      git:
+        revision: b9ffcf9464b96c324b95a6f9a4916ebf7c76daf4
+        url: https://github.com/red-hat-data-services/odh-cli
+  - containerImage: quay.io/rhoai/odh-dashboard-rhel9@sha256:cbb7496dcc3fcedfd2fa4c0faec6133d306645b7581d19a2b158631b5a0f2156
+    name: odh-dashboard-v3-3
+    source:
+      git:
+        revision: a556143be7ef376fa33c4ea4af80410b2799521d
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-data-science-pipelines-argo-argoexec-rhel9@sha256:ec66f8c3bfbaef5fcde2849c84559d68432697e0fb507af30eaed6b538ac4851
+    name: odh-data-science-pipelines-argo-argoexec-v3-3
+    source:
+      git:
+        revision: c6ca7282737fc7c95583d27348031960ec5bbe9d
+        url: https://github.com/red-hat-data-services/argo-workflows
+  - containerImage: quay.io/rhoai/odh-data-science-pipelines-argo-workflowcontroller-rhel9@sha256:d9a1fb4c37f270189cb244f31ecf4b7511a61c8e98f131fc9e8bd9e85e22145e
+    name: odh-data-science-pipelines-argo-workflowcontroller-v3-3
+    source:
+      git:
+        revision: c6ca7282737fc7c95583d27348031960ec5bbe9d
+        url: https://github.com/red-hat-data-services/argo-workflows
+  - containerImage: quay.io/rhoai/odh-data-science-pipelines-operator-controller-rhel9@sha256:2ba900e8c5e129a963939b06fe43d40fb3e78007efe7aaf2bcc6f1bbe3b4ad08
+    name: odh-data-science-pipelines-operator-controller-v3-3
+    source:
+      git:
+        revision: 49e210d034fc39847c6553f7837d75a7d8f7ba5e
+        url: https://github.com/red-hat-data-services/data-science-pipelines-operator
+  - containerImage: quay.io/rhoai/odh-feast-operator-rhel9@sha256:d09fb6c8683d37f6d9f2eca05e876dd408d3616a29a9d2f9e4dcc612c856c0c5
+    name: odh-feast-operator-v3-3
+    source:
+      git:
+        revision: 63d047fcda93da7edf0aeefc73af19fb0644b092
+        url: https://github.com/red-hat-data-services/feast
+  - containerImage: quay.io/rhoai/odh-feature-server-rhel9@sha256:6d71b3f660bdcb92e63cfef813c451a339d25adca45a84a8e9f53262821f8343
+    name: odh-feature-server-v3-3
+    source:
+      git:
+        revision: 63d047fcda93da7edf0aeefc73af19fb0644b092
+        url: https://github.com/red-hat-data-services/feast
+  - containerImage: quay.io/rhoai/odh-fms-guardrails-orchestrator-rhel9@sha256:95bbc913025afb00f5062cfc8b5859ba78a655a4fa2159253ad1c3ed14ac37d9
+    name: odh-fms-guardrails-orchestrator-v3-3
+    source:
+      git:
+        revision: f54e5f3259bda2d636d0dfb25dc5a44eb7655da4
+        url: https://github.com/red-hat-data-services/fms-guardrails-orchestrator
+  - containerImage: quay.io/rhoai/odh-guardrails-detector-huggingface-runtime-rhel9@sha256:fdd97cbc59fe03d7ce3af526245ed790843c9efeb750035e2b8498fe98847452
+    name: odh-guardrails-detector-huggingface-runtime-v3-3
+    source:
+      git:
+        revision: 21c370b09764435d9b1000c4e2d141336563e1a6
+        url: https://github.com/red-hat-data-services/guardrails-detectors
+  - containerImage: quay.io/rhoai/odh-kf-notebook-controller-rhel9@sha256:b68584db374f71de5ff1253fe9929f621afa6b1a42616dc76b7b4172e0dfea7c
+    name: odh-kf-notebook-controller-v3-3
+    source:
+      git:
+        revision: 7f61fded2907f95d7611a981303c987082aee2cf
+        url: https://github.com/red-hat-data-services/kubeflow
+  - containerImage: quay.io/rhoai/odh-kserve-agent-rhel9@sha256:258d2450404223acd6ae58bad334a41634fea4c5d311c2b498492bb1ff3fdc2c
+    name: odh-kserve-agent-v3-3
+    source:
+      git:
+        revision: 1f78fb51617878d2307a04cd40d81d0ae033d192
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kserve-controller-rhel9@sha256:c637756a86f4b23fc3844677a1a20b642f72c116b8c8ee88bc70b9c5f9026ce0
+    name: odh-kserve-controller-v3-3
+    source:
+      git:
+        revision: 1f78fb51617878d2307a04cd40d81d0ae033d192
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kserve-router-rhel9@sha256:dc5a371f7041d1dbaa131613e9bf610e66aab1017e83fb5c0eb162ac1e986675
+    name: odh-kserve-router-v3-3
+    source:
+      git:
+        revision: 1f78fb51617878d2307a04cd40d81d0ae033d192
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kserve-storage-initializer-rhel9@sha256:1d2dce3a253efe6595a180466701817a9d6366bb9e0c9e6c777ff81da76c3756
+    name: odh-kserve-storage-initializer-v3-3
+    source:
+      git:
+        revision: 1f78fb51617878d2307a04cd40d81d0ae033d192
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kube-auth-proxy-rhel9@sha256:71d271b23e1d1a43b850a8ae2450bd60c4d01e8b2a463a0dbb41b53d18bf1863
+    name: odh-kube-auth-proxy-v3-3
+    source:
+      git:
+        revision: 35d29e12652c0a446939f2bb6cc36cb076176ecf
+        url: https://github.com/red-hat-data-services/kube-auth-proxy
+  - containerImage: quay.io/rhoai/odh-kube-auth-proxy-rhel9@sha256:71d271b23e1d1a43b850a8ae2450bd60c4d01e8b2a463a0dbb41b53d18bf1863
+    name: odh-kube-auth-proxy-v3-3
+    source:
+      git:
+        revision: 35d29e12652c0a446939f2bb6cc36cb076176ecf
+        url: https://github.com/red-hat-data-services/kube-auth-proxy
+  - containerImage: quay.io/rhoai/odh-kuberay-operator-controller-rhel9@sha256:c45fc232e3b1dd5680c427692d566a9b38bb73cd07e3939a627e728a4d9a5edb
+    name: odh-kuberay-operator-controller-v3-3
+    source:
+      git:
+        revision: 937aba3e2ee7abe3962db0436e4959add325e187
+        url: https://github.com/red-hat-data-services/kuberay
+  - containerImage: quay.io/rhoai/odh-llama-stack-core-rhel9@sha256:0d8f37b5438a86f47f780e33d913b4f6257fcebf6ae6d28a8bfa9071276ceed4
+    name: odh-llama-stack-core-v3-3
+    source:
+      git:
+        revision: 9e7ac5ecdc7537913e88af246261346123423138
+        url: https://github.com/red-hat-data-services/ogx-distribution
+  - containerImage: quay.io/rhoai/odh-llama-stack-k8s-operator-rhel9@sha256:e1203155e4ad0ea991de5097e841b195db14acef75c5e32ba0a8af33ea6c50b1
+    name: odh-llama-stack-k8s-operator-v3-3
+    source:
+      git:
+        revision: 2895fd987c3bdb8686cefb3433e70c9948e9a6c0
+        url: https://github.com/red-hat-data-services/ogx-k8s-operator
+  - containerImage: quay.io/rhoai/odh-llm-d-inference-scheduler-rhel9@sha256:bff0094004b438ac21825f3e1828641c271cadb600f6495ed646e9abab0d145b
+    name: odh-llm-d-inference-scheduler-v3-3
+    source:
+      git:
+        revision: d15070aa03f6a4a43dbb04328f1a50ee18eaad48
+        url: https://github.com/red-hat-data-services/llm-d-inference-scheduler
+  - containerImage: quay.io/rhoai/odh-llm-d-routing-sidecar-rhel9@sha256:6cfc1658304d660d38dffed08bfdd628bbf0fb1a21f0c441d7ad84a61ceea931
+    name: odh-llm-d-routing-sidecar-v3-3
+    source:
+      git:
+        revision: d15070aa03f6a4a43dbb04328f1a50ee18eaad48
+        url: https://github.com/red-hat-data-services/llm-d-inference-scheduler
+  - containerImage: quay.io/rhoai/odh-maas-api-rhel9@sha256:6c3ff356b9374c0c11c1970bb7bd9b555024f09e2ec71e6e152043373ce1b67d
+    name: odh-maas-api-v3-3
+    source:
+      git:
+        revision: a6a8dd5d0cb6930e58e8db81eebcdad89b41a5d1
+        url: https://github.com/red-hat-data-services/models-as-a-service
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-api-server-v2-rhel9@sha256:063d62cc96e8064c5e4e6ba47e65540d64cc2b6a6bdf7ec6499e76fecb4c7982
+    name: odh-ml-pipelines-api-server-v2-v3-3
+    source:
+      git:
+        revision: 29b164e386d0776bc010bbcbd2358a2af1b98a9b
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-driver-rhel9@sha256:2ce0ac6dbbcce6a23f37607f778f0ba11371e11f09c21b1618a46347fbc1b9d8
+    name: odh-ml-pipelines-driver-v3-3
+    source:
+      git:
+        revision: 29b164e386d0776bc010bbcbd2358a2af1b98a9b
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-launcher-rhel9@sha256:e22467eb348ae4ebfeeaf42fda06f3f6f7361ab4d72410c7f4623bab5e2809bc
+    name: odh-ml-pipelines-launcher-v3-3
+    source:
+      git:
+        revision: 29b164e386d0776bc010bbcbd2358a2af1b98a9b
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-persistenceagent-v2-rhel9@sha256:9d73671fd4e42edab3e947bde4952c8bea4ed9ef29f14dcc9cad4918501077be
+    name: odh-ml-pipelines-persistenceagent-v2-v3-3
+    source:
+      git:
+        revision: 29b164e386d0776bc010bbcbd2358a2af1b98a9b
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-scheduledworkflow-v2-rhel9@sha256:c6f182d5b2131cb0d66c10fd1b848993bc3b8cd3330c9a71c93adea0e93596ac
+    name: odh-ml-pipelines-scheduledworkflow-v2-v3-3
+    source:
+      git:
+        revision: 29b164e386d0776bc010bbcbd2358a2af1b98a9b
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-mlflow-operator-rhel9@sha256:3987b502ddd7e202ef276d10256c757ce80490a0b5b277ff46bf383f6483a578
+    name: odh-mlflow-operator-v3-3
+    source:
+      git:
+        revision: 167e02be20b09b86b92346be69f6fc03828a7e9a
+        url: https://github.com/red-hat-data-services/mlflow-operator
+  - containerImage: quay.io/rhoai/odh-mlflow-rhel9@sha256:d22379599b74a5d94e65c608dfb7a5420f86f55197ca3cc5658aab130028e9e2
+    name: odh-mlflow-v3-3
+    source:
+      git:
+        revision: eafb63b204b904b2bbc3cbb8eb44491f17dbe0dd
+        url: https://github.com/red-hat-data-services/mlflow
+  - containerImage: quay.io/rhoai/odh-mlmd-grpc-server-rhel9@sha256:07bf762a8b0355f0204c8e003abf5a9ec5a288b0dedb71e21c557c8d857baaa8
+    name: odh-mlmd-grpc-server-v3-3
+    source:
+      git:
+        revision: c27238776462001309afc4efb8eb017a8eb271b0
+        url: https://github.com/red-hat-data-services/ml-metadata
+  - containerImage: quay.io/rhoai/odh-mlserver-rhel9@sha256:31448b3610d168388bf5af404fc54feb0e8a2a8bdf910acaa06b608abe7ed41a
+    name: odh-mlserver-v3-3
+    source:
+      git:
+        revision: 6de7e0c33c2d5b9809275c3f55095624e3c4e91d
+        url: https://github.com/red-hat-data-services/MLServer
+  - containerImage: quay.io/rhoai/odh-mod-arch-gen-ai-rhel9@sha256:08692d5858df641300debdba704caaab5bf0b9168c7e1db8bd44131558a04136
+    name: odh-mod-arch-gen-ai-v3-3
+    source:
+      git:
+        revision: 3025316c5d457da81c4cf494cd6753ef06f33be5
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-mod-arch-maas-rhel9@sha256:149fbfe4e655afa48cd3415a56d342a8d547872c93822efc6902d5714def3e57
+    name: odh-mod-arch-maas-v3-3
+    source:
+      git:
+        revision: a556143be7ef376fa33c4ea4af80410b2799521d
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-mod-arch-model-registry-rhel9@sha256:8fdbb4338140c27a46884d6839b6bc786cba4fab9b6c2372950946db7a5e76e4
+    name: odh-mod-arch-model-registry-v3-3
+    source:
+      git:
+        revision: 5e1107caef3f42a610f565a00987b1a5389299fe
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-model-controller-rhel9@sha256:7a943ac16bba3501610c2dc3810d8983a625fd1089ee4777229964527941803f
+    name: odh-model-controller-v3-3
+    source:
+      git:
+        revision: b30219e073ec59ccef4077353a3d35a0579932d4
+        url: https://github.com/red-hat-data-services/odh-model-controller
+  - containerImage: quay.io/rhoai/odh-model-metadata-collection-rhel9@sha256:b99817b3f3dbb1c0fdbb084d67dd6c1ae5084989df14900707820fe5e31c704f
+    name: odh-model-metadata-collection-v3-3
+    source:
+      git:
+        revision: 44593072fba6eaeee50310503405925441415707
+        url: https://github.com/red-hat-data-services/model-metadata-collection
+  - containerImage: quay.io/rhoai/odh-model-performance-data-rhel9@sha256:e6d74bf267220ae2bd4f62a4ec642db50724af281f04a90db9c4bf52532dc14d
+    name: odh-model-performance-data-v3-3
+    source:
+      git:
+        revision: ebf52c5ab1da52e4cc18d654210ce839dd07d362
+        url: https://github.com/red-hat-data-services/models-perf-benchmark-data
+  - containerImage: quay.io/rhoai/odh-model-registry-job-async-upload-rhel9@sha256:fc3c3c8ab77535001c77021d4cb421144440f9beeb8baecf235cb529ef79577d
+    name: odh-model-registry-job-async-upload-v3-3
+    source:
+      git:
+        revision: 8d988edfcec3f4c7ae40c195fd1a4d1144932b81
+        url: https://github.com/red-hat-data-services/model-registry
+  - containerImage: quay.io/rhoai/odh-model-registry-operator-rhel9@sha256:1c55dc6541779a5822b0708fd5bc0bf6c04462a3620d8066ed6b0bed7136839a
+    name: odh-model-registry-operator-v3-3
+    source:
+      git:
+        revision: 7a3d212cfb4f51abf4c47f921592a1e4690335ea
+        url: https://github.com/red-hat-data-services/model-registry-operator
+  - containerImage: quay.io/rhoai/odh-model-registry-rhel9@sha256:1027a32a10f97e9049385bb3437db62077f34b9daeaff12e05cf7be5227af3eb
+    name: odh-model-registry-v3-3
+    source:
+      git:
+        revision: a7b935c317232972b59adf5ddc3cff54de6cc475
+        url: https://github.com/red-hat-data-services/model-registry
+  - containerImage: quay.io/rhoai/odh-must-gather-rhel9@sha256:cd0815e753f4eb929aefbda25044d40789cbb38e09408986fcddc45daa0082a7
+    name: odh-must-gather-v3-3
+    source:
+      git:
+        revision: a4ef16509e158a59c05ea87ece6e93f2698ff9f8
+        url: https://github.com/red-hat-data-services/must-gather
+  - containerImage: quay.io/rhoai/odh-notebook-controller-rhel9@sha256:c8936147d99e2fdbf3f2ea84c3c6fa6800400e3048a11517c9dbacec3e770dcd
+    name: odh-notebook-controller-v3-3
+    source:
+      git:
+        revision: 7f61fded2907f95d7611a981303c987082aee2cf
+        url: https://github.com/red-hat-data-services/kubeflow
+  - containerImage: quay.io/rhoai/odh-openvino-model-server-rhel9@sha256:d1277d8f47c266d4172b2078ed18ae7ccbb2f16ca7fee4ad3be3a8ba0105cff4
+    name: odh-openvino-model-server-v3-3
+    source:
+      git:
+        revision: 4851705714a58be6c87e30b9baeb911ceabbc607
+        url: https://github.com/red-hat-data-services/openvino_model_server
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-datascience-cpu-py312-rhel9@sha256:5b759aaec5c33392533269b58a40d704e447e4999f8916513e1927d31d5c249d
+    name: odh-pipeline-runtime-datascience-cpu-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-minimal-cpu-py312-rhel9@sha256:92cdbe04e77886960cf6544d75d4e370d304d0ddcc4aa7d7482779f35392e8ba
+    name: odh-pipeline-runtime-minimal-cpu-py312-v3-3
+    source:
+      git:
+        revision: 0b50975c2583f7fca29cc25b6f35dddbbf0c085d
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-pytorch-cuda-py312-rhel9@sha256:4dd0b9097749d6d24f4ae79e124a2199960ccc58e274b0e3a70fade09e979d44
+    name: odh-pipeline-runtime-pytorch-cuda-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9@sha256:f3a8f7e069f6d66ef5368cf16bc4a23ff08a9cc9246398f0051c00fc6f9cec8e
+    name: odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-3
+    source:
+      git:
+        revision: b72cfd5c0ea1d10ee17c5f12a27fcbfa6c75f223
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9@sha256:3eff6a961fdc910b51318be6c7b6199b09ff254ce02b6c804236df912fda3529
+    name: odh-pipeline-runtime-pytorch-rocm-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9@sha256:11fd4cb35218cf8c0716a655c1542052636c9ed0382d58135af5bbd2f6ecb42a
+    name: odh-pipeline-runtime-tensorflow-cuda-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9@sha256:cbd76f205d51e18772bd9998d3067174ff5c0a261aab2eef6a73100f7b254fab
+    name: odh-pipeline-runtime-tensorflow-rocm-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-rhel9-operator@sha256:8fbe06f6234c82a82d9de6eeaed08c18d6da74e8abef3b7124a3ccec294c8ce6
+    name: odh-operator-v3-3
+    source:
+      git:
+        revision: d39c3b8cc730bda1b28f861cfdc5e5f7dc5ddf92
+        url: https://github.com/red-hat-data-services/rhods-operator
+  - containerImage: quay.io/rhoai/odh-ta-lmes-driver-rhel9@sha256:592830f3e955b73aa90fb85f75722ec9a3ca8127b6411d8c522e7eebbf3bec6d
+    name: odh-ta-lmes-driver-v3-3
+    source:
+      git:
+        revision: 9c44fbca03515948a2f9aa4f4ad20244a20e5609
+        url: https://github.com/red-hat-data-services/trustyai-service-operator
+  - containerImage: quay.io/rhoai/odh-ta-lmes-job-rhel9@sha256:60c5f080975de1bb8fc6be6ee1f413da4e200ee55fc57174184fcdc7d9352ab7
+    name: odh-ta-lmes-job-v3-3
+    source:
+      git:
+        revision: 037e7af23ca843200fae6235c4bf7102a1ee320f
+        url: https://github.com/red-hat-data-services/lm-evaluation-harness
+  - containerImage: quay.io/rhoai/odh-trainer-rhel9@sha256:e7dd23f5a76404e5d6e3040e63ab6bcdc4fd1976a0e85c4d3daa89dc154dcc23
+    name: odh-trainer-v3-3
+    source:
+      git:
+        revision: 184dd31ca6dd36d37c9fe3badc0a8b1ddb64a218
+        url: https://github.com/red-hat-data-services/trainer
+  - containerImage: quay.io/rhoai/odh-training-cuda121-torch24-py311-rhel9@sha256:3ae0b3c03ef52ac4141add10e399dc8abc6ca37772042915a1521eda93947702
+    name: odh-training-cuda121-torch24-py311-v3-3
+    source:
+      git:
+        revision: d037aa566684f4a60039ff0f226d5e2134a63351
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-cuda124-torch25-py311-rhel9@sha256:8e5a5b25689c3585cec863a933ce2dc9368dd19b0e6422203ffb107b112d0a8d
+    name: odh-training-cuda124-torch25-py311-v3-3
+    source:
+      git:
+        revision: d037aa566684f4a60039ff0f226d5e2134a63351
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-cuda128-torch28-py312-rhel9@sha256:689de9349fe3dc8592a7879331aee4a17d937e6aeac33f069fa5721deb421cfa
+    name: odh-training-cuda128-torch28-py312-v3-3
+    source:
+      git:
+        revision: d037aa566684f4a60039ff0f226d5e2134a63351
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-cuda128-torch29-py312-rhel9@sha256:5dabe70cb1df8c243a5967abab52b77137bea1c186c737f851ba1442b72cfae0
+    name: odh-training-cuda128-torch29-py312-v3-3
+    source:
+      git:
+        revision: 7fcaf5814ea62d298dd31e688376e4205dc7fddd
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-operator-rhel9@sha256:db799863f740028708b6aedab781e142cbb378c4b435d19873f5baeac858649e
+    name: odh-training-operator-v3-3
+    source:
+      git:
+        revision: c993c276f3b5dfa73d1eaaa22c0fd1cfc85e03c4
+        url: https://github.com/red-hat-data-services/training-operator
+  - containerImage: quay.io/rhoai/odh-training-rocm62-torch24-py311-rhel9@sha256:d78958ce1128eee6282ca2894b416d0733dcbcf910942e78cbbce73a8326f97b
+    name: odh-training-rocm62-torch24-py311-v3-3
+    source:
+      git:
+        revision: d037aa566684f4a60039ff0f226d5e2134a63351
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-rocm62-torch25-py311-rhel9@sha256:a8421c2e1138247919222d4cf34c4692dcd3d17e79f58d8e40e31d1bdfb2c208
+    name: odh-training-rocm62-torch25-py311-v3-3
+    source:
+      git:
+        revision: d037aa566684f4a60039ff0f226d5e2134a63351
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-rocm64-torch28-py312-rhel9@sha256:079c5d668bd058ff9048d158834485065dfa0a037593c12435c210f7873cf642
+    name: odh-training-rocm64-torch28-py312-v3-3
+    source:
+      git:
+        revision: d037aa566684f4a60039ff0f226d5e2134a63351
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-rocm64-torch29-py312-rhel9@sha256:234e03c21a89193bc0422befa56f466e2ee648621063c2a677f9795db1450b55
+    name: odh-training-rocm64-torch29-py312-v3-3
+    source:
+      git:
+        revision: d037aa566684f4a60039ff0f226d5e2134a63351
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-trustyai-garak-lls-provider-dsp-rhel9@sha256:cfe033c776d3a0ff66d2e3a43566154f51b239b7efb4a87975ec971c5fd38d7e
+    name: odh-trustyai-garak-lls-provider-dsp-v3-3
+    source:
+      git:
+        revision: 454a69547faf0ea0b19dc8177571592ca8ba7f71
+        url: https://github.com/red-hat-data-services/llama-stack-provider-trustyai-garak
+  - containerImage: quay.io/rhoai/odh-trustyai-nemo-guardrails-server-rhel9@sha256:be29a76bdd20fe96371fa4ec23601e501b988bec9392103a6f4911f762880b78
+    name: odh-trustyai-nemo-guardrails-server-v3-3
+    source:
+      git:
+        revision: 9113afccf1c568afaf81d625b8c432722129c630
+        url: https://github.com/red-hat-data-services/NeMo-Guardrails
+  - containerImage: quay.io/rhoai/odh-trustyai-service-operator-rhel9@sha256:7057fb413e972162e0d9af02ddcbd4397da1b7d58dd0226bae44ba2af0cfba93
+    name: odh-trustyai-service-operator-v3-3
+    source:
+      git:
+        revision: 9c44fbca03515948a2f9aa4f4ad20244a20e5609
+        url: https://github.com/red-hat-data-services/trustyai-service-operator
+  - containerImage: quay.io/rhoai/odh-trustyai-service-rhel9@sha256:b8d43194390a496e4b95533292a3ab94fadb848f33c95ed22fb9038825531d7f
+    name: odh-trustyai-service-v3-3
+    source:
+      git:
+        revision: 1061070ff78bbd86518956622aa0e812e1368f17
+        url: https://github.com/red-hat-data-services/trustyai-explainability
+  - containerImage: quay.io/rhoai/odh-trustyai-vllm-orchestrator-gateway-rhel9@sha256:3698b1d53d425b1b5b9b7bd9c56c642a35cd16f69d620089cb0c1b1ac337a65a
+    name: odh-trustyai-vllm-orchestrator-gateway-v3-3
+    source:
+      git:
+        revision: d0adf9928d0c4d3d1c6643218b7eba2af9f61782
+        url: https://github.com/red-hat-data-services/vllm-orchestrator-gateway
+  - containerImage: quay.io/rhoai/odh-vllm-cpu-rhel9@sha256:ae35844b296e080849724430f054dd6e601f02566ac1c0bf12143123b874f1a4
+    name: odh-vllm-cpu-v3-3
+    source:
+      git:
+        revision: 7e7f1af5b6c67407d566dae082dd58643e7587ac
+        url: https://github.com/red-hat-data-services/vllm-cpu
+  - containerImage: quay.io/rhoai/odh-vllm-gaudi-rhel9@sha256:8987b6a78b20e8dca669b3816f7615f1b901c76efb4ea96cf61b7dcb37f2f315
+    name: odh-vllm-gaudi-v3-3
+    source:
+      git:
+        revision: 8aef930cb5de87aa86c9cb796341ce4384a5328a
+        url: https://github.com/red-hat-data-services/vllm-gaudi
+  - containerImage: quay.io/rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9@sha256:3a5a9ffd7b100d9d64eced15052e65c7287e3a1f461a03a5fbf2217097682cd5
+    name: odh-workbench-codeserver-datascience-cpu-py312-v3-3
+    source:
+      git:
+        revision: 0b50975c2583f7fca29cc25b6f35dddbbf0c085d
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9@sha256:7bac6c402ae4e6376bb8f109b8bdee67cbcd323d7d487cf8caf469e625857901
+    name: odh-workbench-jupyter-datascience-cpu-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9@sha256:5ed6025cf10c3c681ca637e4437d2f8ac7aa90da940db2c9433c0926c09a6dd6
+    name: odh-workbench-jupyter-minimal-cpu-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9@sha256:1f2d8fc70730845eac14446bce7bb7e0600d128168187f7145453e62a65f6816
+    name: odh-workbench-jupyter-minimal-cuda-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9@sha256:2e88f6dcd82c71399d50f2f6aba86436090b90f6ebc22c4413f31ce0f5871422
+    name: odh-workbench-jupyter-minimal-rocm-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9@sha256:c9fa628a33164335b72ac2fcc3f80ce2ae9c64167358edf1ca2712b86fea1cb5
+    name: odh-workbench-jupyter-pytorch-cuda-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9@sha256:24ca88c5657c99afeb9245afb2d4b5d8dcc9094c6b6f6dec534d36b1fc4eaaa6
+    name: odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3
+    source:
+      git:
+        revision: b72cfd5c0ea1d10ee17c5f12a27fcbfa6c75f223
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9@sha256:1f4f4c0eae2da3c2942387bc3e146696beb8ee59d82099210289b337da7003c9
+    name: odh-workbench-jupyter-pytorch-rocm-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9@sha256:8cd14c14143f574669388a7e905426baa62caa40d51af52931aac05ce0326b0b
+    name: odh-workbench-jupyter-tensorflow-cuda-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9@sha256:0568dddd961c5ac9fb7cf2a0c30838ac9e83cfc8e4d4571edbd80b643c8f39a0
+    name: odh-workbench-jupyter-tensorflow-rocm-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9@sha256:4dc985503b1254716528a1a4574dbb26f6c97857a77c8dddda3e2c58bc0585cb
+    name: odh-workbench-jupyter-trustyai-cpu-py312-v3-3
+    source:
+      git:
+        revision: 330292b9bc5843fcd1ee30f5e635040d893e470a
+        url: https://github.com/red-hat-data-services/notebooks

--- a/release/3.3.3/stage/RC2/snapshot-fbc/snapshot-fbc-stage-ocp-419-rhoai-v3-3-1779221507.yaml
+++ b/release/3.3.3/stage/RC2/snapshot-fbc/snapshot-fbc-stage-ocp-419-rhoai-v3-3-1779221507.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-419-1779221507
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: bcf0c204331a152d220dedec61ec73765eb6f8da
+    konflux-release-data/ocp-version: ocp-419
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-419
+  components:
+    - name: rhoai-fbc-fragment-ocp-419
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:4c8af161009921f341682a5fdfdf05e30cfc84714f692c4a309cad7bb9c5f63d
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: fcaeb6251de571e1a1feca35f6092ae23711f54a

--- a/release/3.3.3/stage/RC2/snapshot-fbc/snapshot-fbc-stage-ocp-420-rhoai-v3-3-1779221507.yaml
+++ b/release/3.3.3/stage/RC2/snapshot-fbc/snapshot-fbc-stage-ocp-420-rhoai-v3-3-1779221507.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-420-1779221507
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: bcf0c204331a152d220dedec61ec73765eb6f8da
+    konflux-release-data/ocp-version: ocp-420
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-420
+  components:
+    - name: rhoai-fbc-fragment-ocp-420
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:2e7964a48e7f78b5dfd6e8cb3052f0f76b2a6c9c8efb562f2677d6ff495a97de
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: fcaeb6251de571e1a1feca35f6092ae23711f54a

--- a/release/3.3.3/stage/RC2/snapshot-fbc/snapshot-fbc-stage-ocp-421-rhoai-v3-3-1779221507.yaml
+++ b/release/3.3.3/stage/RC2/snapshot-fbc/snapshot-fbc-stage-ocp-421-rhoai-v3-3-1779221507.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-421-1779221507
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: bcf0c204331a152d220dedec61ec73765eb6f8da
+    konflux-release-data/ocp-version: ocp-421
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-421
+  components:
+    - name: rhoai-fbc-fragment-ocp-421
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:424065bcddf8a47a7e064f9803dd13326c39830b6f2614e67b360dc441133d7c
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: fcaeb6251de571e1a1feca35f6092ae23711f54a


### PR DESCRIPTION
## Summary
- Add prod release artifacts for RHOAI 3.3.3 (components + FBC for OCP 4.19/4.20/4.21)
- Add stage RC1 release artifacts (components + FBC)
- Add stage RC2 release artifacts (components + FBC)

## Artifact Sources
- **Prod**: `rhods-devops-infra/tools/rhoai-release-helper/prod-release-1779281517`
- **Stage RC1 Components**: [GH Actions #25861465969](https://github.com/red-hat-data-services/rhods-devops-infra/actions/runs/25861465969)
- **Stage RC1 FBC**: [GH Actions #25864922808](https://github.com/red-hat-data-services/rhods-devops-infra/actions/runs/25864922808)
- **Stage RC2 Components**: [GH Actions #26112631626](https://github.com/red-hat-data-services/rhods-devops-infra/actions/runs/26112631626)
- **Stage RC2 FBC**: [GH Actions #26116697843](https://github.com/red-hat-data-services/rhods-devops-infra/actions/runs/26116697843)