### PR TITLE
Add odh-agents-operator to bundle-patch.yaml and build-config

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -191,6 +191,8 @@ ARG ODH_OGX_CORE_GIT_URL=
 ARG ODH_OGX_CORE_GIT_COMMIT=
 ARG ODH_OGX_K8S_OPERATOR_GIT_URL=
 ARG ODH_OGX_K8S_OPERATOR_GIT_COMMIT=
+ARG ODH_AGENTS_OPERATOR_GIT_URL=
+ARG ODH_AGENTS_OPERATOR_GIT_COMMIT=
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -396,7 +398,9 @@ LABEL \
       odh-ogx-core.git.url="${ODH_OGX_CORE_GIT_URL}" \
       odh-ogx-core.git.commit="${ODH_OGX_CORE_GIT_COMMIT}" \
       odh-ogx-k8s-operator.git.url="${ODH_OGX_K8S_OPERATOR_GIT_URL}" \
-      odh-ogx-k8s-operator.git.commit="${ODH_OGX_K8S_OPERATOR_GIT_COMMIT}"
+      odh-ogx-k8s-operator.git.commit="${ODH_OGX_K8S_OPERATOR_GIT_COMMIT}" \
+      odh-agents-operator.git.url="${ODH_AGENTS_OPERATOR_GIT_URL}" \
+      odh-agents-operator.git.commit="${ODH_AGENTS_OPERATOR_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -219,6 +219,8 @@ patch:
       value: quay.io/rhoai/odh-ogx-core-rhel9@sha256:74d2497940617875aaa29a084454b6f9089e64675fd8db7e0ab60def960a7617
     - name: RELATED_IMAGE_ODH_OGX_K8S_OPERATOR_IMAGE
       value: quay.io/rhoai/odh-ogx-k8s-operator-rhel9@sha256:83a1e268edddc1095e0f9f574a0f46eff1462e96511acc5d8e5696cad0fffdf4
+    - name: RELATED_IMAGE_ODH_AGENTS_OPERATOR_IMAGE
+      value: quay.io/rhoai/odh-agents-operator-rhel9@sha256:2a950baa216a8a1c9239d862f5ff2cc11df76d305870c2c8b5eb1d31304a511e
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -111,6 +111,7 @@ config:
         rhoai/odh-kserve-localmodelnode-agent-rhel9: rhoai/odh-kserve-localmodelnode-agent-rhel9
         rhoai/odh-ogx-core-rhel9: rhoai/odh-ogx-core-rhel9
         rhoai/odh-ogx-k8s-operator-rhel9: rhoai/odh-ogx-k8s-operator-rhel9
+        rhoai/odh-agents-operator-rhel9: rhoai/odh-agents-operator-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds build-config integration for component 'odh-agents-operator'.

## Files changed
- `bundle/bundle-patch.yaml` — added `RELATED_IMAGE_ODH_AGENTS_OPERATOR_IMAGE` to `patch.relatedImages`
- `config/build-config.yaml` — added `rhoai/odh-agents-operator-rhel9` to `config.replacements[0].repo_mappings`
- `bundle/Dockerfile` — added ARG and git label entries for odh-agents-operator

> **NOTE:** The SHA256 digest for `RELATED_IMAGE_ODH_AGENTS_OPERATOR_IMAGE` is a **placeholder** — the image has not yet been built by Konflux. Before merging this PR, replace the digest with the real value.

**Jira:** https://redhat.atlassian.net/browse/RHOAIENG-63609