### PR TITLE
Add odh-authbridge-proxy to bundle-patch.yaml

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -197,6 +197,8 @@ ARG ODH_MOD_ARCH_AGENT_OPS_GIT_URL=
 ARG ODH_MOD_ARCH_AGENT_OPS_GIT_COMMIT=
 ARG ODH_AI_GATEWAY_OPERATOR_GIT_URL=
 ARG ODH_AI_GATEWAY_OPERATOR_GIT_COMMIT=
+ARG ODH_AUTHBRIDGE_PROXY_GIT_URL=
+ARG ODH_AUTHBRIDGE_PROXY_GIT_COMMIT=
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -408,7 +410,9 @@ LABEL \
       odh-mod-arch-agent-ops.git.url="${ODH_MOD_ARCH_AGENT_OPS_GIT_URL}" \
       odh-mod-arch-agent-ops.git.commit="${ODH_MOD_ARCH_AGENT_OPS_GIT_COMMIT}" \
       odh-ai-gateway-operator.git.url="${ODH_AI_GATEWAY_OPERATOR_GIT_URL}" \
-      odh-ai-gateway-operator.git.commit="${ODH_AI_GATEWAY_OPERATOR_GIT_COMMIT}"
+      odh-ai-gateway-operator.git.commit="${ODH_AI_GATEWAY_OPERATOR_GIT_COMMIT}" \
+      odh-authbridge-proxy.git.url="${ODH_AUTHBRIDGE_PROXY_GIT_URL}" \
+      odh-authbridge-proxy.git.commit="${ODH_AUTHBRIDGE_PROXY_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -226,7 +226,7 @@ patch:
     - name: RELATED_IMAGE_ODH_AI_GATEWAY_OPERATOR_IMAGE
       value: "quay.io/rhoai/odh-ai-gateway-operator-rhel9@sha256:9005837b608155b2bac646bc9402394a977227d837393ec38de40cef06653243"
     - name: RELATED_IMAGE_ODH_AUTHBRIDGE_PROXY_IMAGE
-      value: quay.io/rhoai/odh-authbridge-proxy-rhel9@sha256:5700c2355dc9d193cd4d7c45a462e0bda966946752ad02973faa3f6a4fe1fb9e
+      value: quay.io/rhoai/odh-authbridge-proxy-rhel9@sha256:74a09104fc4a27b4e354ccbb81d0a2dfc4544f48f78622c76d2303f3b26ba8ba
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -225,6 +225,8 @@ patch:
       value: quay.io/rhoai/odh-mod-arch-agent-ops-rhel9@sha256:0bed03dbc2b88529198c52c9dcb105df7664fb094d3424adff7b97a08554e3e8
     - name: RELATED_IMAGE_ODH_AI_GATEWAY_OPERATOR_IMAGE
       value: "quay.io/rhoai/odh-ai-gateway-operator-rhel9@sha256:9005837b608155b2bac646bc9402394a977227d837393ec38de40cef06653243"
+    - name: RELATED_IMAGE_ODH_AUTHBRIDGE_PROXY_IMAGE
+      value: quay.io/rhoai/odh-authbridge-proxy-rhel9@sha256:5700c2355dc9d193cd4d7c45a462e0bda966946752ad02973faa3f6a4fe1fb9e
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -114,6 +114,7 @@ config:
         rhoai/odh-agents-operator-rhel9: rhoai/odh-agents-operator-rhel9
         rhoai/odh-mod-arch-agent-ops-rhel9: rhoai/odh-mod-arch-agent-ops-rhel9
         rhoai/odh-ai-gateway-operator-rhel9: rhoai/odh-ai-gateway-operator-rhel9
+        rhoai/odh-authbridge-proxy-rhel9: rhoai/odh-authbridge-proxy-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds 'odh-authbridge-proxy' to the RHOAI-Build-Config bundle.

Component: odh-authbridge-proxy
Product: RHOAI
Target branch: rhoai-3.5-ea.2
Jira: https://redhat.atlassian.net/browse/RHOAIENG-66070

**Files changed:**
- `bundle/bundle-patch.yaml` — added RELATED_IMAGE_ODH_AUTHBRIDGE_PROXY_IMAGE
- `config/build-config.yaml` — added rhoai/odh-authbridge-proxy-rhel9 to repo_mappings
- `bundle/Dockerfile` — added ARG + LABEL entries for odh-authbridge-proxy

> **NOTE:** SHA256 digest is a placeholder — replace before merging.