### PR TITLE
Add release artifacts for RHOAI 2.25.7

### DIFF
--- a/release/2.25.7/prod/release-components/prod-release-components-rhoai-v2-25-1781006141.yaml
+++ b/release/2.25.7/prod/release-components/prod-release-components-rhoai-v2-25-1781006141.yaml
@@ -1,0 +1,679 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-v2-25-prod-1781006141-1
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 9628df633f53621ba4a485ea06f379a763c8c8d6
+    konflux-release-data/artifact-type: components
+    konflux-release-data/environment: prod
+    appstudio.openshift.io/application: rhoai-v2-25
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-components-prod
+  snapshot: rhoai-v2-25-1780517141
+  data:
+    version: 2.25.7
+    releaseNotes:
+      cves:
+        - key: 'CVE-2026-34993' # https://redhat.atlassian.net/browse/RHOAIENG-65960
+          component: 'odh-training-rocm62-torch25-py311-v2-25'
+        - key: 'CVE-2026-34993' # https://redhat.atlassian.net/browse/RHOAIENG-65951
+          component: 'odh-training-cuda121-torch24-py311-v2-25'
+        - key: 'CVE-2026-34993' # https://redhat.atlassian.net/browse/RHOAIENG-65936
+          component: 'odh-training-cuda124-torch25-py311-v2-25'
+        - key: 'CVE-2026-34993' # https://redhat.atlassian.net/browse/RHOAIENG-65935
+          component: 'odh-training-rocm62-torch24-py311-v2-25'
+        - key: 'CVE-2026-39892' # https://redhat.atlassian.net/browse/RHOAIENG-62085
+          component: 'odh-vllm-gaudi-v2-25'
+        - key: 'CVE-2026-6321' # https://redhat.atlassian.net/browse/RHOAIENG-61152
+          component: 'odh-mod-arch-model-registry-v2-25'
+        - key: 'CVE-2026-6321' # https://redhat.atlassian.net/browse/RHOAIENG-61143
+          component: 'odh-dashboard-v2-25'
+        - key: 'CVE-2026-42041' # https://redhat.atlassian.net/browse/RHOAIENG-61089
+          component: 'odh-mod-arch-model-registry-v2-25'
+        - key: 'CVE-2026-42041' # https://redhat.atlassian.net/browse/RHOAIENG-61087
+          component: 'odh-dashboard-v2-25'
+        - key: 'CVE-2026-42039' # https://redhat.atlassian.net/browse/RHOAIENG-61003
+          component: 'odh-mod-arch-model-registry-v2-25'
+        - key: 'CVE-2026-42039' # https://redhat.atlassian.net/browse/RHOAIENG-61001
+          component: 'odh-dashboard-v2-25'
+        - key: 'CVE-2026-42043' # https://redhat.atlassian.net/browse/RHOAIENG-60995
+          component: 'odh-mod-arch-model-registry-v2-25'
+        - key: 'CVE-2026-42043' # https://redhat.atlassian.net/browse/RHOAIENG-60993
+          component: 'odh-dashboard-v2-25'
+        - key: 'CVE-2026-42033' # https://redhat.atlassian.net/browse/RHOAIENG-60583
+          component: 'odh-mod-arch-model-registry-v2-25'
+        - key: 'CVE-2026-42033' # https://redhat.atlassian.net/browse/RHOAIENG-60581
+          component: 'odh-dashboard-v2-25'
+        - key: 'CVE-2025-14813' # https://redhat.atlassian.net/browse/RHOAIENG-60265
+          component: 'odh-modelmesh-v2-25'
+        - key: 'CVE-2026-42035' # https://redhat.atlassian.net/browse/RHOAIENG-60201
+          component: 'odh-mod-arch-model-registry-v2-25'
+        - key: 'CVE-2026-42035' # https://redhat.atlassian.net/browse/RHOAIENG-60200
+          component: 'odh-dashboard-v2-25'
+        - key: 'CVE-2026-41240' # https://redhat.atlassian.net/browse/RHOAIENG-60175
+          component: 'odh-mod-arch-model-registry-v2-25'
+        - key: 'CVE-2026-41240' # https://redhat.atlassian.net/browse/RHOAIENG-60174
+          component: 'odh-dashboard-v2-25'
+        - key: 'CVE-2026-41242' # https://redhat.atlassian.net/browse/RHOAIENG-60073
+          component: 'odh-mod-arch-model-registry-v2-25'
+        - key: 'CVE-2026-41242' # https://redhat.atlassian.net/browse/RHOAIENG-60072
+          component: 'odh-dashboard-v2-25'
+        - key: 'CVE-2026-40895' # https://redhat.atlassian.net/browse/RHOAIENG-59714
+          component: 'odh-mod-arch-model-registry-v2-25'
+        - key: 'CVE-2026-40895' # https://redhat.atlassian.net/browse/RHOAIENG-59712
+          component: 'odh-dashboard-v2-25'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59275
+          component: 'odh-kserve-storage-initializer-v2-25'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59270
+          component: 'odh-feature-server-v2-25'
+        - key: 'CVE-2026-28684' # https://redhat.atlassian.net/browse/RHOAIENG-59229
+          component: 'odh-vllm-gaudi-v2-25'
+        - key: 'CVE-2026-28684' # https://redhat.atlassian.net/browse/RHOAIENG-59219
+          component: 'odh-kserve-storage-initializer-v2-25'
+        - key: 'CVE-2026-28684' # https://redhat.atlassian.net/browse/RHOAIENG-59215
+          component: 'odh-feature-server-v2-25'
+        - key: 'CVE-2026-40192' # https://redhat.atlassian.net/browse/RHOAIENG-58562
+          component: 'odh-caikit-tgis-serving-v2-25'
+        - key: 'CVE-2026-1462' # https://redhat.atlassian.net/browse/RHOAIENG-57855
+          component: 'odh-modelmesh-runtime-adapter-v2-25'
+        - key: 'CVE-2026-32280' # https://redhat.atlassian.net/browse/RHOAIENG-57703
+          component: 'odh-operator-v2-25'
+        - key: 'CVE-2025-62718' # https://redhat.atlassian.net/browse/RHOAIENG-57649
+          component: 'odh-mod-arch-model-registry-v2-25'
+        - key: 'CVE-2025-62718' # https://redhat.atlassian.net/browse/RHOAIENG-57648
+          component: 'odh-dashboard-v2-25'
+        - key: 'CVE-2026-34986' # https://redhat.atlassian.net/browse/RHOAIENG-56831
+          component: 'odh-model-controller-v2-25'
+        - key: 'CVE-2026-27489' # https://redhat.atlassian.net/browse/RHOAIENG-56476
+          component: 'odh-workbench-jupyter-trustyai-cpu-py312-v2-25'
+        - key: 'CVE-2026-27489' # https://redhat.atlassian.net/browse/RHOAIENG-56474
+          component: 'odh-workbench-jupyter-tensorflow-rocm-py312-v2-25'
+        - key: 'CVE-2026-27489' # https://redhat.atlassian.net/browse/RHOAIENG-56472
+          component: 'odh-workbench-jupyter-tensorflow-cuda-py312-v2-25'
+        - key: 'CVE-2026-27489' # https://redhat.atlassian.net/browse/RHOAIENG-56470
+          component: 'odh-workbench-jupyter-pytorch-rocm-py312-v2-25'
+        - key: 'CVE-2026-27489' # https://redhat.atlassian.net/browse/RHOAIENG-56468
+          component: 'odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v2-25'
+        - key: 'CVE-2026-27489' # https://redhat.atlassian.net/browse/RHOAIENG-56466
+          component: 'odh-workbench-jupyter-pytorch-cuda-py312-v2-25'
+        - key: 'CVE-2026-27489' # https://redhat.atlassian.net/browse/RHOAIENG-56464
+          component: 'odh-workbench-jupyter-datascience-cpu-py312-v2-25'
+        - key: 'CVE-2026-27489' # https://redhat.atlassian.net/browse/RHOAIENG-56462
+          component: 'odh-workbench-codeserver-datascience-cpu-py312-v2-25'
+        - key: 'CVE-2026-27489' # https://redhat.atlassian.net/browse/RHOAIENG-56460
+          component: 'odh-pipeline-runtime-tensorflow-rocm-py312-v2-25'
+        - key: 'CVE-2026-27489' # https://redhat.atlassian.net/browse/RHOAIENG-56458
+          component: 'odh-pipeline-runtime-tensorflow-cuda-py312-v2-25'
+        - key: 'CVE-2026-27489' # https://redhat.atlassian.net/browse/RHOAIENG-56456
+          component: 'odh-pipeline-runtime-pytorch-rocm-py312-v2-25'
+        - key: 'CVE-2026-27489' # https://redhat.atlassian.net/browse/RHOAIENG-56454
+          component: 'odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v2-25'
+        - key: 'CVE-2026-27489' # https://redhat.atlassian.net/browse/RHOAIENG-56452
+          component: 'odh-pipeline-runtime-pytorch-cuda-py312-v2-25'
+        - key: 'CVE-2026-27489' # https://redhat.atlassian.net/browse/RHOAIENG-56450
+          component: 'odh-pipeline-runtime-datascience-cpu-py312-v2-25'
+        - key: 'CVE-2026-4800' # https://redhat.atlassian.net/browse/RHOAIENG-56397
+          component: 'odh-mod-arch-model-registry-v2-25'
+        - key: 'CVE-2026-4800' # https://redhat.atlassian.net/browse/RHOAIENG-56396
+          component: 'odh-dashboard-v2-25'
+        - key: 'CVE-2026-27893' # https://redhat.atlassian.net/browse/RHOAIENG-55678
+          component: 'odh-vllm-gaudi-v2-25'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55301
+          component: 'odh-workbench-jupyter-trustyai-cpu-py312-v2-25'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55300
+          component: 'odh-workbench-jupyter-tensorflow-rocm-py312-v2-25'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55299
+          component: 'odh-workbench-jupyter-tensorflow-cuda-py312-v2-25'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55298
+          component: 'odh-workbench-jupyter-pytorch-rocm-py312-v2-25'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55297
+          component: 'odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v2-25'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55296
+          component: 'odh-workbench-jupyter-pytorch-cuda-py312-v2-25'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55295
+          component: 'odh-workbench-jupyter-minimal-rocm-py312-v2-25'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55294
+          component: 'odh-workbench-jupyter-minimal-cuda-py312-v2-25'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55293
+          component: 'odh-workbench-jupyter-minimal-cpu-py312-v2-25'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55292
+          component: 'odh-workbench-jupyter-datascience-cpu-py312-v2-25'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55291
+          component: 'odh-workbench-codeserver-datascience-cpu-py312-v2-25'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55288
+          component: 'odh-pipeline-runtime-tensorflow-rocm-py312-v2-25'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55287
+          component: 'odh-pipeline-runtime-tensorflow-cuda-py312-v2-25'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55286
+          component: 'odh-pipeline-runtime-pytorch-rocm-py312-v2-25'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55285
+          component: 'odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v2-25'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55284
+          component: 'odh-pipeline-runtime-pytorch-cuda-py312-v2-25'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55283
+          component: 'odh-pipeline-runtime-minimal-cpu-py312-v2-25'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55282
+          component: 'odh-pipeline-runtime-datascience-cpu-py312-v2-25'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55268
+          component: 'odh-llm-d-inference-scheduler-v2-25'
+        - key: 'CVE-2026-29063' # https://redhat.atlassian.net/browse/RHOAIENG-55001
+          component: 'odh-mod-arch-model-registry-v2-25'
+        - key: 'CVE-2026-29063' # https://redhat.atlassian.net/browse/RHOAIENG-55000
+          component: 'odh-dashboard-v2-25'
+        - key: 'CVE-2026-33231' # https://redhat.atlassian.net/browse/RHOAIENG-54650
+          component: 'odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v2-25'
+        - key: 'CVE-2026-33231' # https://redhat.atlassian.net/browse/RHOAIENG-54648
+          component: 'odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v2-25'
+        - key: 'CVE-2026-28500' # https://redhat.atlassian.net/browse/RHOAIENG-54198
+          component: 'odh-workbench-jupyter-trustyai-cpu-py312-v2-25'
+        - key: 'CVE-2026-28500' # https://redhat.atlassian.net/browse/RHOAIENG-54197
+          component: 'odh-workbench-jupyter-tensorflow-rocm-py312-v2-25'
+        - key: 'CVE-2026-28500' # https://redhat.atlassian.net/browse/RHOAIENG-54196
+          component: 'odh-workbench-jupyter-tensorflow-cuda-py312-v2-25'
+        - key: 'CVE-2026-28500' # https://redhat.atlassian.net/browse/RHOAIENG-54195
+          component: 'odh-workbench-jupyter-pytorch-rocm-py312-v2-25'
+        - key: 'CVE-2026-28500' # https://redhat.atlassian.net/browse/RHOAIENG-54194
+          component: 'odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v2-25'
+        - key: 'CVE-2026-28500' # https://redhat.atlassian.net/browse/RHOAIENG-54193
+          component: 'odh-workbench-jupyter-pytorch-cuda-py312-v2-25'
+        - key: 'CVE-2026-28500' # https://redhat.atlassian.net/browse/RHOAIENG-54192
+          component: 'odh-workbench-jupyter-datascience-cpu-py312-v2-25'
+        - key: 'CVE-2026-28500' # https://redhat.atlassian.net/browse/RHOAIENG-54191
+          component: 'odh-workbench-codeserver-datascience-cpu-py312-v2-25'
+        - key: 'CVE-2026-28500' # https://redhat.atlassian.net/browse/RHOAIENG-54190
+          component: 'odh-pipeline-runtime-tensorflow-rocm-py312-v2-25'
+        - key: 'CVE-2026-28500' # https://redhat.atlassian.net/browse/RHOAIENG-54189
+          component: 'odh-pipeline-runtime-tensorflow-cuda-py312-v2-25'
+        - key: 'CVE-2026-28500' # https://redhat.atlassian.net/browse/RHOAIENG-54188
+          component: 'odh-pipeline-runtime-pytorch-rocm-py312-v2-25'
+        - key: 'CVE-2026-28500' # https://redhat.atlassian.net/browse/RHOAIENG-54187
+          component: 'odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v2-25'
+        - key: 'CVE-2026-28500' # https://redhat.atlassian.net/browse/RHOAIENG-54186
+          component: 'odh-pipeline-runtime-pytorch-cuda-py312-v2-25'
+        - key: 'CVE-2026-28500' # https://redhat.atlassian.net/browse/RHOAIENG-54185
+          component: 'odh-pipeline-runtime-datascience-cpu-py312-v2-25'
+        - key: 'CVE-2026-32981' # https://redhat.atlassian.net/browse/RHOAIENG-54028
+          component: 'odh-workbench-jupyter-trustyai-cpu-py312-v2-25'
+        - key: 'CVE-2026-32981' # https://redhat.atlassian.net/browse/RHOAIENG-54027
+          component: 'odh-workbench-jupyter-tensorflow-rocm-py312-v2-25'
+        - key: 'CVE-2026-32981' # https://redhat.atlassian.net/browse/RHOAIENG-54026
+          component: 'odh-workbench-jupyter-tensorflow-cuda-py312-v2-25'
+        - key: 'CVE-2026-32981' # https://redhat.atlassian.net/browse/RHOAIENG-54025
+          component: 'odh-workbench-jupyter-pytorch-rocm-py312-v2-25'
+        - key: 'CVE-2026-32981' # https://redhat.atlassian.net/browse/RHOAIENG-54024
+          component: 'odh-workbench-jupyter-pytorch-cuda-py312-v2-25'
+        - key: 'CVE-2026-32981' # https://redhat.atlassian.net/browse/RHOAIENG-54023
+          component: 'odh-workbench-jupyter-datascience-cpu-py312-v2-25'
+        - key: 'CVE-2026-32981' # https://redhat.atlassian.net/browse/RHOAIENG-54020
+          component: 'odh-pipeline-runtime-tensorflow-rocm-py312-v2-25'
+        - key: 'CVE-2026-32981' # https://redhat.atlassian.net/browse/RHOAIENG-54019
+          component: 'odh-pipeline-runtime-tensorflow-cuda-py312-v2-25'
+        - key: 'CVE-2026-32981' # https://redhat.atlassian.net/browse/RHOAIENG-54018
+          component: 'odh-pipeline-runtime-pytorch-rocm-py312-v2-25'
+        - key: 'CVE-2026-32981' # https://redhat.atlassian.net/browse/RHOAIENG-54017
+          component: 'odh-pipeline-runtime-pytorch-cuda-py312-v2-25'
+        - key: 'CVE-2026-32981' # https://redhat.atlassian.net/browse/RHOAIENG-54016
+          component: 'odh-pipeline-runtime-datascience-cpu-py312-v2-25'
+        - key: 'CVE-2026-29074' # https://redhat.atlassian.net/browse/RHOAIENG-53352
+          component: 'odh-mod-arch-model-registry-v2-25'
+        - key: 'CVE-2026-29074' # https://redhat.atlassian.net/browse/RHOAIENG-53351
+          component: 'odh-dashboard-v2-25'
+        - key: 'CVE-2026-32597' # https://redhat.atlassian.net/browse/RHOAIENG-53140
+          component: 'odh-vllm-gaudi-v2-25'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52807
+          component: 'odh-workbench-jupyter-trustyai-cpu-py312-v2-25'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52806
+          component: 'odh-workbench-jupyter-tensorflow-rocm-py312-v2-25'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52805
+          component: 'odh-workbench-jupyter-tensorflow-cuda-py312-v2-25'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52804
+          component: 'odh-workbench-jupyter-pytorch-rocm-py312-v2-25'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52803
+          component: 'odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v2-25'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52802
+          component: 'odh-workbench-jupyter-pytorch-cuda-py312-v2-25'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52801
+          component: 'odh-workbench-jupyter-minimal-rocm-py312-v2-25'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52800
+          component: 'odh-workbench-jupyter-minimal-cuda-py312-v2-25'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52799
+          component: 'odh-workbench-jupyter-minimal-cpu-py312-v2-25'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52798
+          component: 'odh-workbench-jupyter-datascience-cpu-py312-v2-25'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52797
+          component: 'odh-workbench-codeserver-datascience-cpu-py312-v2-25'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52796
+          component: 'odh-pipeline-runtime-tensorflow-rocm-py312-v2-25'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52795
+          component: 'odh-pipeline-runtime-tensorflow-cuda-py312-v2-25'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52794
+          component: 'odh-pipeline-runtime-pytorch-rocm-py312-v2-25'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52793
+          component: 'odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v2-25'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52792
+          component: 'odh-pipeline-runtime-pytorch-cuda-py312-v2-25'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52791
+          component: 'odh-pipeline-runtime-minimal-cpu-py312-v2-25'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52790
+          component: 'odh-pipeline-runtime-datascience-cpu-py312-v2-25'
+        - key: 'CVE-2026-25960' # https://redhat.atlassian.net/browse/RHOAIENG-52432
+          component: 'odh-vllm-gaudi-v2-25'
+        - key: 'CVE-2026-25048' # https://redhat.atlassian.net/browse/RHOAIENG-52051
+          component: 'odh-vllm-gaudi-v2-25'
+        - key: 'CVE-2025-69227' # https://redhat.atlassian.net/browse/RHOAIENG-49602
+          component: 'odh-caikit-nlp-v2-25'
+        - key: 'CVE-2025-69228' # https://redhat.atlassian.net/browse/RHOAIENG-49560
+          component: 'odh-caikit-nlp-v2-25'
+        - key: 'CVE-2025-61726' # https://redhat.atlassian.net/browse/RHOAIENG-48597
+          component: 'odh-llm-d-routing-sidecar-v2-25'
+        - key: 'CVE-2025-61726' # https://redhat.atlassian.net/browse/RHOAIENG-48596
+          component: 'odh-llm-d-inference-scheduler-v2-25'
+        - key: 'CVE-2025-61726' # https://redhat.atlassian.net/browse/RHOAIENG-48595
+          component: 'odh-llama-stack-k8s-operator-v2-25'
+        - key: 'CVE-2026-24747' # https://redhat.atlassian.net/browse/RHOAIENG-47902
+          component: 'odh-vllm-gaudi-v2-25'
+        - key: 'CVE-2025-48956' # https://redhat.atlassian.net/browse/RHOAIENG-41368
+          component: 'odh-vllm-cpu-v2-25'
+      issues:
+          fixed:
+            - id: RHOAIENG-59753
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59203
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-50153
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65960
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65951
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65936
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65935
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-62085
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-61152
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-61143
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-61089
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-61087
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-61003
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-61001
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-60995
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-60993
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-60583
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-60581
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-60265
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-60201
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-60200
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-60175
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-60174
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-60073
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-60072
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59714
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59712
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59275
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59270
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59229
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59219
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59215
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-58562
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-57855
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-57703
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-57649
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-57648
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56831
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56476
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56474
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56472
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56470
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56468
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56466
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56464
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56462
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56460
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56458
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56456
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56454
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56452
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56450
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56397
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56396
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55678
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55301
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55300
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55299
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55298
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55297
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55296
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55295
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55294
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55293
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55292
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55291
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55288
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55287
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55286
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55285
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55284
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55283
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55282
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55268
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55001
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55000
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54650
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54648
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54198
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54197
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54196
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54195
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54194
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54193
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54192
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54191
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54190
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54189
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54188
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54187
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54186
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54185
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54028
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54027
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54026
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54025
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54024
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54023
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54020
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54019
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54018
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54017
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54016
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-53352
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-53351
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-53140
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52807
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52806
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52805
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52804
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52803
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52802
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52801
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52800
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52799
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52798
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52797
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52796
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52795
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52794
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52793
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52792
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52791
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52790
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52432
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52051
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-49602
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-49560
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-48597
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-48596
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-48595
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-47902
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-41368
+              public: true
+              source: redhat.atlassian.net

