### PR TITLE
RHOAI release config: automation-3.5-ea.33 → rhoai-3.5-ea.33

### DIFF
--- a/.tekton/odh-operator-bundle-v3-5-ea-33-push.yaml
+++ b/.tekton/odh-operator-bundle-v3-5-ea-33-push.yaml
@@ -7,15 +7,19 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    build.appstudio.openshift.io/build-nudge-files: "catalog/catalog-patch.yaml"
+    # Trigger on bundle/ changes (or this tekton file)
+    # No trigger if bundle/bundle-patch.yaml is the only change
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.4"
-      && ( "helm/rhai-on-openshift-chart/**".pathChanged() || ".tekton/rhai-on-openshift-chart-v3-4-push.yaml".pathChanged() )
+      && target_branch == "rhoai-3.5-ea.33"
+      && ( "bundle/**".pathChanged() || ".tekton/odh-operator-bundle-v3-5-ea-33-push.yaml".pathChanged() )
+      && files.all.exists(p, !p.matches('^bundle/bundle-patch\\.yaml$'))
   labels:
-    appstudio.openshift.io/application: rhoai-v3-4
-    appstudio.openshift.io/component: rhai-on-openshift-chart-v3-4
+    appstudio.openshift.io/application: rhoai-v3-5-ea-33
+    appstudio.openshift.io/component: odh-operator-bundle-v3-5-ea-33
     pipelines.appstudio.openshift.io/type: build
-  name: rhai-on-openshift-chart-v3-4-on-push
+  name: odh-operator-bundle-v3-5-ea-33-on-push
   namespace: rhoai-tenant
 spec:
   params:
@@ -27,15 +31,21 @@ spec:
     value:
     - '{{target_branch}}-{{revision}}'
   - name: output-image
-    value: quay.io/rhoai/rhai-on-openshift-chart:{{target_branch}}
+    value: quay.io/rhoai/odh-operator-bundle:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.1"
+    value: "3.5-ea.33.1"
+  - name: dockerfile
+    value: bundle/Dockerfile
   - name: path-context
-    value: "helm/rhai-on-openshift-chart"
+    value: .
   - name: hermetic
-    value: false
+    value: true
   - name: build-source-image
     value: true
+  - name: build-image-index
+    value: false
+  - name: build-args-file
+    value: bundle/bundle_build_args.map
   pipelineRef:
     resolver: git
     params:
@@ -44,18 +54,9 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/helm-chart-build.yaml
-  taskRunSpecs:
-  - pipelineTaskName: build-helm-chart
-    stepSpecs:
-    - name: package-and-push
-      computeResources:
-        requests:
-          memory: 0.3Gi
-        limits:
-          memory: 4Gi
+      value: pipelines/container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhai-on-openshift-chart-v3-4
+    serviceAccountName: build-pipeline-odh-operator-bundle-v3-5-ea-33
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/odh-operator-bundle-v3-5-ea-33-scheduled.yaml
+++ b/.tekton/odh-operator-bundle-v3-5-ea-33-scheduled.yaml
@@ -7,15 +7,16 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    build.appstudio.openshift.io/build-nudge-files: "schedule/catalog-github-trigger.txt"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.4"
-      && ( "helm/rhai-on-xks-chart/**".pathChanged() || ".tekton/rhai-on-xks-chart-v3-4-push.yaml".pathChanged() )
+      && target_branch == "rhoai-3.5-ea.33"
+      && "schedule/bundle-tekton-trigger.txt".pathChanged()
   labels:
-    appstudio.openshift.io/application: rhoai-v3-4
-    appstudio.openshift.io/component: rhai-on-xks-chart-v3-4
+    appstudio.openshift.io/application: rhoai-v3-5-ea-33
+    appstudio.openshift.io/component: odh-operator-bundle-v3-5-ea-33
     pipelines.appstudio.openshift.io/type: build
-  name: rhai-on-xks-chart-v3-4-on-push
+  name: odh-operator-bundle-v3-5-ea-33-on-schedule
   namespace: rhoai-tenant
 spec:
   params:
@@ -26,16 +27,23 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
+    - '{{target_branch}}-nightly'
   - name: output-image
-    value: quay.io/rhoai/rhai-on-xks-chart:{{target_branch}}
+    value: quay.io/rhoai/odh-operator-bundle:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.1"
+    value: "3.5-ea.33.1"
+  - name: dockerfile
+    value: bundle/Dockerfile
   - name: path-context
