### PR TITLE
Revert "Update defaultChannel to stable-3.x"

### DIFF
--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -1,7 +1,7 @@
 patch:
   olm.package:
     name: rhods-operator
-    defaultChannel: stable-3.x
+    defaultChannel: stable
   olm.channels:
     - name: fast
       entries:


### PR DESCRIPTION
## Summary

- Reverts commit a632ef959d which changed `defaultChannel` from `stable` to `stable-3.x` in `catalog-patch.yaml` on `rhoai-2.25`
- This change broke FBC builds for OCP v4.16/17/18 because the `stable-3.x` channel does not exist in those catalogs (RHOAI 3.x was never shipped on OCP < 4.19)
- OLM picks metadata from the highest version bundle, so this revert does not affect OperatorHub on v4.19/20/21 — the rhoai-3.x FBC's `defaultChannel: stable-3.x` takes precedence there

## Error

```
level=fatal msg="failed to load or rebuild cache: failed to rebuild cache: build package index:
process package "rhods-operator": invalid index:
└── invalid package "rhods-operator":
    └── invalid channel "stable-3.x":
        └── channel must contain at least one bundle"
```

## Context

- Original commit: https://github.com/red-hat-data-services/RHOAI-Build-Config/commit/a632ef959d
- Failed stage promoter run: https://github.com/red-hat-data-services/rhods-devops-infra/actions/runs/26891290586/job/79333983625

## Test plan

- [ ] Retrigger FBC build for v4.16/17/18 and confirm OPM cache build succeeds
- [ ] Verify v4.19/20/21 FBC builds still succeed