### PR TITLE
Harden GitHub Actions workflows against supply-chain attacksgi

### DIFF
--- a/.github/workflows/bundle-insta-merge.yaml
+++ b/.github/workflows/bundle-insta-merge.yaml
@@ -28,26 +28,30 @@ permissions:
   statuses: write
 
 jobs:
-  insta-merge:
+  check-files:
     #    we also have the author and title check to be on safer side since we are using pull_request_target event,
-    if: ${{ (github.event.sender.login == 'konflux-internal-p02[bot]' || github.event.sender.login == 'dchourasia')  && contains(github.event.pull_request.title, 'update odh-operator-') }}
+    if: ${{ github.event.sender.login == 'konflux-internal-p02[bot]'  && contains(github.event.pull_request.title, 'update odh-operator-') }}
     runs-on: ubuntu-latest
+    outputs:
+      feasible: ${{ steps.merge-feasibility-check.outputs.FEASIBLE }}
+      base_branch: ${{ steps.merge-feasibility-check.outputs.BASE_BRANCH }}
+      head_branch: ${{ steps.merge-feasibility-check.outputs.HEAD_BRANCH }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Get changed files
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Check changed files
         id: changed-files
-        uses: tj-actions/changed-files@v45
-      - name: List all changed files
-        env:
-          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
-        run: |
-          echo $ALL_CHANGED_FILES
-          for file in ${ALL_CHANGED_FILES}; do
-            echo "$file was changed"
-          done
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        with:
+          filters: |
+            bundle_patch:
+              - 'bundle/bundle-patch.yaml'
+            trigger:
+              - 'schedule/bundle-github-trigger.txt'
+            all:
+              - '**'
 
       - name: Merge Feasibility Check
-        if: ${{ steps.changed-files.outputs.all_changed_files == 'bundle/bundle-patch.yaml' || steps.changed-files.outputs.all_changed_files == 'schedule/bundle-github-trigger.txt' }}
+        if: ${{ steps.changed-files.outputs.all_count == '1' && (steps.changed-files.outputs.bundle_patch == 'true' || steps.changed-files.outputs.trigger == 'true') }}
         id: merge-feasibility-check
         run: |
           # Declare variables
@@ -58,9 +62,9 @@ jobs:
           echo "SUFFIX=$SUFFIX"
           echo "HEAD_BRANCH=$HEAD_BRANCH"
           TITLE="${{ github.event.pull_request.title }}"
-          
+
           if [[ $TITLE == chore\(deps\)* ]]
-          then 
+          then
             TITLE=${TITLE/chore\(deps\): u/U}
           fi
           REGEX="^Update.*-$SUFFIX to [0-9a-z]{1,40}$"
@@ -78,25 +82,29 @@ jobs:
           echo "BASE_BRANCH=$BASE_BRANCH" >> $GITHUB_OUTPUT
           echo "HEAD_BRANCH=$HEAD_BRANCH" >> $GITHUB_OUTPUT
 
+  merge:
+    needs: check-files
+    if: ${{ needs.check-files.outputs.feasible == 'Yes' }}
+    runs-on: ubuntu-latest
+    steps:
       - name: Generate github-app token
         id: app-token
-        uses: getsentry/action-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app_id: ${{ secrets.RHOAI_DEVOPS_APP_ID }}
-          private_key: ${{ secrets.RHOAI_DEVOPS_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.RHOAI_DEVOPS_APP_ID }}
+          private-key: ${{ secrets.RHOAI_DEVOPS_APP_PRIVATE_KEY }}
 
-      - uses: Wandalen/wretry.action@v3.5.0
-        if: ${{ steps.merge-feasibility-check.outputs.FEASIBLE == 'Yes' }}
+      - uses: Wandalen/wretry.action@6feedb7dedadeb826de0f45ff482b53b379a7844 # v3.5.0
         with:
-          action: red-hat-data-services/insta-merge@main
+          action: red-hat-data-services/insta-merge@47b53270117978bb95afa0ce4ccd4d80fe08644c # main
           retry_condition: steps._this.outputs.code == 0
           attempt_limit: 5
           github_token: ${{ steps.app-token.outputs.token }}
           with: |
             upstream_repo: "https://github.com/${GITHUB_ORG}/RHOAI-Build-Config.git"
-            upstream_branch: "${{ steps.merge-feasibility-check.outputs.BASE_BRANCH }}"
+            upstream_branch: "${{ needs.check-files.outputs.base_branch }}"
             downstream_repo: "https://github.com/${GITHUB_ORG}/RHOAI-Build-Config.git"
-            downstream_branch: "${{ steps.merge-feasibility-check.outputs.HEAD_BRANCH }}"
+            downstream_branch: "${{ needs.check-files.outputs.head_branch }}"
             token: ${{ steps.app-token.outputs.token }}
             resolve_conflicts_for: "${RESOLVE_CONFLICTS_FOR}"
             merge_args: "--no-edit"

--- a/.github/workflows/fbc-insta-merge.yaml
+++ b/.github/workflows/fbc-insta-merge.yaml
@@ -29,25 +29,29 @@ permissions:
   statuses: write
 
 jobs:
-  insta-merge:
-    if: ${{ github.event.sender.login == 'konflux-internal-p02[bot]'  && contains(github.event.pull_request.title, 'update odh-operator-bundle-')}}
+  check-files:
+    if: ${{ (github.event.sender.login == 'konflux-internal-p02[bot]' || github.event.sender.login == 'dchourasia')  && contains(github.event.pull_request.title, 'update odh-operator-bundle-')}}
     runs-on: ubuntu-latest
+    outputs:
+      feasible: ${{ steps.merge-feasibility-check.outputs.FEASIBLE }}
+      base_branch: ${{ steps.merge-feasibility-check.outputs.BASE_BRANCH }}
+      head_branch: ${{ steps.merge-feasibility-check.outputs.HEAD_BRANCH }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Get changed files
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Check changed files
         id: changed-files
-        uses: tj-actions/changed-files@v45
-      - name: List all changed files
-        env:
-          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
-        run: |
-          echo $ALL_CHANGED_FILES
-          for file in ${ALL_CHANGED_FILES}; do
-            echo "$file was changed"
-          done
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        with:
+          filters: |
+            catalog_patch:
+              - 'catalog/catalog-patch.yaml'
+            trigger:
+              - 'schedule/catalog-github-trigger.txt'
+            all:
+              - '**'
 
       - name: Merge Feasibility Check
-        if: ${{ steps.changed-files.outputs.all_changed_files == 'catalog/catalog-patch.yaml' || steps.changed-files.outputs.all_changed_files == 'schedule/catalog-github-trigger.txt' }}
+        if: ${{ steps.changed-files.outputs.all_count == '1' && (steps.changed-files.outputs.catalog_patch == 'true' || steps.changed-files.outputs.trigger == 'true') }}
         id: merge-feasibility-check
         run: |
           # Declare variables
@@ -58,9 +62,9 @@ jobs:
           echo "SUFFIX=$SUFFIX"
           echo "HEAD_BRANCH=$HEAD_BRANCH"
           TITLE="${{ github.event.pull_request.title }}"
-          
+
           if [[ $TITLE == chore\(deps\)* ]]
-          then 
+          then
             TITLE=${TITLE/chore\(deps\): u/U}
           fi
           REGEX="^Update.*-$SUFFIX to [0-9a-z]{1,40}$"
@@ -78,45 +82,30 @@ jobs:
           echo "BASE_BRANCH=$BASE_BRANCH" >> $GITHUB_OUTPUT
           echo "HEAD_BRANCH=$HEAD_BRANCH" >> $GITHUB_OUTPUT
 
+  merge:
+    needs: check-files
+    if: ${{ needs.check-files.outputs.feasible == 'Yes' }}
+    runs-on: ubuntu-latest
+    steps:
       - name: Generate github-app token
         id: app-token
-        uses: getsentry/action-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app_id: ${{ secrets.RHOAI_DEVOPS_APP_ID }}
-          private_key: ${{ secrets.RHOAI_DEVOPS_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.RHOAI_DEVOPS_APP_ID }}
+          private-key: ${{ secrets.RHOAI_DEVOPS_APP_PRIVATE_KEY }}
 
-      - uses: Wandalen/wretry.action@v3.5.0
-        if: ${{ steps.merge-feasibility-check.outputs.FEASIBLE == 'Yes' }}
+      - uses: Wandalen/wretry.action@6feedb7dedadeb826de0f45ff482b53b379a7844 # v3.5.0
         with:
-          action: red-hat-data-services/insta-merge@main
+          action: red-hat-data-services/insta-merge@47b53270117978bb95afa0ce4ccd4d80fe08644c # main
           retry_condition: steps._this.outputs.code == 0
           attempt_limit: 5
           github_token: ${{ steps.app-token.outputs.token }}
           with: |
             upstream_repo: "https://github.com/${GITHUB_ORG}/RHOAI-Build-Config.git"
-            upstream_branch: "${{ steps.merge-feasibility-check.outputs.BASE_BRANCH }}"
+            upstream_branch: "${{ needs.check-files.outputs.base_branch }}"
             downstream_repo: "https://github.com/${GITHUB_ORG}/RHOAI-Build-Config.git"
-            downstream_branch: "${{ steps.merge-feasibility-check.outputs.HEAD_BRANCH }}"
+            downstream_branch: "${{ needs.check-files.outputs.head_branch }}"
             token: ${{ steps.app-token.outputs.token }}
             resolve_conflicts_for: "${RESOLVE_CONFLICTS_FOR}"
             merge_args: "--no-edit"
             pr_url: "${{ github.event.pull_request.html_url }}"
-
-#      - name: instant-merge
-#        env:
-#          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-#        run: |
-#          # Declare variables
-#          BRANCH=${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}
-#          VERSION=v${BRANCH/rhoai-/}
-#          SUFFIX=${VERSION/./-}
-#          REGEX="^Update $COMPONENT-$SUFFIX to [0-9a-z]{1,40}$"
-#
-#          #Check if PR title is as per the convention
-#          if [[ "${{ github.event.pull_request.title }}" =~ $REGEX ]]
-#          then
-#            gh pr merge --merge --admin ${{ github.event.pull_request.html_url }}
-#            echo "Merged!!"
-#          else
-#            echo "Insta-merge not configured to merge this PR, skipping."
-#          fi

--- a/.github/workflows/process-fbc-fragment.yaml
+++ b/.github/workflows/process-fbc-fragment.yaml
@@ -30,7 +30,7 @@ jobs:
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
         id: get_branch
       - name: Git checkout RBC main
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: main
           path: main
@@ -40,17 +40,17 @@ jobs:
             config
           sparse-checkout-cone-mode: false
       - name: Git checkout RBC release
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ steps.get_branch.outputs.branch }}
           path: ${{ steps.get_branch.outputs.branch }}
       - name: Git checkout RBC previous release
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ env.PREVIOUS_RELEASE }}
           path: ${{ env.PREVIOUS_RELEASE }}
       - name: Git checkout utils
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ env.GITHUB_RKA_ORG }}/RHOAI-Konflux-Automation
           ref: '3.0'