--- a/release/2.25.7/prod/release-fbc/prod-release-fbc-ocp-416-rhoai-v2-25-1781006141.yaml
+++ b/release/2.25.7/prod/release-fbc/prod-release-fbc-ocp-416-rhoai-v2-25-1781006141.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-416-prod-1781006141
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 9628df633f53621ba4a485ea06f379a763c8c8d6
+    konflux-release-data/ocp-version: ocp-416
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: prod
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-416
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-416-fbc-prod
+  snapshot: rhoai-fbc-fragment-ocp-416-1781005297
+  data:
+    version: 2.25.7

--- a/release/2.25.7/prod/release-fbc/prod-release-fbc-ocp-417-rhoai-v2-25-1781006141.yaml
+++ b/release/2.25.7/prod/release-fbc/prod-release-fbc-ocp-417-rhoai-v2-25-1781006141.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-417-prod-1781006141
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 9628df633f53621ba4a485ea06f379a763c8c8d6
+    konflux-release-data/ocp-version: ocp-417
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: prod
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-417
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-417-fbc-prod
+  snapshot: rhoai-fbc-fragment-ocp-417-1781005297
+  data:
+    version: 2.25.7

--- a/release/2.25.7/prod/release-fbc/prod-release-fbc-ocp-418-rhoai-v2-25-1781006141.yaml
+++ b/release/2.25.7/prod/release-fbc/prod-release-fbc-ocp-418-rhoai-v2-25-1781006141.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-418-prod-1781006141
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 9628df633f53621ba4a485ea06f379a763c8c8d6
+    konflux-release-data/ocp-version: ocp-418
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: prod
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-418
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-418-fbc-prod
+  snapshot: rhoai-fbc-fragment-ocp-418-1781005297
+  data:
+    version: 2.25.7