-    value: "helm/rhai-on-xks-chart"
+    value: .
   - name: hermetic
-    value: false
+    value: true
   - name: build-source-image
     value: true
+  - name: build-image-index
+    value: false
+  - name: build-args-file
+    value: bundle/bundle_build_args.map
   pipelineRef:
     resolver: git
     params:
@@ -44,18 +52,9 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/helm-chart-build.yaml
-  taskRunSpecs:
-  - pipelineTaskName: build-helm-chart
-    stepSpecs:
-    - name: package-and-push
-      computeResources:
-        requests:
-          memory: 0.3Gi
-        limits:
-          memory: 4Gi
+      value: pipelines/container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhai-on-xks-chart-v3-4
+    serviceAccountName: build-pipeline-odh-operator-bundle-v3-5-ea-33
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhai-on-openshift-chart-v3-5-ea-33-push.yaml
+++ b/.tekton/rhai-on-openshift-chart-v3-5-ea-33-push.yaml
@@ -9,13 +9,13 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.4"
-      && "schedule/helm-chart-tekton-trigger.txt".pathChanged()
+      && target_branch == "rhoai-3.5-ea.33"
+      && ( "helm/rhai-on-openshift-chart/**".pathChanged() || ".tekton/rhai-on-openshift-chart-v3-5-ea-33-push.yaml".pathChanged() )
   labels:
-    appstudio.openshift.io/application: rhoai-v3-4
-    appstudio.openshift.io/component: rhai-on-openshift-chart-v3-4
+    appstudio.openshift.io/application: rhoai-v3-5-ea-33
+    appstudio.openshift.io/component: rhai-on-openshift-chart-v3-5-ea-33
     pipelines.appstudio.openshift.io/type: build
-  name: rhai-on-openshift-chart-v3-4-on-schedule
+  name: rhai-on-openshift-chart-v3-5-ea-33-on-push
   namespace: rhoai-tenant
 spec:
   params:
@@ -26,11 +26,10 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - '{{target_branch}}-nightly'
   - name: output-image
     value: quay.io/rhoai/rhai-on-openshift-chart:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.1"
+    value: "3.5-ea.33.1"
   - name: path-context
     value: "helm/rhai-on-openshift-chart"
   - name: hermetic
@@ -56,7 +55,7 @@ spec:
         limits:
           memory: 4Gi
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhai-on-openshift-chart-v3-4
+    serviceAccountName: build-pipeline-rhai-on-openshift-chart-v3-5-ea-33
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhai-on-openshift-chart-v3-5-ea-33-scheduled.yaml
+++ b/.tekton/rhai-on-openshift-chart-v3-5-ea-33-scheduled.yaml
@@ -7,16 +7,15 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    build.appstudio.openshift.io/build-nudge-files: "schedule/catalog-github-trigger.txt"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.4"
-      && "schedule/bundle-tekton-trigger.txt".pathChanged()
+      && target_branch == "rhoai-3.5-ea.33"
+      && "schedule/helm-chart-tekton-trigger.txt".pathChanged()
   labels:
-    appstudio.openshift.io/application: rhoai-v3-4
-    appstudio.openshift.io/component: odh-operator-bundle-v3-4
+    appstudio.openshift.io/application: rhoai-v3-5-ea-33
+    appstudio.openshift.io/component: rhai-on-openshift-chart-v3-5-ea-33
     pipelines.appstudio.openshift.io/type: build
-  name: odh-operator-bundle-v3-4-on-schedule
+  name: rhai-on-openshift-chart-v3-5-ea-33-on-schedule
   namespace: rhoai-tenant
 spec:
   params:
@@ -29,21 +28,15 @@ spec:
     - '{{target_branch}}-{{revision}}'
     - '{{target_branch}}-nightly'
   - name: output-image
-    value: quay.io/rhoai/odh-operator-bundle:{{target_branch}}
+    value: quay.io/rhoai/rhai-on-openshift-chart:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.1"
-  - name: dockerfile
-    value: bundle/Dockerfile
+    value: "3.5-ea.33.1"
   - name: path-context
-    value: .
+    value: "helm/rhai-on-openshift-chart"
   - name: hermetic
-    value: true
+    value: false
   - name: build-source-image
     value: true
