### PR TITLE
RHOAI z-stream: 3.4.1 → 3.4.2

### DIFF
--- a/.tekton/odh-operator-bundle-v3-4-push.yaml
+++ b/.tekton/odh-operator-bundle-v3-4-push.yaml
@@ -33,7 +33,7 @@ spec:
   - name: output-image
     value: quay.io/rhoai/odh-operator-bundle:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.1"
+    value: "3.4.2"
   - name: dockerfile
     value: bundle/Dockerfile
   - name: path-context

--- a/.tekton/odh-operator-bundle-v3-4-scheduled.yaml
+++ b/.tekton/odh-operator-bundle-v3-4-scheduled.yaml
@@ -31,7 +31,7 @@ spec:
   - name: output-image
     value: quay.io/rhoai/odh-operator-bundle:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.1"
+    value: "3.4.2"
   - name: dockerfile
     value: bundle/Dockerfile
   - name: path-context

--- a/.tekton/rhai-on-openshift-chart-v3-4-push.yaml
+++ b/.tekton/rhai-on-openshift-chart-v3-4-push.yaml
@@ -29,7 +29,7 @@ spec:
   - name: output-image
     value: quay.io/rhoai/rhai-on-openshift-chart:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.1"
+    value: "3.4.2"
   - name: path-context
     value: "helm/rhai-on-openshift-chart"
   - name: hermetic

--- a/.tekton/rhai-on-openshift-chart-v3-4-scheduled.yaml
+++ b/.tekton/rhai-on-openshift-chart-v3-4-scheduled.yaml
@@ -30,7 +30,7 @@ spec:
   - name: output-image
     value: quay.io/rhoai/rhai-on-openshift-chart:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.1"
+    value: "3.4.2"
   - name: path-context
     value: "helm/rhai-on-openshift-chart"
   - name: hermetic

--- a/.tekton/rhai-on-xks-chart-v3-4-push.yaml
+++ b/.tekton/rhai-on-xks-chart-v3-4-push.yaml
@@ -29,7 +29,7 @@ spec:
   - name: output-image
     value: quay.io/rhoai/rhai-on-xks-chart:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.1"
+    value: "3.4.2"
   - name: path-context
     value: "helm/rhai-on-xks-chart"
   - name: hermetic

--- a/.tekton/rhai-on-xks-chart-v3-4-scheduled.yaml
+++ b/.tekton/rhai-on-xks-chart-v3-4-scheduled.yaml
@@ -30,7 +30,7 @@ spec:
   - name: output-image
     value: quay.io/rhoai/rhai-on-xks-chart:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.1"
+    value: "3.4.2"
   - name: path-context
     value: "helm/rhai-on-xks-chart"
   - name: hermetic

--- a/.tekton/rhoai-fbc-fragment-v3-4-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-v3-4-push.yaml
@@ -35,7 +35,7 @@ spec:
   - name: output-image
     value: quay.io/rhoai/rhoai-fbc-fragment:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.1"
+    value: "3.4.2"
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/.tekton/rhoai-fbc-fragment-v3-4-scheduled.yaml
+++ b/.tekton/rhoai-fbc-fragment-v3-4-scheduled.yaml
@@ -33,7 +33,7 @@ spec:
   - name: output-image
     value: quay.io/rhoai/rhoai-fbc-fragment:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.1"
+    value: "3.4.2"
   - name: build-platforms
     value:
     - linux/x86_64

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -1,5 +1,5 @@
 patch:
-  version: 3.4.1
+  version: 3.4.2
   relatedImages:
     - name: RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE
       value: "quay.io/rhoai/odh-kf-notebook-controller-rhel9@sha256:8fdab8122b0433dfa1045f22074c891d2b84fd21a073f406d12d5bcbe9b9b805"

--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -7,16 +7,16 @@ patch:
       package: rhods-operator
       schema: olm.channel
       entries:
-        - name: rhods-operator.3.4.1
-          replaces: rhods-operator.3.4.0
-          skipRange: '>=3.3.0 <3.4.1'
+        - name: rhods-operator.3.4.2
+          replaces: rhods-operator.3.4.1
+          skipRange: '>=3.3.0 <3.4.2'
     - name: stable-3.x
       package: rhods-operator
       schema: olm.channel
       entries:
-        - name: rhods-operator.3.4.1
-          replaces: rhods-operator.3.4.0
-          skipRange: '>=3.3.0 <3.4.1'
+        - name: rhods-operator.3.4.2
+          replaces: rhods-operator.3.4.1
+          skipRange: '>=3.3.0 <3.4.2'
 
   olm.bundle:
     - quay.io/rhoai/odh-operator-bundle@sha256:bfcfc38203eff8ce87331416bae8addb5ebedabe51ef949844624cf3e615bb14

--- a/config/trustyai-pig-build-config.yaml
+++ b/config/trustyai-pig-build-config.yaml
@@ -1,4 +1,4 @@
-#!productVersion=3.4.0
+#!productVersion=3.4.2
 #!scmRevision=rhoai-3.4
 
 


### PR DESCRIPTION
**Z-stream release** (`rbc_zstream_release`): `3.4.1` → `3.4.2` on branch `rhoai-3.4`.

- `config/trustyai-pig-build-config.yaml` — productVersion (when latest)
- `bundle/bundle-patch.yaml` — patch version
- `catalog/catalog-patch.yaml` — OLM channel entries
- `.tekton/` — rhoai-version parameters