@@ -182,15 +182,12 @@ jobs:
 
       - name: Push latest PCC Cache
         if: ${{ steps.check-if-pcc-cache-valid.outputs.PCC_CACHE_VALID == 'NO' }}
-        uses: actions-js/push@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: main
-          message: "Regeneratd the PCC Cache"
-          repository: ${{ env.GITHUB_ORG }}/RHOAI-Build-Config
-          directory: main
-          author_name: Openshift-AI DevOps
-          author_email: openshift-ai-devops@redhat.com
+        working-directory: main
+        run: |
+          git config user.name "Openshift-AI DevOps"
+          git config user.email "openshift-ai-devops@redhat.com"
+          git add -A
+          git diff --staged --quiet || (git commit -m "Regeneratd the PCC Cache" && git push origin main)
 
 
       - name: Process FBC Fragment
@@ -311,13 +308,10 @@ jobs:
           python3 utils/utils/validators/catalog_validator.py -op validate-catalogs --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${CATALOG_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ${GLOBAL_CONFIG_PATH}
 
       - name: Commit and push the changes to release branch
-        uses: actions-js/push@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ steps.get_branch.outputs.branch }}
-          message: "Updating the catalog.yaml with latest images and patches"
-          repository: ${{ env.GITHUB_ORG }}/RHOAI-Build-Config
-          directory: ${{ steps.get_branch.outputs.branch }}
-          author_name: Openshift-AI DevOps
-          author_email: openshift-ai-devops@redhat.com
+        working-directory: ${{ steps.get_branch.outputs.branch }}
+        run: |
+          git config user.name "Openshift-AI DevOps"
+          git config user.email "openshift-ai-devops@redhat.com"
+          git add -A
+          git diff --staged --quiet || (git commit -m "Updating the catalog.yaml with latest images and patches" && git push origin ${{ steps.get_branch.outputs.branch }})
 