-  - name: build-image-index
-    value: false
-  - name: build-args-file
-    value: bundle/bundle_build_args.map
   pipelineRef:
     resolver: git
     params:
@@ -52,9 +45,18 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/helm-chart-build.yaml
+  taskRunSpecs:
+  - pipelineTaskName: build-helm-chart
+    stepSpecs:
+    - name: package-and-push
+      computeResources:
+        requests:
+          memory: 0.3Gi
+        limits:
+          memory: 4Gi
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-operator-bundle-v3-4
+    serviceAccountName: build-pipeline-rhai-on-openshift-chart-v3-5-ea-33
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhai-on-xks-chart-v3-5-ea-33-push.yaml
+++ b/.tekton/rhai-on-xks-chart-v3-5-ea-33-push.yaml
@@ -9,18 +9,15 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.4"
-      && "schedule/catalog-tekton-trigger.txt".pathChanged()
+      && target_branch == "rhoai-3.5-ea.33"
+      && ( "helm/rhai-on-xks-chart/**".pathChanged() || ".tekton/rhai-on-xks-chart-v3-5-ea-33-push.yaml".pathChanged() )
   labels:
-    appstudio.openshift.io/application: rhoai-v3-4
-    appstudio.openshift.io/component: rhoai-fbc-fragment-v3-4
+    appstudio.openshift.io/application: rhoai-v3-5-ea-33
+    appstudio.openshift.io/component: rhai-on-xks-chart-v3-5-ea-33
     pipelines.appstudio.openshift.io/type: build
-  name: rhoai-fbc-fragment-v3-4-on-schedule
+  name: rhai-on-xks-chart-v3-5-ea-33-on-push
   namespace: rhoai-tenant
 spec:
-  timeouts:
-    pipeline: 10h
-    tasks: 8h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -29,37 +26,16 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - '{{target_branch}}-nightly'
   - name: output-image
-    value: quay.io/rhoai/rhoai-fbc-fragment:{{target_branch}}
+    value: quay.io/rhoai/rhai-on-xks-chart:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.1"
-  - name: build-platforms
-    value:
-    - linux/x86_64
-    - linux/ppc64le
-    - linux/s390x
-    - linux/arm64
-  - name: dockerfile
-    value: Dockerfile
+    value: "3.5-ea.33.1"
   - name: path-context
-    value: catalog/v4.19
+    value: "helm/rhai-on-xks-chart"
   - name: hermetic
-    value: true
+    value: false
   - name: build-source-image
     value: true
-  - name: build-image-index
-    value: true
-  - name: build-args-file
-    value: catalog/catalog_build_args.map
-  - name: skip-checks
-    value: false
-  - name: build-type
-    value: "nightly"
-  - name: workflow_url
-    value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/conforma-reporter.yaml"
-  - name: smoke_url
-    value: "https://github.com/red-hat-data-services/rhods-devops-infra/actions/workflows/smoke-trigger.yaml"
   pipelineRef:
     resolver: git
     params:
@@ -68,9 +44,18 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/fbc-fragment-build.yaml
+      value: pipelines/helm-chart-build.yaml
+  taskRunSpecs:
+  - pipelineTaskName: build-helm-chart
+    stepSpecs:
+    - name: package-and-push
+      computeResources:
+        requests:
+          memory: 0.3Gi
+        limits:
+          memory: 4Gi
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhoai-fbc-fragment-v3-4
+    serviceAccountName: build-pipeline-rhai-on-xks-chart-v3-5-ea-33
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhai-on-xks-chart-v3-5-ea-33-scheduled.yaml
+++ b/.tekton/rhai-on-xks-chart-v3-5-ea-33-scheduled.yaml
@@ -7,23 +7,17 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    # Trigger on catalog/ changes (or this tekton file)
-    # No trigger if catalog/catalog-patch.yaml is the only change
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.4"
-      && ( "catalog/**".pathChanged() || ".tekton/rhoai-fbc-fragment-v3-4-push.yaml".pathChanged() )
-      && files.all.exists(p, !p.matches('^catalog/catalog-patch\\.yaml$'))
+      && target_branch == "rhoai-3.5-ea.33"
+      && "schedule/helm-chart-tekton-trigger.txt".pathChanged()
   labels:
-    appstudio.openshift.io/application: rhoai-v3-4
-    appstudio.openshift.io/component: rhoai-fbc-fragment-v3-4
+    appstudio.openshift.io/application: rhoai-v3-5-ea-33
+    appstudio.openshift.io/component: rhai-on-xks-chart-v3-5-ea-33
     pipelines.appstudio.openshift.io/type: build