--- a/release/2.25.7/prod/release-fbc/prod-release-fbc-ocp-419-rhoai-v2-25-1781006141.yaml
+++ b/release/2.25.7/prod/release-fbc/prod-release-fbc-ocp-419-rhoai-v2-25-1781006141.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-419-prod-1781006141
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 9628df633f53621ba4a485ea06f379a763c8c8d6
+    konflux-release-data/ocp-version: ocp-419
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: prod
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-419
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-419-fbc-prod
+  snapshot: rhoai-fbc-fragment-ocp-419-1781005297
+  data:
+    version: 2.25.7

--- a/release/2.25.7/prod/release-fbc/prod-release-fbc-ocp-420-rhoai-v2-25-1781006141.yaml
+++ b/release/2.25.7/prod/release-fbc/prod-release-fbc-ocp-420-rhoai-v2-25-1781006141.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-420-prod-1781006141
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 9628df633f53621ba4a485ea06f379a763c8c8d6
+    konflux-release-data/ocp-version: ocp-420
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: prod
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-420
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-420-fbc-prod
+  snapshot: rhoai-fbc-fragment-ocp-420-1781005297
+  data:
+    version: 2.25.7

--- a/release/2.25.7/prod/release-fbc/prod-release-fbc-ocp-421-rhoai-v2-25-1781006141.yaml
+++ b/release/2.25.7/prod/release-fbc/prod-release-fbc-ocp-421-rhoai-v2-25-1781006141.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-421-prod-1781006141
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 9628df633f53621ba4a485ea06f379a763c8c8d6
+    konflux-release-data/ocp-version: ocp-421
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: prod
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-421
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-421-fbc-prod
+  snapshot: rhoai-fbc-fragment-ocp-421-1781005297
+  data:
+    version: 2.25.7

