### PR TITLE
offboard images

### DIFF
--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -165,14 +165,8 @@ patch:
       value: "quay.io/rhoai/odh-spark-operator-rhel9@sha256:7c80c40210f8c8e2f7b3a5f0c7e4b1e2d3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8"
     - name: RELATED_IMAGE_ODH_CLI_IMAGE
       value: "quay.io/rhoai/odh-cli-rhel9@sha256:48251462258815e02b33615945db76fbdf798e3075ba6274435b99b97b60cf0d"
-    - name: RELATED_IMAGE_ODH_TH06_CUDA130_TORCH210_PY312_IMAGE
-      value: "quay.io/rhoai/odh-th06-cuda130-torch210-py312-rhel9@sha256:1643411428aae0e2262c412ae73bd778a832bb39f7d5d1ecf02716508d1548c2"
-    - name: RELATED_IMAGE_ODH_TH06_CPU_TORCH210_PY312_IMAGE
-      value: "quay.io/rhoai/odh-th06-cpu-torch210-py312-rhel9@sha256:f1931700ec97a703581bbd0ac5c55932450fa6a8e73e4f52c0a86503f9daa887"
     - name: RELATED_IMAGE_ODH_WORKLOAD_VARIANT_AUTOSCALER_CONTROLLER_IMAGE
       value: "quay.io/rhoai/odh-workload-variant-autoscaler-controller-rhel9@sha256:8a259703397ebf746ed2e6169dd5f81db0883f1856d2868cdb58b6133b9d16a5"
-    - name: RELATED_IMAGE_ODH_TH06_ROCM64_TORCH291_PY312_IMAGE
-      value: "quay.io/rhoai/odh-th06-rocm64-torch291-py312-rhel9@sha256:02476fa53e338eba010b32c1188c12c7aa724797d153c4582727c5645212f0f7"
     - name: RELATED_IMAGE_ODH_LLM_D_KV_CACHE_IMAGE
       value: "quay.io/rhoai/odh-llm-d-kv-cache-rhel9@sha256:e868795182674523845c8707bd5623fe8e33443bfce31d0c1bec69f5057049c6"
     - name: RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-67692
Konflux Offboarding Training Universal Images to rename 3 universal training images to th-torch-cuda-py312 targeting the 3.5 EA2 release. The goal is to encode the Python version in the name to simplify onboarding/offboarding images as dependency versions change in each release.

Older images	                                               New images
th06-cpu-torch210-py312	                th-torch-cpu-py312
th06-cuda130-torch210-py312	        th-torch-cuda-py312
th06-rocm64-torch291-py312	         th-torch-rocm-py312