### PR TITLE
Fix: Replace cp with rsync to prevent stale files

### DIFF
--- a/.github/workflows/process-operator-bundle.yaml
+++ b/.github/workflows/process-operator-bundle.yaml
@@ -127,8 +127,10 @@ jobs:
             -y ${BUNDLE_PUSH_PIPELINE_PATH} \
             -x enable
 
-          cp -r ${RAW_INPUTS_DIR}/* ${BRANCH}/bundle
-          cp -r ${HELM_RAW_INPUTS_DIR}/* ${BRANCH}/helm/
+          # Use rsync --delete to properly sync directories and remove stale files
+          # This prevents orphaned files from persisting when they are removed from to-be-processed/
+          rsync -av --delete ${RAW_INPUTS_DIR}/ ${BRANCH}/bundle/
+          rsync -av --delete ${HELM_RAW_INPUTS_DIR}/ ${BRANCH}/helm/
 
       - name: Print debug logs
         if: always()


### PR DESCRIPTION
This PR fixes a bug in the `process-operator-bundle.yaml` workflow that causes stale files to persist in the `bundle/` and `helm/` directories when files are removed from `to-be-processed/`.

The workflow currently uses `cp -r` to sync processed files that **Does NOT delete stale files** that exist in destination but not in source. This caused the issue addressed in PR #22984, where obsolete webhook files had to be manually removed because the workflow didn't delete them automatically.

The `rsync --delete` approach **Deletes stale files** automatically


