### PR TITLE
RHOAI z-stream: 2.25.7 → 2.25.9

### DIFF
--- a/.tekton/odh-operator-bundle-v2-25-push.yaml
+++ b/.tekton/odh-operator-bundle-v2-25-push.yaml
@@ -42,7 +42,7 @@ spec:
   - name: build-image-index
     value: false
   - name: rhoai-version
-    value: "2.25.7"
+    value: "2.25.9"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-operator-bundle-v2-25-scheduled.yaml
+++ b/.tekton/odh-operator-bundle-v2-25-scheduled.yaml
@@ -41,7 +41,7 @@ spec:
   - name: build-image-index
     value: false
   - name: rhoai-version
-    value: "2.25.7"
+    value: "2.25.9"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/rhoai-fbc-fragment-v2-25-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-v2-25-push.yaml
@@ -47,7 +47,7 @@ spec:
   - name: build-type
     value: "ci"
   - name: rhoai-version
-    value: "2.25.7"
+    value: "2.25.9"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/rhoai-fbc-fragment-v2-25-scheduled.yaml
+++ b/.tekton/rhoai-fbc-fragment-v2-25-scheduled.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-type
     value: "nightly"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "2.25.7"
+    value: "2.25.9"
   - name: workflow_url
     value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/conforma-reporter.yaml"
   - name: smoke_url

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -1,5 +1,5 @@
 patch:
-  version: 2.25.7
+  version: 2.25.9
   relatedImages:
     - name: RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE
       value: "quay.io/rhoai/odh-kf-notebook-controller-rhel9@sha256:8fdab8122b0433dfa1045f22074c891d2b84fd21a073f406d12d5bcbe9b9b805"

--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -5,29 +5,29 @@ patch:
   olm.channels:
     - name: fast
       entries:
-      - name: rhods-operator.2.25.7
-        replaces: rhods-operator.2.25.6
-        skipRange: '>=2.24.0 <2.25.7'
+      - name: rhods-operator.2.25.9
+        replaces: rhods-operator.2.25.7
+        skipRange: '>=2.24.0 <2.25.9'
     - name: alpha
       entries:
-      - name: rhods-operator.2.25.7
-        replaces: rhods-operator.2.25.6
-        skipRange: '>=2.24.0 <2.25.7'
+      - name: rhods-operator.2.25.9
+        replaces: rhods-operator.2.25.7
+        skipRange: '>=2.24.0 <2.25.9'
     - name: stable
       entries:
-      - name: rhods-operator.2.25.7
-        replaces: rhods-operator.2.25.6
-        skipRange: '>=2.22.0 <2.25.7'
+      - name: rhods-operator.2.25.9
+        replaces: rhods-operator.2.25.7
+        skipRange: '>=2.22.0 <2.25.9'
     - name: stable-2.25
       entries:
-      - name: rhods-operator.2.25.7
-        replaces: rhods-operator.2.25.6
-        skipRange: '>=2.22.0 <2.25.7'
+      - name: rhods-operator.2.25.9
+        replaces: rhods-operator.2.25.7
+        skipRange: '>=2.22.0 <2.25.9'
     - name: eus-2.25
       entries:
-      - name: rhods-operator.2.25.7
-        replaces: rhods-operator.2.25.6
-        skipRange: '>=2.16.0 <2.25.7'
+      - name: rhods-operator.2.25.9
+        replaces: rhods-operator.2.25.7
+        skipRange: '>=2.16.0 <2.25.9'
 
   olm.bundle:
     - quay.io/rhoai/odh-operator-bundle@sha256:7f172a8a2143238bfb64fb6d9c1e508ac7deeac8829cb893976b52df25497ded

--- a/config/trustyai-pig-build-config.yaml
+++ b/config/trustyai-pig-build-config.yaml
@@ -1,4 +1,4 @@
-#!productVersion=2.25.7
+#!productVersion=2.25.9
 #!scmRevision=rhoai-2.25
 
 


### PR DESCRIPTION
**Z-stream release** (`rbc_zstream_release`): `2.25.7` → `2.25.9` on branch `rhoai-2.25`.

- `config/trustyai-pig-build-config.yaml` — productVersion (when latest)
- `bundle/bundle-patch.yaml` — patch version
- `catalog/catalog-patch.yaml` — OLM channel entries
- `.tekton/` — rhoai-version parameters