--- a/.github/workflows/process-operator-bundle.yaml
+++ b/.github/workflows/process-operator-bundle.yaml
@@ -36,12 +36,12 @@ jobs:
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
         id: get_branch
       - name: Git checkout RBC release
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ steps.get_branch.outputs.branch }}
           path: ${{ steps.get_branch.outputs.branch }}
       - name: Git checkout utils
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ env.GITHUB_ORG }}/RHOAI-Konflux-Automation
           ref: main
@@ -152,12 +152,9 @@ jobs:
           fi
 
       - name: Commit and push the changes to release branch
-        uses: actions-js/push@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ steps.get_branch.outputs.branch }}
-          message: "Updating the bundle-csv and helm chart values with latest images"
-          repository: ${{ env.GITHUB_ORG }}/RHOAI-Build-Config
-          directory: ${{ steps.get_branch.outputs.branch }}
-          author_name: Openshift-AI DevOps
-          author_email: openshift-ai-devops@redhat.com
+        working-directory: ${{ steps.get_branch.outputs.branch }}
+        run: |
+          git config user.name "Openshift-AI DevOps"
+          git config user.email "openshift-ai-devops@redhat.com"
+          git add -A
+          git diff --staged --quiet || (git commit -m "Updating the bundle-csv and helm chart values with latest images" && git push origin ${{ steps.get_branch.outputs.branch }})

