### PR TITLE
RHOAI main z-stream: 3.3.3 → 3.3.4

### DIFF
--- a/.tekton/rhoai-fbc-fragment-rhoai-33-ocp-419-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-33-ocp-419-push.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "3.3.3"
+    value: "3.3.4"
   - name: ocp-version
     value: "4.19"
   - name: fbc-pipeline-branch

--- a/.tekton/rhoai-fbc-fragment-rhoai-33-ocp-420-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-33-ocp-420-push.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "3.3.3"
+    value: "3.3.4"
   - name: ocp-version
     value: "4.20"
   - name: fbc-pipeline-branch

--- a/.tekton/rhoai-fbc-fragment-rhoai-33-ocp-421-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-33-ocp-421-push.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "3.3.3"
+    value: "3.3.4"
   - name: ocp-version
     value: "4.21"
   - name: fbc-pipeline-branch


### PR DESCRIPTION
**Main z-stream** (`rbc_zstream_main`): `3.3.3` → `3.3.4`.

- Train segment: `rhoai-33`
- Updated `rhoai-version` in `.tekton/rhoai-fbc-fragment-rhoai-33-ocp-*.yaml`