-  name: rhoai-fbc-fragment-v3-4-on-push
+  name: rhai-on-xks-chart-v3-5-ea-33-on-schedule
   namespace: rhoai-tenant
 spec:
-  timeouts:
-    pipeline: 10h
-    tasks: 8h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -32,32 +26,17 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
+    - '{{target_branch}}-nightly'
   - name: output-image
-    value: quay.io/rhoai/rhoai-fbc-fragment:{{target_branch}}
+    value: quay.io/rhoai/rhai-on-xks-chart:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.1"
-  - name: dockerfile
-    value: Dockerfile
+    value: "3.5-ea.33.1"
   - name: path-context
-    value: catalog/v4.19
+    value: "helm/rhai-on-xks-chart"
   - name: hermetic
-    value: true
+    value: false
   - name: build-source-image
     value: true
-  - name: build-image-index
-    value: true
-  - name: build-platforms
-    value:
-    - linux/x86_64
-    - linux/ppc64le
-    - linux/s390x
-    - linux/arm64
-  - name: build-args-file
-    value: catalog/catalog_build_args.map
-  - name: skip-checks
-    value: false
-  - name: build-type
-    value: "ci"
   pipelineRef:
     resolver: git
     params:
@@ -66,9 +45,18 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/fbc-fragment-build.yaml
+      value: pipelines/helm-chart-build.yaml
+  taskRunSpecs:
+  - pipelineTaskName: build-helm-chart
+    stepSpecs:
+    - name: package-and-push
+      computeResources:
+        requests:
+          memory: 0.3Gi
+        limits:
+          memory: 4Gi
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhoai-fbc-fragment-v3-4
+    serviceAccountName: build-pipeline-rhai-on-xks-chart-v3-5-ea-33
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhoai-fbc-fragment-v3-5-ea-33-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-v3-5-ea-33-push.yaml
@@ -7,17 +7,23 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    # Trigger on catalog/ changes (or this tekton file)
+    # No trigger if catalog/catalog-patch.yaml is the only change
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.4"
-      && "schedule/helm-chart-tekton-trigger.txt".pathChanged()
+      && target_branch == "rhoai-3.5-ea.33"
+      && ( "catalog/**".pathChanged() || ".tekton/rhoai-fbc-fragment-v3-5-ea-33-push.yaml".pathChanged() )
+      && files.all.exists(p, !p.matches('^catalog/catalog-patch\\.yaml$'))
   labels:
-    appstudio.openshift.io/application: rhoai-v3-4
-    appstudio.openshift.io/component: rhai-on-xks-chart-v3-4
+    appstudio.openshift.io/application: rhoai-v3-5-ea-33
+    appstudio.openshift.io/component: rhoai-fbc-fragment-v3-5-ea-33
     pipelines.appstudio.openshift.io/type: build
-  name: rhai-on-xks-chart-v3-4-on-schedule
+  name: rhoai-fbc-fragment-v3-5-ea-33-on-push
   namespace: rhoai-tenant
 spec:
+  timeouts:
+    pipeline: 10h
+    tasks: 8h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -26,17 +32,32 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - '{{target_branch}}-nightly'
   - name: output-image
-    value: quay.io/rhoai/rhai-on-xks-chart:{{target_branch}}
+    value: quay.io/rhoai/rhoai-fbc-fragment:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.1"
+    value: "3.5-ea.33.1"
+  - name: dockerfile
+    value: Dockerfile
   - name: path-context
-    value: "helm/rhai-on-xks-chart"
+    value: catalog/v4.19
   - name: hermetic
-    value: false
+    value: true
   - name: build-source-image
     value: true
+  - name: build-image-index
+    value: true
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
+  - name: build-args-file
+    value: catalog/catalog_build_args.map
+  - name: skip-checks
+    value: false
+  - name: build-type
+    value: "ci"
   pipelineRef:
     resolver: git
     params:
