### PR TITLE
Add odh-ai-gateway-operator to bundle-patch.yaml

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -195,6 +195,8 @@ ARG ODH_AGENTS_OPERATOR_GIT_URL=
 ARG ODH_AGENTS_OPERATOR_GIT_COMMIT=
 ARG ODH_MOD_ARCH_AGENT_OPS_GIT_URL=
 ARG ODH_MOD_ARCH_AGENT_OPS_GIT_COMMIT=
+ARG ODH_AI_GATEWAY_OPERATOR_GIT_URL=
+ARG ODH_AI_GATEWAY_OPERATOR_GIT_COMMIT=
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -404,7 +406,9 @@ LABEL \
       odh-agents-operator.git.url="${ODH_AGENTS_OPERATOR_GIT_URL}" \
       odh-agents-operator.git.commit="${ODH_AGENTS_OPERATOR_GIT_COMMIT}" \
       odh-mod-arch-agent-ops.git.url="${ODH_MOD_ARCH_AGENT_OPS_GIT_URL}" \
-      odh-mod-arch-agent-ops.git.commit="${ODH_MOD_ARCH_AGENT_OPS_GIT_COMMIT}"
+      odh-mod-arch-agent-ops.git.commit="${ODH_MOD_ARCH_AGENT_OPS_GIT_COMMIT}" \
+      odh-ai-gateway-operator.git.url="${ODH_AI_GATEWAY_OPERATOR_GIT_URL}" \
+      odh-ai-gateway-operator.git.commit="${ODH_AI_GATEWAY_OPERATOR_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -224,7 +224,7 @@ patch:
     - name: RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE
       value: quay.io/rhoai/odh-mod-arch-agent-ops-rhel9@sha256:0bed03dbc2b88529198c52c9dcb105df7664fb094d3424adff7b97a08554e3e8
     - name: RELATED_IMAGE_ODH_AI_GATEWAY_OPERATOR_IMAGE
-      value: "quay.io/rhoai/odh-ai-gateway-operator-rhel9@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+      value: "quay.io/rhoai/odh-ai-gateway-operator-rhel9@sha256:9005837b608155b2bac646bc9402394a977227d837393ec38de40cef06653243"
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -223,6 +223,8 @@ patch:
       value: quay.io/rhoai/odh-agents-operator-rhel9@sha256:2a950baa216a8a1c9239d862f5ff2cc11df76d305870c2c8b5eb1d31304a511e
     - name: RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE
       value: quay.io/rhoai/odh-mod-arch-agent-ops-rhel9@sha256:0bed03dbc2b88529198c52c9dcb105df7664fb094d3424adff7b97a08554e3e8
+    - name: RELATED_IMAGE_ODH_AI_GATEWAY_OPERATOR_IMAGE
+      value: "quay.io/rhoai/odh-ai-gateway-operator-rhel9@sha256:0000000000000000000000000000000000000000000000000000000000000000"
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -113,6 +113,7 @@ config:
         rhoai/odh-ogx-k8s-operator-rhel9: rhoai/odh-ogx-k8s-operator-rhel9
         rhoai/odh-agents-operator-rhel9: rhoai/odh-agents-operator-rhel9
         rhoai/odh-mod-arch-agent-ops-rhel9: rhoai/odh-mod-arch-agent-ops-rhel9
+        rhoai/odh-ai-gateway-operator-rhel9: rhoai/odh-ai-gateway-operator-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds `odh-ai-gateway-operator` to the red-hat-data-services/RHOAI-Build-Config bundle relatedImages.

Component: odh-ai-gateway-operator
Product context: RHOAI
Quay org: rhoai
Upstream repo: https://github.com/red-hat-data-services/ai-gateway-operator @ rhoai-3.5-ea.2
Jira: https://redhat.atlassian.net/browse/RHOAIENG-66477

**Files changed:**
- `bundle/bundle-patch.yaml` — added `RELATED_IMAGE_ODH_AI_GATEWAY_OPERATOR_IMAGE` to `patch.relatedImages`
- `config/build-config.yaml` — added `rhoai/odh-ai-gateway-operator-rhel9` to `config.replacements[0].repo_mappings`
- `bundle/Dockerfile` — added ARG `ODH_AI_GATEWAY_OPERATOR_GIT_URL`, ARG `ODH_AI_GATEWAY_OPERATOR_GIT_COMMIT`, and git label entries for `odh-ai-gateway-operator`

> **NOTE:** The SHA256 digest for `RELATED_IMAGE_ODH_AI_GATEWAY_OPERATOR_IMAGE` is a **placeholder** — the image has not yet been built by Konflux.
> Before merging this PR, replace the digest with the real value:
> ```
> skopeo inspect --no-creds docker://quay.io/rhoai/odh-ai-gateway-operator-rhel9:odh-stable | jq -r '.Digest'
> ```
