### PR TITLE
Add odh-mod-arch-agent-ops to bundle-patch.yaml

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -193,6 +193,8 @@ ARG ODH_OGX_K8S_OPERATOR_GIT_URL=
 ARG ODH_OGX_K8S_OPERATOR_GIT_COMMIT=
 ARG ODH_AGENTS_OPERATOR_GIT_URL=
 ARG ODH_AGENTS_OPERATOR_GIT_COMMIT=
+ARG ODH_MOD_ARCH_AGENT_OPS_GIT_URL=
+ARG ODH_MOD_ARCH_AGENT_OPS_GIT_COMMIT=
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -400,7 +402,9 @@ LABEL \
       odh-ogx-k8s-operator.git.url="${ODH_OGX_K8S_OPERATOR_GIT_URL}" \
       odh-ogx-k8s-operator.git.commit="${ODH_OGX_K8S_OPERATOR_GIT_COMMIT}" \
       odh-agents-operator.git.url="${ODH_AGENTS_OPERATOR_GIT_URL}" \
-      odh-agents-operator.git.commit="${ODH_AGENTS_OPERATOR_GIT_COMMIT}"
+      odh-agents-operator.git.commit="${ODH_AGENTS_OPERATOR_GIT_COMMIT}" \
+      odh-mod-arch-agent-ops.git.url="${ODH_MOD_ARCH_AGENT_OPS_GIT_URL}" \
+      odh-mod-arch-agent-ops.git.commit="${ODH_MOD_ARCH_AGENT_OPS_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -221,6 +221,8 @@ patch:
       value: quay.io/rhoai/odh-ogx-k8s-operator-rhel9@sha256:83a1e268edddc1095e0f9f574a0f46eff1462e96511acc5d8e5696cad0fffdf4
     - name: RELATED_IMAGE_ODH_AGENTS_OPERATOR_IMAGE
       value: quay.io/rhoai/odh-agents-operator-rhel9@sha256:2a950baa216a8a1c9239d862f5ff2cc11df76d305870c2c8b5eb1d31304a511e
+    - name: RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE
+      value: quay.io/rhoai/odh-mod-arch-agent-ops-rhel9@sha256:0bed03dbc2b88529198c52c9dcb105df7664fb094d3424adff7b97a08554e3e8
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -112,6 +112,7 @@ config:
         rhoai/odh-ogx-core-rhel9: rhoai/odh-ogx-core-rhel9
         rhoai/odh-ogx-k8s-operator-rhel9: rhoai/odh-ogx-k8s-operator-rhel9
         rhoai/odh-agents-operator-rhel9: rhoai/odh-agents-operator-rhel9
+        rhoai/odh-mod-arch-agent-ops-rhel9: rhoai/odh-mod-arch-agent-ops-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds 'odh-mod-arch-agent-ops' to the red-hat-data-services/RHOAI-Build-Config bundle relatedImages.

Component: odh-mod-arch-agent-ops
Product context: RHOAI
Quay org: rhoai
Upstream repo: https://github.com/red-hat-data-services/odh-dashboard @ rhoai-3.5-ea.2
Jira: https://redhat.atlassian.net/browse/RHOAIENG-63303

**Files changed:**
- `bundle/bundle-patch.yaml` — added `RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE` to `patch.relatedImages`
- `config/build-config.yaml` — added `rhoai/odh-mod-arch-agent-ops-rhel9` to `config.replacements[0].repo_mappings`
- `bundle/Dockerfile` — added ARG and LABEL entries for `odh-mod-arch-agent-ops`

> **NOTE:** The SHA256 digest for `RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE` is a **placeholder** — the image has not yet been built by Konflux.
> Before merging this PR, replace the digest with the real value.