### PR TITLE
Fix: Replace rsync with pattern-based sync to preserve permanent configs

### DIFF
--- a/.github/workflows/process-operator-bundle.yaml
+++ b/.github/workflows/process-operator-bundle.yaml
@@ -58,9 +58,6 @@ jobs:
           ln -s $yq_filename yq
           cp $yq_filename /usr/local/bin/yq
 
-          echo "-> Installing rsync" >&2
-          microdnf install -y rsync
-
           pip install --default-timeout=100 -r utils/utils/processors/requirements.txt
 
       - name: Process Operator Bundle
@@ -130,10 +127,16 @@ jobs:
             -y ${BUNDLE_PUSH_PIPELINE_PATH} \
             -x enable
 
-          # Use rsync --delete to properly sync directories and remove stale files
-          # This prevents orphaned files from persisting when they are removed from to-be-processed/
-          rsync -av --delete ${RAW_INPUTS_DIR}/ ${BRANCH}/bundle/
-          rsync -av --delete ${HELM_RAW_INPUTS_DIR}/ ${BRANCH}/helm/
+          # Sync processed content back to bundle and helm directories
+          # Convention: root-level files are permanent configs, subdirectories are synced content
+          # Strategy: delete all subdirectories then copy processed content to remove stale files
+          # WARNING: If permanent config subdirectories are added, this logic must be updated
+
+          find ${BRANCH}/bundle/ -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} \;
+          cp -r ${RAW_INPUTS_DIR}/* ${BRANCH}/bundle/
+
+          find ${BRANCH}/helm/ -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} \;
+          cp -r ${HELM_RAW_INPUTS_DIR}/* ${BRANCH}/helm/
 
       - name: Print debug logs
         if: always()


### PR DESCRIPTION
## Problem

Previous [PR #23114](https://github.com/red-hat-data-services/RHOAI-Build-Config/pull/23114) introduced `rsync --delete` to fix stale files, but it had a critical flaw that deleted essential configuration files:

**What was deleted:**
- bundle/: `Dockerfile`, `bundle-patch.yaml`, `csv-patch.yaml`, `additional-images-patch.yaml`
- helm/: `xks-values-patch.yaml`, `openshift-values-patch.yaml`

See commit: https://github.com/red-hat-data-services/RHOAI-Build-Config/commit/fedfc10f0100f6ba1d2f4a6bff8c7d2aece2992f

**Why this happened:**
bundle/ and helm/ are hybrid directories containing both permanent configs (root-level files maintained in this repo) and synced content (subdirectories from external workflows). rsync treated the entire directory as a sync target and deleted files that existed in the destination but not in the source.

## New Fix

Pattern-based sync using a structural convention:
- Root-level files = permanent configs (preserved)
- Subdirectories = synced content (replaced)

This approach:
- Removes stale files in synced subdirectories (original goal)
- Removes orphaned subdirectories
- Preserves all permanent configs
- No rsync dependency needed

## Limitation

Assumes permanent configs remain as root-level files. If permanent config subdirectories are added in the future, this logic must be updated, otherwise those subdirectories will be deleted.