--- a/release/2.25.7/stage/release-components/release-components-stage-rhoai-v2-25-1780517141.yaml
+++ b/release/2.25.7/stage/release-components/release-components-stage-rhoai-v2-25-1780517141.yaml
@@ -1,0 +1,16 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    appstudio.openshift.io/application: rhoai-v2-25
+    konflux-release-data/artifact-type: components
+    konflux-release-data/environment: stage
+    konflux-release-data/rbc-release-commit: 9628df633f53621ba4a485ea06f379a763c8c8d6
+  name: rhoai-v2-25-stage-1780517141
+  namespace: rhoai-tenant
+spec:
+  data:
+    version: 2.25.7
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-components-stage
+  snapshot: rhoai-v2-25-1780517141

--- a/release/2.25.7/stage/release-fbc/release-fbc-stage-ocp-416-rhoai-v2-25-1781005297.yaml
+++ b/release/2.25.7/stage/release-fbc/release-fbc-stage-ocp-416-rhoai-v2-25-1781005297.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-416-stage-1781005297
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 9628df633f53621ba4a485ea06f379a763c8c8d6
+    konflux-release-data/ocp-version: ocp-416
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-416
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-416-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-416-1781005297
+  data:
+    version: 2.25.7

--- a/release/2.25.7/stage/release-fbc/release-fbc-stage-ocp-417-rhoai-v2-25-1781005297.yaml
+++ b/release/2.25.7/stage/release-fbc/release-fbc-stage-ocp-417-rhoai-v2-25-1781005297.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-417-stage-1781005297
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 9628df633f53621ba4a485ea06f379a763c8c8d6
+    konflux-release-data/ocp-version: ocp-417
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-417
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-417-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-417-1781005297
+  data:
+    version: 2.25.7

--- a/release/2.25.7/stage/release-fbc/release-fbc-stage-ocp-418-rhoai-v2-25-1781005297.yaml
+++ b/release/2.25.7/stage/release-fbc/release-fbc-stage-ocp-418-rhoai-v2-25-1781005297.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-418-stage-1781005297
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 9628df633f53621ba4a485ea06f379a763c8c8d6
+    konflux-release-data/ocp-version: ocp-418
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-418
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-418-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-418-1781005297
+  data:
+    version: 2.25.7

--- a/release/2.25.7/stage/release-fbc/release-fbc-stage-ocp-419-rhoai-v2-25-1781005297.yaml
+++ b/release/2.25.7/stage/release-fbc/release-fbc-stage-ocp-419-rhoai-v2-25-1781005297.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-419-stage-1781005297
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 9628df633f53621ba4a485ea06f379a763c8c8d6
+    konflux-release-data/ocp-version: ocp-419
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-419
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-419-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-419-1781005297
+  data:
+    version: 2.25.7

--- a/release/2.25.7/stage/release-fbc/release-fbc-stage-ocp-420-rhoai-v2-25-1781005297.yaml
+++ b/release/2.25.7/stage/release-fbc/release-fbc-stage-ocp-420-rhoai-v2-25-1781005297.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-420-stage-1781005297
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 9628df633f53621ba4a485ea06f379a763c8c8d6
+    konflux-release-data/ocp-version: ocp-420
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-420
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-420-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-420-1781005297
+  data:
+    version: 2.25.7

--- a/release/2.25.7/stage/release-fbc/release-fbc-stage-ocp-421-rhoai-v2-25-1781005297.yaml
+++ b/release/2.25.7/stage/release-fbc/release-fbc-stage-ocp-421-rhoai-v2-25-1781005297.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-421-stage-1781005297
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 9628df633f53621ba4a485ea06f379a763c8c8d6
+    konflux-release-data/ocp-version: ocp-421
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-421
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-421-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-421-1781005297
+  data:
+    version: 2.25.7

