### PR TITLE
Update RHAII vLLM images to 3.4.1 stage for RHOAI 3.4.1

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -40,12 +40,12 @@ additionalImages:
   - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
     value: "registry.redhat.io/rhaii/vllm-gaudi-rhel9:3.4.0@sha256:71008b2151586551ec0969ffc5b175f726ed6f6bebee29cdc289549e216609bc"
   - name: RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-cuda-rhel9:3.4.1-1780080223@sha256:1a799438f49926465794842fb0430b7ef8940c8f492ae19a0532248d1dcfb385"
+    value: "registry.stage.redhat.io/rhaii/vllm-cuda-rhel9:3.4.1@sha256:1a799438f49926465794842fb0430b7ef8940c8f492ae19a0532248d1dcfb385"
   - name: RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-rocm-rhel9:3.4.1-1780080416@sha256:2d9b289cc7b24b19c80137e5b0a24515c6ba370f07e4b0fce48791d01ed1dc9a"
+    value: "registry.stage.redhat.io/rhaii/vllm-rocm-rhel9:3.4.1@sha256:2d9b289cc7b24b19c80137e5b0a24515c6ba370f07e4b0fce48791d01ed1dc9a"
   - name: RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-spyre-rhel9:3.4.1-1780080206@sha256:26a609247b8271a6f408e3c23adf95f15d2fe4e1d9befcfef5b6a06cfa6d717b"
+    value: "registry.stage.redhat.io/rhaii/vllm-spyre-rhel9:3.4.1@sha256:26a609247b8271a6f408e3c23adf95f15d2fe4e1d9befcfef5b6a06cfa6d717b"
   - name: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-cpu-rhel9:3.4.1-1780080099@sha256:c60b2eb7d53a44e11d24c8657d92562c0479e048a940d601b8d5e4d46c887e13"
+    value: "registry.stage.redhat.io/rhaii/vllm-cpu-rhel9:3.4.1@sha256:c60b2eb7d53a44e11d24c8657d92562c0479e048a940d601b8d5e4d46c887e13"
   - name: RELATED_IMAGE_UBI_MINIMAL_IMAGE
     value: "registry.redhat.io/ubi9/ubi-minimal:9.7@sha256:907b68736aa798b2d38255b7aa070b2a70acb90803864a40f05d0ec47556ddd0"

--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -40,12 +40,12 @@ additionalImages:
   - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
     value: "registry.redhat.io/rhaii/vllm-gaudi-rhel9:3.4.0@sha256:71008b2151586551ec0969ffc5b175f726ed6f6bebee29cdc289549e216609bc"
   - name: RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE
-    value: "registry.redhat.io/rhaii/vllm-cuda-rhel9:3.4.0@sha256:ad06abf3bb5235ebb5b2df84cd1b9fd09e823f0ff2eebfc82bb4590275ccfe0b"
+    value: "registry.stage.redhat.io/rhaii/vllm-cuda-rhel9:3.4.1-1780080223@sha256:1a799438f49926465794842fb0430b7ef8940c8f492ae19a0532248d1dcfb385"
   - name: RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE
-    value: "registry.redhat.io/rhaii/vllm-rocm-rhel9:3.4.0@sha256:98375507f524731a76877fb7ac5451be6fabbf8751e18802943ae8abe44a9bca"
+    value: "registry.stage.redhat.io/rhaii/vllm-rocm-rhel9:3.4.1-1780080416@sha256:2d9b289cc7b24b19c80137e5b0a24515c6ba370f07e4b0fce48791d01ed1dc9a"
   - name: RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE
-    value: "registry.redhat.io/rhaii/vllm-spyre-rhel9:3.4.0@sha256:61ee874175b314a4d5425e68b4320ef53af2318c58ef7e74e77d8bbf5183fc33"
+    value: "registry.stage.redhat.io/rhaii/vllm-spyre-rhel9:3.4.1-1780080206@sha256:26a609247b8271a6f408e3c23adf95f15d2fe4e1d9befcfef5b6a06cfa6d717b"
   - name: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE
-    value: "registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0@sha256:dd104214095322ca92fb71149ae2bea8cfff54d6d261079740f673a840ed0795"
+    value: "registry.stage.redhat.io/rhaii/vllm-cpu-rhel9:3.4.1-1780080099@sha256:c60b2eb7d53a44e11d24c8657d92562c0479e048a940d601b8d5e4d46c887e13"
   - name: RELATED_IMAGE_UBI_MINIMAL_IMAGE
     value: "registry.redhat.io/ubi9/ubi-minimal:9.7@sha256:907b68736aa798b2d38255b7aa070b2a70acb90803864a40f05d0ec47556ddd0"


### PR DESCRIPTION
## Summary

- Updates 4 RHAII vLLM images from 3.4.0 (prod) to 3.4.1 (stage) in `bundle/additional-images-patch.yaml`
- Stage registry entries (`registry.stage.redhat.io`) are automatically replaced with `registry.redhat.io` during processing
- Uses short version tags (`3.4.1`) instead of build-specific tags — SHA digest pins the exact image

## Images Updated

| Image | Old (3.4.0 prod) | New (3.4.1 stage) |
|-------|-------------------|-------------------|
| vllm-cuda | `ad06abf3...` | `1a799438...` |
| vllm-rocm | `98375507...` | `2d9b289c...` |
| vllm-spyre | `61ee8741...` | `26a60924...` |
| vllm-cpu | `dd104214...` | `c60b2eb7...` |

Unchanged: `vllm-gaudi` (no new build provided)

## Validation

vllm-cuda, vllm-rocm, and vllm-cpu validated successfully by RHAII team (Raghul M). vllm-spyre has a known runtime bug with chunked prefill being tracked separately.

## Ref

- RHOAIENG-63795
- RC stage images announced by RHAII productization team