@@ -45,18 +66,9 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/helm-chart-build.yaml
-  taskRunSpecs:
-  - pipelineTaskName: build-helm-chart
-    stepSpecs:
-    - name: package-and-push
-      computeResources:
-        requests:
-          memory: 0.3Gi
-        limits:
-          memory: 4Gi
+      value: pipelines/fbc-fragment-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhai-on-xks-chart-v3-4
+    serviceAccountName: build-pipeline-rhoai-fbc-fragment-v3-5-ea-33
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhoai-fbc-fragment-v3-5-ea-33-scheduled.yaml
+++ b/.tekton/rhoai-fbc-fragment-v3-5-ea-33-scheduled.yaml
@@ -7,21 +7,20 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    build.appstudio.openshift.io/build-nudge-files: "catalog/catalog-patch.yaml"
-    # Trigger on bundle/ changes (or this tekton file)
-    # No trigger if bundle/bundle-patch.yaml is the only change
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.4"
-      && ( "bundle/**".pathChanged() || ".tekton/odh-operator-bundle-v3-4-push.yaml".pathChanged() )
-      && files.all.exists(p, !p.matches('^bundle/bundle-patch\\.yaml$'))
+      && target_branch == "rhoai-3.5-ea.33"
+      && "schedule/catalog-tekton-trigger.txt".pathChanged()
   labels:
-    appstudio.openshift.io/application: rhoai-v3-4
-    appstudio.openshift.io/component: odh-operator-bundle-v3-4
+    appstudio.openshift.io/application: rhoai-v3-5-ea-33
+    appstudio.openshift.io/component: rhoai-fbc-fragment-v3-5-ea-33
     pipelines.appstudio.openshift.io/type: build
-  name: odh-operator-bundle-v3-4-on-push
+  name: rhoai-fbc-fragment-v3-5-ea-33-on-schedule
   namespace: rhoai-tenant
 spec:
+  timeouts:
+    pipeline: 10h
+    tasks: 8h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -30,22 +29,37 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
+    - '{{target_branch}}-nightly'
   - name: output-image
-    value: quay.io/rhoai/odh-operator-bundle:{{target_branch}}
+    value: quay.io/rhoai/rhoai-fbc-fragment:{{target_branch}}
   - name: rhoai-version
-    value: "3.4.1"
+    value: "3.5-ea.33.1"
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
   - name: dockerfile
-    value: bundle/Dockerfile
+    value: Dockerfile
   - name: path-context
-    value: .
+    value: catalog/v4.19
   - name: hermetic
     value: true
   - name: build-source-image
     value: true
   - name: build-image-index
-    value: false
+    value: true
   - name: build-args-file
-    value: bundle/bundle_build_args.map
+    value: catalog/catalog_build_args.map
+  - name: skip-checks
+    value: false
+  - name: build-type
+    value: "nightly"
+  - name: workflow_url
+    value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/conforma-reporter.yaml"
+  - name: smoke_url
+    value: "https://github.com/red-hat-data-services/rhods-devops-infra/actions/workflows/smoke-trigger.yaml"
   pipelineRef:
     resolver: git
     params:
@@ -54,9 +68,9 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/container-build.yaml
+      value: pipelines/fbc-fragment-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-operator-bundle-v3-4
+    serviceAccountName: build-pipeline-rhoai-fbc-fragment-v3-5-ea-33
   workspaces:
   - name: git-auth
     secret:

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -1,5 +1,5 @@
 patch:
-  version: 3.4.1
+  version: 3.5-ea.33.1
   relatedImages:
     - name: RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE
       value: "quay.io/rhoai/odh-kf-notebook-controller-rhel9@sha256:8fdab8122b0433dfa1045f22074c891d2b84fd21a073f406d12d5bcbe9b9b805"

--- a/bundle/csv-patch.yaml
+++ b/bundle/csv-patch.yaml
@@ -28,4 +28,4 @@ spec:
     email: managed-open-data-hub@redhat.com
   links:
   - name: Red Hat OpenShift AI
-    url: https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4
+    url: https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5


### PR DESCRIPTION
## Summary

Automated updates for the release line: merge changes from the automation branch into the target release branch.

## Branches

- **Target:** `rhoai-3.5-ea.33`
- **Source:** `automation-3.5-ea.33`

## Changes

Release-line configuration only (not `main`): Tekton definitions under `.tekton`, `bundle/bundle-patch.yaml`, and `bundle/csv-patch.yaml` when applicable for this release step.

## Review

Please verify image references and bundle metadata for the intended release.

[View diff (compare)](https://github.com/red-hat-data-services/RHOAI-Build-Config/compare/rhoai-3.5-ea.33...automation-3.5-ea.33)