### PR TITLE
RHOAI z-stream: 3.4.0-ea.1 → 3.4.1-ea.1

### DIFF
--- a/.tekton/odh-operator-bundle-v3-4-ea-1-push.yaml
+++ b/.tekton/odh-operator-bundle-v3-4-ea-1-push.yaml
@@ -32,7 +32,7 @@ spec:
   - name: output-image
     value: quay.io/rhoai/odh-operator-bundle:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.0-ea.1"
+    value: "3.4.1-ea.1"
   - name: dockerfile
     value: bundle/Dockerfile
   - name: path-context

--- a/.tekton/odh-operator-bundle-v3-4-ea-1-scheduled.yaml
+++ b/.tekton/odh-operator-bundle-v3-4-ea-1-scheduled.yaml
@@ -31,7 +31,7 @@ spec:
   - name: output-image
     value: quay.io/rhoai/odh-operator-bundle:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.0-ea.1"
+    value: "3.4.1-ea.1"
   - name: build-platforms
     value:
     - linux/x86_64

--- a/.tekton/rhoai-fbc-fragment-v3-4-ea-1-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-v3-4-ea-1-push.yaml
@@ -35,7 +35,7 @@ spec:
   - name: output-image
     value: quay.io/rhoai/rhoai-fbc-fragment:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.0-ea.1"
+    value: "3.4.1-ea.1"
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/.tekton/rhoai-fbc-fragment-v3-4-ea-1-scheduled.yaml
+++ b/.tekton/rhoai-fbc-fragment-v3-4-ea-1-scheduled.yaml
@@ -34,7 +34,7 @@ spec:
   - name: output-image
     value: quay.io/rhoai/rhoai-fbc-fragment:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.0-ea.1"
+    value: "3.4.1-ea.1"
   - name: build-platforms
     value:
     - linux/x86_64

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -1,5 +1,5 @@
 patch:
-  version: 3.4.0-ea.1
+  version: 3.4.1-ea.1
   relatedImages:
     - name: RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE
       value: "quay.io/rhoai/odh-kf-notebook-controller-rhel9@sha256:8fdab8122b0433dfa1045f22074c891d2b84fd21a073f406d12d5bcbe9b9b805"

--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -7,8 +7,8 @@ patch:
       package: rhods-operator
       schema: olm.channel
       entries:
-      - name: rhods-operator.3.4.0-ea.1
-        skipRange: '>=3.3.0 <3.4.0'
+      - name: rhods-operator.3.4.1-ea.1
+        skipRange: '>=3.3.0 <3.4.1'
   
   olm.bundle:
     - quay.io/rhoai/odh-operator-bundle@sha256:d469aa393ef263ee1bfc560e5d7f7331208f5cdc16f5ce6a772742c74ac3fc8b

--- a/config/trustyai-pig-build-config.yaml
+++ b/config/trustyai-pig-build-config.yaml
@@ -1,4 +1,4 @@
-#!productVersion=3.4.0-ea.1
+#!productVersion=3.4.1-ea.1
 #!scmRevision=rhoai-3.4-ea.1
 
 


### PR DESCRIPTION
**Z-stream release** (`rbc_zstream_release`): `3.4.0-ea.1` → `3.4.1-ea.1` on branch `rhoai-3.4-ea.1`.

- `config/trustyai-pig-build-config.yaml` — productVersion (when latest)
- `bundle/bundle-patch.yaml` — patch version
- `catalog/catalog-patch.yaml` — OLM channel entries
- `.tekton/` — rhoai-version parameters
