### PR TITLE
Bump TrustyAI PIG productVersion to 3.4.1

### DIFF
--- a/config/trustyai-pig-build-config.yaml
+++ b/config/trustyai-pig-build-config.yaml
@@ -1,4 +1,4 @@
-#!productVersion=3.4.0
+#!productVersion=3.4.1
 #!scmRevision=rhoai-3.4
 
 


### PR DESCRIPTION
## Summary

- Update `productVersion` from `3.4.0` to `3.4.1` in `config/trustyai-pig-build-config.yaml`

## Why

The `konflux-config-validator` in [rhods-devops-infra](https://github.com/red-hat-data-services/rhods-devops-infra/actions/runs/27290303074/job/80608812651) derives version `3.4.1` from the bundle push pipeline version label and expects PIG configs to match. The TrustyAI PIG config still has `3.4.0`, causing the validation to fail:

```
Component 'trustyai' productVersion '3.4.0' does not match expected '3.4.1'
```