### PR TITLE
Update llama-stack-core image to latest AIPCC build

### DIFF
--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -140,7 +140,7 @@ patch:
     - name: RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE
       value: "quay.io/rhoai/odh-model-registry-job-async-upload-rhel9@sha256:2791e74c01749df5a5526f799211bcd5087c7c1e92a0ac947ede8d7ee642f9ca"
     - name: RELATED_IMAGE_ODH_LLAMA_STACK_CORE_IMAGE
-      value: "quay.io/rhoai/odh-llama-stack-core-rhel9@sha256:43b60b1ee6f66fec38fe2ffbbe08dca8541ef162332e4bd8e422ecd24ee02646"
+      value: "quay.io/rhoai/odh-llama-stack-core-rhel9@sha256:379078612fb2fc62806986cb5e80711d1282bae86939fa1a8ca5d5889f9d4e53"
     - name: RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE
       value: "quay.io/rhoai/odh-mod-arch-model-registry-rhel9@sha256:sha256:8b040b818f211081c893e5686bdda91314508582c4e976d481a22b7ffdb004c2"
     - name: RELATED_IMAGE_ODH_MODEL_METADATA_COLLECTION_IMAGE


### PR DESCRIPTION
## Summary

- Updates `RELATED_IMAGE_ODH_LLAMA_STACK_CORE_IMAGE` in `bundle-patch.yaml` to the latest build from AIPCC (`ai-tenant`).
- Source PipelineRun: [llama-stack-cpu-rhoai-2-25-on-push-gdwf5](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/ai-tenant/applications/llama-stack-rhoai-2-25/pipelineruns/llama-stack-cpu-rhoai-2-25-on-push-gdwf5)

| | Old | New |
|---|---|---|
| **Digest** | `sha256:43b60b1ee6f6...` | `sha256:379078612fb2...` |
| **Built** | 2025-07-29 | 2026-06-02 |

## Test plan

- [ ] Verify new operator bundle build succeeds with the updated image reference
- [ ] Confirm llama-stack-core image is accessible at the new digest