--- a/release/2.25.7/stage/snapshot-components/snapshot-components-stage-rhoai-v2-25-1780517141.yaml
+++ b/release/2.25.7/stage/snapshot-components/snapshot-components-stage-rhoai-v2-25-1780517141.yaml
@@ -1,0 +1,474 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  labels:
+    konflux-release-data/artifact-type: components
+    konflux-release-data/rbc-release-commit: 9628df633f53621ba4a485ea06f379a763c8c8d6
+    test.appstudio.openshift.io/type: override
+  name: rhoai-v2-25-1780517141
+  namespace: rhoai-tenant
+spec:
+  application: rhoai-v2-25
+  components:
+  - containerImage: quay.io/rhoai/odh-operator-bundle@sha256:d6e42016a7fc3bfebcf2626faa3531505fa3c8eed551c20768378649cc89956a
+    name: odh-operator-bundle-v2-25
+    source:
+      git:
+        revision: 67df2cedec1da03aff17ace5076095ee15adf636
+        url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+  - containerImage: quay.io/rhoai/odh-built-in-detector-rhel9@sha256:a089ae1cfc2a5829b76700843cb067ed1f69b54c0937afc1a653975e223ccaec
+    name: odh-built-in-detector-v2-25
+    source:
+      git:
+        revision: f86096d70bd6c801cbd432634da2b784600d4be9
+        url: https://github.com/red-hat-data-services/guardrails-detectors
+  - containerImage: quay.io/rhoai/odh-caikit-nlp-rhel9@sha256:b20c8935671a7a13bc665a4bd741cda64bbf3c3920fc3202a50ed9e0621dc3aa
+    name: odh-caikit-nlp-v2-25
+    source:
+      git:
+        revision: f717aa377b9293795ff85917bdace8987312b1e0
+        url: https://github.com/red-hat-data-services/caikit-nlp
+  - containerImage: quay.io/rhoai/odh-caikit-tgis-serving-rhel9@sha256:54c1d8853bc4098760d0a9a81d3a44649b17947da1937b8fb09a9d3702400c9c
+    name: odh-caikit-tgis-serving-v2-25
+    source:
+      git:
+        revision: 5c8137fa65bbc2ed691c6aa2ee89e9807f0c776f
+        url: https://github.com/red-hat-data-services/caikit-tgis-serving
+  - containerImage: quay.io/rhoai/odh-codeflare-operator-rhel9@sha256:8bcd4025d48f85e12b50c3afdb89ab18af38a65ab54c6aace93447eaa84a1f1a
+    name: odh-codeflare-operator-v2-25
+    source:
+      git:
+        revision: d0b93c3a0728bf1908be78a561dc17ae8a666023
+        url: https://github.com/red-hat-data-services/codeflare-operator
+  - containerImage: quay.io/rhoai/odh-dashboard-rhel9@sha256:5ee6a3378deedf683b063073364380f9c00c35a32efad9ca567fd092db778b56
+    name: odh-dashboard-v2-25
+    source:
+      git:
+        revision: ee3c234d74eb3824ab1dce19276549a87389eff1
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-data-science-pipelines-argo-argoexec-rhel9@sha256:96383f7e21d05aedd5b07910c9126f15faa0097c2abc34dbbfcd35282d5c6bb5
+    name: odh-data-science-pipelines-argo-argoexec-v2-25
+    source:
+      git:
+        revision: aa05360dd1c56978d74a66bd500c55aeea58517d
+        url: https://github.com/red-hat-data-services/argo-workflows
+  - containerImage: quay.io/rhoai/odh-data-science-pipelines-argo-workflowcontroller-rhel9@sha256:00fbab61904284011cafc8d0da03a630fa0e2c2c51c91e9d10ad5d7cfc4b140f
+    name: odh-data-science-pipelines-argo-workflowcontroller-v2-25
+    source:
+      git:
+        revision: aa05360dd1c56978d74a66bd500c55aeea58517d
+        url: https://github.com/red-hat-data-services/argo-workflows
+  - containerImage: quay.io/rhoai/odh-data-science-pipelines-operator-controller-rhel9@sha256:ac320384623911fa198eb2d10930b6e4c2d075f663795675d7f0ff79989abd26
+    name: odh-data-science-pipelines-operator-controller-v2-25
+    source:
+      git:
+        revision: 1ccf19a7a91b5a46dfc99324d143550b18bdb23d
+        url: https://github.com/red-hat-data-services/data-science-pipelines-operator
+  - containerImage: quay.io/rhoai/odh-feast-operator-rhel9@sha256:297337cf1f1724e86651b03ce3d9f8e4ac36e66a4c530381d62bcd702cded4b7
+    name: odh-feast-operator-v2-25
+    source:
+      git:
+        revision: 967f901e3534287b0689aa295e2528f339587a14
+        url: https://github.com/red-hat-data-services/feast
+  - containerImage: quay.io/rhoai/odh-feature-server-rhel9@sha256:a8bbf30998057b5d5186baf6215e92972f82f16a41d37525796e6de9089c2030
+    name: odh-feature-server-v2-25
+    source:
+      git:
+        revision: 967f901e3534287b0689aa295e2528f339587a14
+        url: https://github.com/red-hat-data-services/feast
+  - containerImage: quay.io/rhoai/odh-fms-guardrails-orchestrator-rhel9@sha256:dd695223d4e556463f9b9756e775c9fff0945fd3dbcfa8fb76baed393aaab52e
+    name: odh-fms-guardrails-orchestrator-v2-25
+    source:
+      git:
+        revision: 31cb15a0d4c07e89b68a5bac9c85b356b648e3e5
+        url: https://github.com/red-hat-data-services/fms-guardrails-orchestrator
+  - containerImage: quay.io/rhoai/odh-guardrails-detector-huggingface-runtime-rhel9@sha256:079d8b6a770fd05fa1f63d36dc4933cb76d2cec4cf97a8ce80a9aa376211bf7c
+    name: odh-guardrails-detector-huggingface-runtime-v2-25
+    source:
+      git:
+        revision: f86096d70bd6c801cbd432634da2b784600d4be9
+        url: https://github.com/red-hat-data-services/guardrails-detectors
+  - containerImage: quay.io/rhoai/odh-kf-notebook-controller-rhel9@sha256:e9e3a55eb3b75298bb6ace5572e60b94f7e65482db6957e614677039b31f0332
+    name: odh-kf-notebook-controller-v2-25
+    source:
+      git:
+        revision: 671bc08eba5a7d628d813d5e9cf118f0e61ec41b
+        url: https://github.com/red-hat-data-services/kubeflow
+  - containerImage: quay.io/rhoai/odh-kserve-agent-rhel9@sha256:387945cf4e280f9cdc4fe5e1f55e7214cd9b181807d421d38a1519abca21a12a
+    name: odh-kserve-agent-v2-25
+    source:
+      git:
+        revision: dc3334efe6ba168aeb0a13256a2df183de80d483
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kserve-controller-rhel9@sha256:26010c2d3255be7241c83a0b65be427a48e758433baa8a0e9d5f959cb960622e
+    name: odh-kserve-controller-v2-25
+    source:
+      git:
+        revision: dc3334efe6ba168aeb0a13256a2df183de80d483
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kserve-router-rhel9@sha256:c326c71ea96b936e26809d38722f9d443638bedb66b0099e62c58e7d27c87db7
+    name: odh-kserve-router-v2-25
+    source:
+      git:
+        revision: dc3334efe6ba168aeb0a13256a2df183de80d483
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kserve-storage-initializer-rhel9@sha256:0e900505bb5033e6e9dbc9bb096ee97cdd5abe5bb2030c0d53334b66916476b5
+    name: odh-kserve-storage-initializer-v2-25
+    source:
+      git:
+        revision: 1a311bcca240ae9c92bc4a57ca003f67b4a8934e
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kuberay-operator-controller-rhel9@sha256:7d4ec03db9848e028a2112bae79e5c4919c459955bd54b38f42da8d11cc7b55d
+    name: odh-kuberay-operator-controller-v2-25
+    source:
+      git:
+        revision: d07b8528050d28991b8288fef5016e56e7acad8b
+        url: https://github.com/red-hat-data-services/kuberay
+  - containerImage: quay.io/rhoai/odh-kueue-controller-rhel9@sha256:dfd399b693842255d830d0bb3bea421a6cb23888268131e9bc13975ef5460340
+    name: odh-kueue-controller-v2-25
+    source:
+      git:
+        revision: 9415c617e2479800ac5744338630933742f9bbc7
+        url: https://github.com/red-hat-data-services/kueue
+  - containerImage: quay.io/rhoai/odh-llama-stack-core-rhel9@sha256:379078612fb2fc62806986cb5e80711d1282bae86939fa1a8ca5d5889f9d4e53
+    name: odh-llama-stack-core-v2-25
+    source:
+      git:
+        revision: 0d68e1fd7f73b166faed37222d55e23debff9b81
+        url: https://gitlab.com/redhat/rhel-ai/llama-stack/containers
+  - containerImage: quay.io/rhoai/odh-llama-stack-k8s-operator-rhel9@sha256:bab3707c09662bbc700a008690624ac4ed2fd325ed77093348db2782e8b0681b
+    name: odh-llama-stack-k8s-operator-v2-25
+    source:
+      git:
+        revision: 9296630bc7ba58c3a1eefad11799320fde35601e
+        url: https://github.com/red-hat-data-services/ogx-k8s-operator
+  - containerImage: quay.io/rhoai/odh-llm-d-inference-scheduler-rhel9@sha256:0638c23b9554fad1e358adbd4ff2225c3932dd7df0a88b08ee2d88f5ee80233c
+    name: odh-llm-d-inference-scheduler-v2-25
+    source:
+      git:
+        revision: 53251d9749d6ac36df29eaf083c30fa26aff5c1a
+        url: https://github.com/red-hat-data-services/llm-d-inference-scheduler
+  - containerImage: quay.io/rhoai/odh-llm-d-routing-sidecar-rhel9@sha256:236b28529f859eae92e605d2f563d868ec9ebe520846acbadc3f9ef221245916
+    name: odh-llm-d-routing-sidecar-v2-25
+    source:
+      git:
+        revision: 0eb55c63e837119bd2833571a566625bf2cccb60
+        url: https://github.com/red-hat-data-services/llm-d-routing-sidecar
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-api-server-v2-rhel9@sha256:8bab6324dd47862d5a878c816fcbc418f0534b367eebe93b54464da2ccb0e9e3
+    name: odh-ml-pipelines-api-server-v2-v2-25
+    source:
+      git:
+        revision: 9b03c785ea10cd9faeb461c27ca5024f09702f79
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-driver-rhel9@sha256:ffd840809fe80c9c191ddfba315081ae5f0fff93982ee474fe3ee1e78e104bba
+    name: odh-ml-pipelines-driver-v2-25
+    source:
+      git:
+        revision: 9b03c785ea10cd9faeb461c27ca5024f09702f79
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-launcher-rhel9@sha256:bcd9671c85006fd60f644782a99a2b3a8787a1a481f93310a1c91a9d844ded53
+    name: odh-ml-pipelines-launcher-v2-25
+    source:
+      git:
+        revision: 9b03c785ea10cd9faeb461c27ca5024f09702f79
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-persistenceagent-v2-rhel9@sha256:55b68243b57776489f95a146ae28c15b7e3944203fb1a0bf4ac38bd1246615ed
+    name: odh-ml-pipelines-persistenceagent-v2-v2-25
+    source:
+      git:
+        revision: 9b03c785ea10cd9faeb461c27ca5024f09702f79
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-runtime-generic-rhel9@sha256:364ec0ec369eb9614fc678e7d0dd0138ab0130d7e9ff279cfc97430dd41d0541
+    name: odh-ml-pipelines-runtime-generic-v2-25
+    source:
+      git:
+        revision: 62e8ee7774cf4dca5ca102a13a81222e8993e963
+        url: https://github.com/red-hat-data-services/ilab-on-ocp
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-scheduledworkflow-v2-rhel9@sha256:29d467140448f0df942df8c8e57f9d6a03621d5602c16778339564b030ca38f3
+    name: odh-ml-pipelines-scheduledworkflow-v2-v2-25
+    source:
+      git:
+        revision: 9b03c785ea10cd9faeb461c27ca5024f09702f79
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-mlmd-grpc-server-rhel9@sha256:a46326a62d6c4a326e2bc542daecb04ed4ad65179f8744d6878fe4a19e4c5eec
+    name: odh-mlmd-grpc-server-v2-25
+    source:
+      git:
+        revision: 321dda7d987866c6521a620a923d430a9fe0810c
+        url: https://github.com/red-hat-data-services/ml-metadata
+  - containerImage: quay.io/rhoai/odh-mm-rest-proxy-rhel9@sha256:42c67780c9fe74eaf986095948fed3b61acd63bba7247654c8581b987b402c59
+    name: odh-mm-rest-proxy-v2-25
+    source:
+      git:
+        revision: 924396a701997291db102537550f87513a07af02
+        url: https://github.com/red-hat-data-services/rest-proxy
+  - containerImage: quay.io/rhoai/odh-mod-arch-model-registry-rhel9@sha256:c19fd5916821cc499b516807cf680d8a1657d3f147deb70f9ee2850e4d43dade
+    name: odh-mod-arch-model-registry-v2-25
+    source:
+      git:
+        revision: ee3c234d74eb3824ab1dce19276549a87389eff1
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-model-controller-rhel9@sha256:d856002a6b40047d788b4b55ecd4cebfd33f00e88e60c210cd7df7b02deb5a67
+    name: odh-model-controller-v2-25
+    source:
+      git:
+        revision: 9ae0dbc171b9489a28816a2725e5fd175fa2a0ca
+        url: https://github.com/red-hat-data-services/odh-model-controller
+  - containerImage: quay.io/rhoai/odh-model-metadata-collection-rhel9@sha256:93ebb6d1c8d9a03b8787812d8d60eccfc629bbb911eb94b93ca7178548d6ed0c
+    name: odh-model-metadata-collection-v2-25
+    source:
+      git:
+        revision: 8f5d6c7d9ff493632913c2168c800c8d20a2c30a
+        url: https://github.com/red-hat-data-services/model-metadata-collection
+  - containerImage: quay.io/rhoai/odh-model-registry-job-async-upload-rhel9@sha256:7220f6957e6f1ebc7cc5c5ed7657a49bc8ec8305b63685e522ee377d332bc8df
+    name: odh-model-registry-job-async-upload-v2-25
+    source:
+      git:
+        revision: 9917cb03ddd9a39493c7fb378b4053c270384053
+        url: https://github.com/red-hat-data-services/model-registry
+  - containerImage: quay.io/rhoai/odh-model-registry-operator-rhel9@sha256:5bdfb3a8e8d276be0085a35d10f0dd6f6f7742ae4f3fb06b7165fd474d2b7ea8
+    name: odh-model-registry-operator-v2-25
+    source:
+      git:
+        revision: 8d8d16e40ec6135e8634827aec99b65a15bd4911
+        url: https://github.com/red-hat-data-services/model-registry-operator
+  - containerImage: quay.io/rhoai/odh-model-registry-rhel9@sha256:731768b3d0fafc6e1dc11921b240132cdfcbf060857a696cede2ac14b2e29cf4
+    name: odh-model-registry-v2-25
+    source:
+      git:
+        revision: 9917cb03ddd9a39493c7fb378b4053c270384053
+        url: https://github.com/red-hat-data-services/model-registry
+  - containerImage: quay.io/rhoai/odh-modelmesh-rhel9@sha256:3de1ae27e1ba67289aab5f7a700abdc429160468f032ca28602b20aaaae9adde
+    name: odh-modelmesh-v2-25
+    source:
+      git:
+        revision: 6a84d26aead05e1b671c95a97e867f42685a60d9
+        url: https://github.com/red-hat-data-services/modelmesh
+  - containerImage: quay.io/rhoai/odh-modelmesh-runtime-adapter-rhel9@sha256:7595fc5261733845e78ec86b48077b9a58882c412b14db1e0cca257ff92036a5
+    name: odh-modelmesh-runtime-adapter-v2-25
+    source:
+      git:
+        revision: 78d719b2ba9ee0667a10d520e9c3ff234b65323e
+        url: https://github.com/red-hat-data-services/modelmesh-runtime-adapter
+  - containerImage: quay.io/rhoai/odh-modelmesh-serving-controller-rhel9@sha256:7ae7d0235e33751dbeee1821d211c2fc39a594ffdf7bae0f4e7554aaa004845a
+    name: odh-modelmesh-serving-controller-v2-25
+    source:
+      git:
+        revision: ec2c888a26e155ad1b18ca18b4a0ba5003029852
+        url: https://github.com/red-hat-data-services/modelmesh-serving
+  - containerImage: quay.io/rhoai/odh-must-gather-rhel9@sha256:b3feaa60abaaa3993e889196629600725f4b513b0407bdeb2cdb454f77da5b21
+    name: odh-must-gather-v2-25
+    source:
+      git:
+        revision: bd49faec14128555f06a9d5d9b162ead66c4415c
+        url: https://github.com/red-hat-data-services/must-gather
+  - containerImage: quay.io/rhoai/odh-notebook-controller-rhel9@sha256:4166a280323daaba576f03e4a2c29bb0bba00e41f8800336a99741794a97d03c
+    name: odh-notebook-controller-v2-25
+    source:
+      git:
+        revision: 671bc08eba5a7d628d813d5e9cf118f0e61ec41b
+        url: https://github.com/red-hat-data-services/kubeflow
+  - containerImage: quay.io/rhoai/odh-openvino-model-server-rhel9@sha256:15ea6a15523d5cc48057b3604c9c3332bc2be78f08925380ab084dd84eac9f07
+    name: odh-openvino-model-server-v2-25
+    source:
+      git:
+        revision: 3fc41e2b2aedfad7f60c1ebcdab3cd46448a63fe
+        url: https://github.com/red-hat-data-services/openvino_model_server
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-datascience-cpu-py312-rhel9@sha256:22ea9fc4352ec427a240fb983afb0ad3e7c1b2f2dc97bce4587695777f23ef07
+    name: odh-pipeline-runtime-datascience-cpu-py312-v2-25
+    source:
+      git:
+        revision: c985e1117cea03fb07cffb39afc6fe383404361c
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-minimal-cpu-py312-rhel9@sha256:d3d4d82d0685feb25ec91cf8928dc5c5859436f44a21cd93b5d2ce7c1869a603
+    name: odh-pipeline-runtime-minimal-cpu-py312-v2-25
+    source:
+      git:
+        revision: 1157e7cd93e9e23faf170bb22e04b4bca884f085
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-pytorch-cuda-py312-rhel9@sha256:8b059881d8d7ef85883c7672a4464368ae564f2ce6104d54ebb03ac5d152d536
+    name: odh-pipeline-runtime-pytorch-cuda-py312-v2-25
+    source:
+      git:
+        revision: c985e1117cea03fb07cffb39afc6fe383404361c
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9@sha256:7c2ce6c9e93266a11cbfdef8b3abbeb9ffd13f983b9fb3a091607d1065d597e0
+    name: odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v2-25
+    source:
+      git:
+        revision: 1157e7cd93e9e23faf170bb22e04b4bca884f085
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9@sha256:d9c32296f9b8b6b9b0fccaafe0e910d96e3e700fa14876f19ad7570523b4b384
+    name: odh-pipeline-runtime-pytorch-rocm-py312-v2-25
+    source:
+      git:
+        revision: c985e1117cea03fb07cffb39afc6fe383404361c
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9@sha256:917272fc0483b20ac426626f5ee5bcdcbc4c88b5bbdbf00cf00a7a59d6bf5686
+    name: odh-pipeline-runtime-tensorflow-cuda-py312-v2-25
+    source:
+      git:
+        revision: c985e1117cea03fb07cffb39afc6fe383404361c
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9@sha256:a4cfdf3f66e855efd3809f83e806becd5f30a8e18e73ef157f81aab37f07cd47
+    name: odh-pipeline-runtime-tensorflow-rocm-py312-v2-25
+    source:
+      git:
+        revision: ccb862536acfc05f9ebc881aa05875c941e77567
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-rhel9-operator@sha256:63a3ae94bd9425c74f90c144750eeffef8dccf401cd0657eafc55f9cb46b8ebb
+    name: odh-operator-v2-25
+    source:
+      git:
+        revision: 0cb55b458f4009a7b8b0e6fe1cef0622c352bdc9
+        url: https://github.com/red-hat-data-services/rhods-operator
+  - containerImage: quay.io/rhoai/odh-ta-lmes-driver-rhel9@sha256:9655833e0ec7682fbe9d8e601bc9277c21416825d1b112b73c9a9a6e2c94ab44
+    name: odh-ta-lmes-driver-v2-25
+    source:
+      git:
+        revision: 38b4755930ced80fdfa34d256a6a1e6f3482cbbf
+        url: https://github.com/red-hat-data-services/trustyai-service-operator
+  - containerImage: quay.io/rhoai/odh-ta-lmes-job-rhel9@sha256:282488d52c9732dafa16ec35d1d84cab00c089e5df7e884077bc5b6859faefd4
+    name: odh-ta-lmes-job-v2-25
+    source:
+      git:
+        revision: 5a0991a10b1ca7c8fd0d990831986f1a0c703b50
+        url: https://github.com/red-hat-data-services/lm-evaluation-harness
+  - containerImage: quay.io/rhoai/odh-training-cuda121-torch24-py311-rhel9@sha256:be1c91897064f7a96afbd2c01e20561b703d415a1643ff61bb1b45d64479ebf2
+    name: odh-training-cuda121-torch24-py311-v2-25
+    source:
+      git:
+        revision: eec522876beb6d4fe545cdd49059216ed97df364
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-cuda124-torch25-py311-rhel9@sha256:930a1375fef224ef4e6765b60fe4bef9ee9ef87757d22bb39eb99197e0663219
+    name: odh-training-cuda124-torch25-py311-v2-25
+    source:
+      git:
+        revision: eec522876beb6d4fe545cdd49059216ed97df364
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-operator-rhel9@sha256:664c8467ad174edd76fa8d9595faf82dd643d3483482076d06da05ff3ffc79dc
+    name: odh-training-operator-v2-25
+    source:
+      git:
+        revision: 90d579c0d86b0fffde714cde86e65b01dfcff93d
+        url: https://github.com/red-hat-data-services/training-operator
+  - containerImage: quay.io/rhoai/odh-training-rocm62-torch24-py311-rhel9@sha256:671ce8e0a24a9aef775e8ed02ab584ff311428770fb683b77040bdf8b4d3450b
+    name: odh-training-rocm62-torch24-py311-v2-25
+    source:
+      git:
+        revision: eec522876beb6d4fe545cdd49059216ed97df364
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-rocm62-torch25-py311-rhel9@sha256:b5cc47cd2ee1d6d0fb8e8e40dbd8071db54b80920ac284a8570dcd6a01f059db
+    name: odh-training-rocm62-torch25-py311-v2-25
+    source:
+      git:
+        revision: eec522876beb6d4fe545cdd49059216ed97df364
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-trustyai-service-operator-rhel9@sha256:6b265c84e47df636c961f9fd7f0ce0345dd19f7dd70b1c1ede7d2fd2717a808c
+    name: odh-trustyai-service-operator-v2-25
+    source:
+      git:
+        revision: 38b4755930ced80fdfa34d256a6a1e6f3482cbbf
+        url: https://github.com/red-hat-data-services/trustyai-service-operator
+  - containerImage: quay.io/rhoai/odh-trustyai-service-rhel9@sha256:ed2ba760e0e61c327b94d2ba1da45cc3f7e3a5540a9da378662436e7eedfb183
+    name: odh-trustyai-service-v2-25
+    source:
+      git:
+        revision: 08e7ca16fc1a75650699fdc6425affa15a7c6dae
+        url: https://github.com/red-hat-data-services/trustyai-explainability
+  - containerImage: quay.io/rhoai/odh-trustyai-vllm-orchestrator-gateway-rhel9@sha256:19d01f86cc6d23f6c2c155d793d3c2cba3eb527c8ecf74a5e942a95f2508bc4f
+    name: odh-trustyai-vllm-orchestrator-gateway-v2-25
+    source:
+      git:
+        revision: 0b8c3ad7ad0f933b36368ac04c1c071c56b77b05
+        url: https://github.com/red-hat-data-services/vllm-orchestrator-gateway
+  - containerImage: quay.io/rhoai/odh-vllm-cpu-rhel9@sha256:1b9c60c11616d88397088f2fdebb7427137fd4e7120c687053a530d7a4f024bf
+    name: odh-vllm-cpu-v2-25
+    source:
+      git:
+        revision: 75a6c76d633217d1eb328a5732e8b25f1966b14c
+        url: https://github.com/red-hat-data-services/vllm-cpu
+  - containerImage: quay.io/rhoai/odh-vllm-cuda-rhel9@sha256:00ecb72d83019274410077c4bdf00138d3dce02be697c883745f4f8d970a5c9b
+    name: odh-vllm-cuda-v2-25
+    source:
+      git:
+        revision: a6bc96e584d2b836b073ce7cc3ae82aa2ab1f1d9
+        url: https://github.com/red-hat-data-services/vllm
+  - containerImage: quay.io/rhoai/odh-vllm-gaudi-rhel9@sha256:d0dd4c5a6f174373ba9431eb2d148702966233909591d7c5583bdbf69e0d2a41
+    name: odh-vllm-gaudi-v2-25
+    source:
+      git:
+        revision: 64586b7488ff846265885f294937c68f3c7dcca5
+        url: https://github.com/red-hat-data-services/vllm-gaudi
+  - containerImage: quay.io/rhoai/odh-vllm-rocm-rhel9@sha256:24d70a19bf54f1c3863c14d69a83b709f86c2333b6850f32212f4599db1c2429
+    name: odh-vllm-rocm-v2-25
+    source:
+      git:
+        revision: ac9ec756f29f47ae7587ce571c8cf38dcc9ad7da
+        url: https://github.com/red-hat-data-services/vllm-rocm
+  - containerImage: quay.io/rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9@sha256:923067e88b0d26a1f2253c5fa34dec2a31ade4034e670d8405b2aa85b364f4c6
+    name: odh-workbench-codeserver-datascience-cpu-py312-v2-25
+    source:
+      git:
+        revision: c985e1117cea03fb07cffb39afc6fe383404361c
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9@sha256:89011c558f155aeb474826527138e223c9d3a3fdbd1df7a098dfe5bf826fa8e0
+    name: odh-workbench-jupyter-datascience-cpu-py312-v2-25
+    source:
+      git:
+        revision: 1157e7cd93e9e23faf170bb22e04b4bca884f085
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9@sha256:fa2ec03e86f45806f79c84596df4e074403e2977e9e8356289c00c219ae3e46a
+    name: odh-workbench-jupyter-minimal-cpu-py312-v2-25
+    source:
+      git:
+        revision: 1157e7cd93e9e23faf170bb22e04b4bca884f085
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9@sha256:0e349ff5100eb54c7c8cd3bf7d90db81301e49a4231172ad151970d62d46e22f
+    name: odh-workbench-jupyter-minimal-cuda-py312-v2-25
+    source:
+      git:
+        revision: 1157e7cd93e9e23faf170bb22e04b4bca884f085
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9@sha256:f05087144bea34302ec8c15022f090dacd19a274a9404e4d00b844d4f8e08a37
+    name: odh-workbench-jupyter-minimal-rocm-py312-v2-25
+    source:
+      git:
+        revision: 1157e7cd93e9e23faf170bb22e04b4bca884f085
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9@sha256:206236a41d7ea0adfd24cdf9df82f9d00c8196ee55ddb6bfcef25b9f431ddbf1
+    name: odh-workbench-jupyter-pytorch-cuda-py312-v2-25
+    source:
+      git:
+        revision: c985e1117cea03fb07cffb39afc6fe383404361c
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9@sha256:44a6de4fbff84b3a567e81184901dd3c8a93c425f6cb21851b55401b6b2bf293
+    name: odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v2-25
+    source:
+      git:
+        revision: 1157e7cd93e9e23faf170bb22e04b4bca884f085
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9@sha256:5927e85b64fcd3fb53dcace71ef9497a460e5401cddf3c6ffd60f3f2c0bccf2c
+    name: odh-workbench-jupyter-pytorch-rocm-py312-v2-25
+    source:
+      git:
+        revision: c985e1117cea03fb07cffb39afc6fe383404361c
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9@sha256:10d57a73bd566723a06a558f61e2314379fd3ddf0963e33fe8a2eb3c5aa3168f
+    name: odh-workbench-jupyter-tensorflow-cuda-py312-v2-25
+    source:
+      git:
+        revision: c985e1117cea03fb07cffb39afc6fe383404361c
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9@sha256:50d971f43bb01bc477091e25475e925b3d22977500fe5d9c270c6a11ae1a6f76
+    name: odh-workbench-jupyter-tensorflow-rocm-py312-v2-25
+    source:
+      git:
+        revision: c985e1117cea03fb07cffb39afc6fe383404361c
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9@sha256:f7da3c23a72cbec025f364fc2fbaac4c82e8b731703b9220dc3ee4b6c91b81e7
+    name: odh-workbench-jupyter-trustyai-cpu-py312-v2-25
+    source:
+      git:
+        revision: 1157e7cd93e9e23faf170bb22e04b4bca884f085
+        url: https://github.com/red-hat-data-services/notebooks