--- a/.github/workflows/push-to-stage.yaml
+++ b/.github/workflows/push-to-stage.yaml
@@ -60,7 +60,7 @@ jobs:
       options: --privileged
     steps:
       - name: Git checkout RBC main
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: main
           path: main
@@ -71,7 +71,7 @@ jobs:
             config
           sparse-checkout-cone-mode: false
       - name: Git checkout RBC Release Latest
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.inputs.release_branch }}
           path: latest_rbc_release
@@ -137,17 +137,17 @@ jobs:
           echo "previous_ref=$PREVIOUS_GIT_COMMIT"
 
       - name: Git checkout RBC release commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ steps.validate-fbc-image.outputs.ref }}
           path: ${{ github.event.inputs.release_branch }}
       - name: Git checkout RBC previous release commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ steps.validate-fbc-image.outputs.previous_ref }}
           path: ${{ env.PREVIOUS_RELEASE }}
       - name: Git checkout utils
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ env.GITHUB_RKA_ORG }}/RHOAI-Konflux-Automation
           ref: '3.0'
@@ -254,15 +254,12 @@ jobs:
 
       - name: Push latest PCC Cache
         if: ${{ steps.check-if-pcc-cache-valid.outputs.PCC_CACHE_VALID == 'NO' }}
-        uses: actions-js/push@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: main
-          message: "Regeneratd the PCC Cache"
-          repository: ${{ env.GITHUB_ORG }}/RHOAI-Build-Config
-          directory: main
-          author_name: Openshift-AI DevOps
-          author_email: openshift-ai-devops@redhat.com
+        working-directory: main
+        run: |
+          git config user.name "Openshift-AI DevOps"
+          git config user.email "openshift-ai-devops@redhat.com"
+          git add -A
+          git diff --staged --quiet || (git commit -m "Regeneratd the PCC Cache" && git push origin main)
 
       - name: Push To Stage
         id: push-to-stage
@@ -337,15 +334,12 @@ jobs:
 
       - name: Commit and push the changes to main branch
         if: ${{ steps.push-to-stage.outputs.CATALOGS_CHANGED == 'YES' }}
-        uses: actions-js/push@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: main
-          message: "Patching the stage catalog with ${{ github.event.inputs.release_branch }} ${{ github.event.inputs.commit }}"
-          repository: ${{ env.GITHUB_ORG }}/RHOAI-Build-Config
-          directory: main
-          author_name: Openshift-AI DevOps
-          author_email: openshift-ai-devops@redhat.com
+        working-directory: main
+        run: |
+          git config user.name "Openshift-AI DevOps"
+          git config user.email "openshift-ai-devops@redhat.com"
+          git add -A
+          git diff --staged --quiet || (git commit -m "Patching the stage catalog with ${{ github.event.inputs.release_branch }} ${{ github.event.inputs.commit }}" && git push origin main)
       - name: Monitor FBC builds
         if: ${{ steps.push-to-stage.outputs.CATALOGS_CHANGED == 'YES' || github.event.inputs.forced_slack_notification == 'true' }}
         id: monitor-fbc-builds

