### PR TITLE
add rsync installation

### DIFF
--- a/.github/workflows/process-operator-bundle.yaml
+++ b/.github/workflows/process-operator-bundle.yaml
@@ -57,7 +57,10 @@ jobs:
           chmod +x $yq_filename
           ln -s $yq_filename yq
           cp $yq_filename /usr/local/bin/yq
-  
+
+          echo "-> Installing rsync" >&2
+          microdnf install -y rsync
+
           pip install --default-timeout=100 -r utils/utils/processors/requirements.txt
 
       - name: Process Operator Bundle


### PR DESCRIPTION
The workflow was failing with 'rsync: command not found' because the `quay.io/rhoai/rhoai-task-toolset:latest container` doesn't include rsync.

Added rsync installation in the 'Install dependencies' step.


Fixes workflow run: https://github.com/red-hat-data-services/RHOAI-Build-Config/actions/runs/26826125847