--- a/release/2.25.7/stage/snapshot-fbc/snapshot-fbc-stage-ocp-416-rhoai-v2-25-1781005297.yaml
+++ b/release/2.25.7/stage/snapshot-fbc/snapshot-fbc-stage-ocp-416-rhoai-v2-25-1781005297.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-416-1781005297
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 9628df633f53621ba4a485ea06f379a763c8c8d6
+    konflux-release-data/ocp-version: ocp-416
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-416
+  components:
+    - name: rhoai-fbc-fragment-ocp-416
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:88bc37ea890e4cf3af04b135611a12ff6becd15dd37cc0b906d9c321eb1ce059
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: 219902bcb43c310ebb10d688b8079d77937b3b6a

--- a/release/2.25.7/stage/snapshot-fbc/snapshot-fbc-stage-ocp-417-rhoai-v2-25-1781005297.yaml
+++ b/release/2.25.7/stage/snapshot-fbc/snapshot-fbc-stage-ocp-417-rhoai-v2-25-1781005297.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-417-1781005297
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 9628df633f53621ba4a485ea06f379a763c8c8d6
+    konflux-release-data/ocp-version: ocp-417
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-417
+  components:
+    - name: rhoai-fbc-fragment-ocp-417
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:598e398e2a852ffbe21fd6cdb8acaaeadedac3b33e262b00b99bd241d01d17af
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: 219902bcb43c310ebb10d688b8079d77937b3b6a