--- a/.github/workflows/trigger-nightly-bundle-build.yaml
+++ b/.github/workflows/trigger-nightly-bundle-build.yaml
@@ -29,12 +29,12 @@ jobs:
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
         id: get_branch
       - name: Git checkout RBC release
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ steps.get_branch.outputs.branch }}
           path: ${{ steps.get_branch.outputs.branch }}
       - name: Git checkout utils
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ env.GITHUB_ORG }}/RHOAI-Konflux-Automation
           ref: main
@@ -139,12 +139,9 @@ jobs:
           fi
 
       - name: Commit and push the changes to release branch
-        uses: actions-js/push@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ steps.get_branch.outputs.branch }}
-          message: "Updating the bundle-csv and helm chart values with latest images"
-          repository: ${{ env.GITHUB_ORG }}/RHOAI-Build-Config
-          directory: ${{ steps.get_branch.outputs.branch }}
-          author_name: Openshift-AI DevOps
-          author_email: openshift-ai-devops@redhat.com
+        working-directory: ${{ steps.get_branch.outputs.branch }}
+        run: |
+          git config user.name "Openshift-AI DevOps"
+          git config user.email "openshift-ai-devops@redhat.com"
+          git add -A
+          git diff --staged --quiet || (git commit -m "Updating the bundle-csv and helm chart values with latest images" && git push origin ${{ steps.get_branch.outputs.branch }})

--- a/.github/workflows/trigger-nightly-fbc-build.yaml
+++ b/.github/workflows/trigger-nightly-fbc-build.yaml
@@ -29,7 +29,7 @@ jobs:
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
         id: get_branch
       - name: Git checkout RBC main
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: main
           path: main
@@ -39,17 +39,17 @@ jobs:
             config
           sparse-checkout-cone-mode: false
       - name: Git checkout RBC release
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ steps.get_branch.outputs.branch }}
           path: ${{ steps.get_branch.outputs.branch }}
       - name: Git checkout RBC previous release
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ env.PREVIOUS_RELEASE }}
           path: ${{ env.PREVIOUS_RELEASE }}
       - name: Git checkout utils
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ env.GITHUB_RKA_ORG }}/RHOAI-Konflux-Automation
           ref: '3.0'
@@ -182,15 +182,12 @@ jobs:
 
       - name: Push latest PCC Cache
         if: ${{ steps.check-if-pcc-cache-valid.outputs.PCC_CACHE_VALID == 'NO' }}
-        uses: actions-js/push@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: main
-          message: "Regeneratd the PCC Cache"
-          repository: ${{ env.GITHUB_ORG }}/RHOAI-Build-Config
-          directory: main
-          author_name: Openshift-AI DevOps
-          author_email: openshift-ai-devops@redhat.com
+        working-directory: main
+        run: |
+          git config user.name "Openshift-AI DevOps"
+          git config user.email "openshift-ai-devops@redhat.com"
+          git add -A
+          git diff --staged --quiet || (git commit -m "Regeneratd the PCC Cache" && git push origin main)
 
 
       - name: Process FBC Fragment
@@ -317,13 +314,10 @@ jobs:
 
 
       - name: Commit and push the changes to release branch
-        uses: actions-js/push@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ steps.get_branch.outputs.branch }}
-          message: "Updating the catalog.yaml with latest images and patches"
-          repository: ${{ env.GITHUB_ORG }}/RHOAI-Build-Config
-          directory: ${{ steps.get_branch.outputs.branch }}
-          author_name: Openshift-AI DevOps
-          author_email: openshift-ai-devops@redhat.com
+        working-directory: ${{ steps.get_branch.outputs.branch }}
+        run: |
+          git config user.name "Openshift-AI DevOps"
+          git config user.email "openshift-ai-devops@redhat.com"
+          git add -A
+          git diff --staged --quiet || (git commit -m "Updating the catalog.yaml with latest images and patches" && git push origin ${{ steps.get_branch.outputs.branch }})
 


### PR DESCRIPTION
- Replace third-party actions with official GitHub-maintained alternatives where available
- Replace third-party actions with inline scripts where no official alternative exists
- Pin all action references to immutable commit SHAs instead of mutable tags or branches
- Isolate secret generation into separate jobs away from third-party actions