### PR TITLE
Fix OCP 4.22 base image registry on rhoai-3.4

### DIFF
--- a/catalog/v4.22/Dockerfile
+++ b/catalog/v4.22/Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.22
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.22
 
 ARG ODH_RHEL9_OPERATOR_GIT_URL=
 ARG ODH_RHEL9_OPERATOR_GIT_COMMIT=


### PR DESCRIPTION
## Summary
- Update OCP 4.22 FBC Dockerfile base image from `brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.22` to `registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.22`
- Same fix as PR #23679 (rhoai-3.5-ea.1) and PR #23684 (main), applied to the `rhoai-3.4` branch