--- a/release/2.25.7/stage/snapshot-fbc/snapshot-fbc-stage-ocp-418-rhoai-v2-25-1781005297.yaml
+++ b/release/2.25.7/stage/snapshot-fbc/snapshot-fbc-stage-ocp-418-rhoai-v2-25-1781005297.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-418-1781005297
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 9628df633f53621ba4a485ea06f379a763c8c8d6
+    konflux-release-data/ocp-version: ocp-418
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-418
+  components:
+    - name: rhoai-fbc-fragment-ocp-418
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:19a45ef6b200e7795ac22ab7bd7903bf9d72cfe25e885e17b4611ea6f4e948d6
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: 219902bcb43c310ebb10d688b8079d77937b3b6a

--- a/release/2.25.7/stage/snapshot-fbc/snapshot-fbc-stage-ocp-419-rhoai-v2-25-1781005297.yaml
+++ b/release/2.25.7/stage/snapshot-fbc/snapshot-fbc-stage-ocp-419-rhoai-v2-25-1781005297.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-419-1781005297
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 9628df633f53621ba4a485ea06f379a763c8c8d6
+    konflux-release-data/ocp-version: ocp-419
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-419
+  components:
+    - name: rhoai-fbc-fragment-ocp-419
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:0b3102c96aa4807186291d08b0cb5ef2e1f0ece0c4ff5d75142efa8a6a8baf1c
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: 219902bcb43c310ebb10d688b8079d77937b3b6a

--- a/release/2.25.7/stage/snapshot-fbc/snapshot-fbc-stage-ocp-420-rhoai-v2-25-1781005297.yaml
+++ b/release/2.25.7/stage/snapshot-fbc/snapshot-fbc-stage-ocp-420-rhoai-v2-25-1781005297.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-420-1781005297
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 9628df633f53621ba4a485ea06f379a763c8c8d6
+    konflux-release-data/ocp-version: ocp-420
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-420
+  components:
+    - name: rhoai-fbc-fragment-ocp-420
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:0172a95ce5451f9d3e79ce5f7675a2b193d2a4908b2652c9563aa105993854b1
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: 219902bcb43c310ebb10d688b8079d77937b3b6a

--- a/release/2.25.7/stage/snapshot-fbc/snapshot-fbc-stage-ocp-421-rhoai-v2-25-1781005297.yaml
+++ b/release/2.25.7/stage/snapshot-fbc/snapshot-fbc-stage-ocp-421-rhoai-v2-25-1781005297.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-421-1781005297
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 9628df633f53621ba4a485ea06f379a763c8c8d6
+    konflux-release-data/ocp-version: ocp-421
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-421
+  components:
+    - name: rhoai-fbc-fragment-ocp-421
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:a89c9e3c68f8bbf1e9b0ef8c52e3d227c2842cf756ae16c90852f18c0196eea0
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: 219902bcb43c310ebb10d688b8079d77937b3b6a


### PR DESCRIPTION
## Summary

Stage and prod release artifacts for RHOAI 2.25.7 (21 files), matching the structure of release/2.25.6.

## Artifacts

| Type | Source | Epoch | Files |
|------|--------|-------|-------|
| prod/release-components | prod-release-1781006141 | 1781006141 | 1 |
| prod/release-fbc | prod-release-1781006141 | 1781006141 | 6 (ocp 4.16-4.21) |
| stage/release-components | GHA run 26909774174 | 1780517141 | 1 |
| stage/release-fbc | Local run (GHA fbc-build failed) | 1781005297 | 6 (ocp 4.16-4.21) |
| stage/snapshot-components | GHA run 26909774174 | 1780517141 | 1 |
| stage/snapshot-fbc | Local run (GHA fbc-build failed) | 1781005297 | 6 (ocp 4.16-4.21) |

## Sources

- Stage components: https://github.com/red-hat-data-services/rhods-devops-infra/actions/runs/26909774174
- Stage FBC: Generated locally (stage promoter fbc-build step failed)
- Prod: rhods-devops-infra/tools/rhoai-release-helper/prod-release-1781006141