### PR TITLE
Add odh-test-comp-rhoai to bundle relatedImages

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -191,6 +191,8 @@ ARG ODH_OGX_CORE_GIT_URL=
 ARG ODH_OGX_CORE_GIT_COMMIT=
 ARG ODH_OGX_K8S_OPERATOR_GIT_URL=
 ARG ODH_OGX_K8S_OPERATOR_GIT_COMMIT=
+ARG ODH_TEST_COMP_RHOAI_GIT_URL=
+ARG ODH_TEST_COMP_RHOAI_GIT_COMMIT=
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -396,7 +398,9 @@ LABEL \
       odh-ogx-core.git.url="${ODH_OGX_CORE_GIT_URL}" \
       odh-ogx-core.git.commit="${ODH_OGX_CORE_GIT_COMMIT}" \
       odh-ogx-k8s-operator.git.url="${ODH_OGX_K8S_OPERATOR_GIT_URL}" \
-      odh-ogx-k8s-operator.git.commit="${ODH_OGX_K8S_OPERATOR_GIT_COMMIT}"
+      odh-ogx-k8s-operator.git.commit="${ODH_OGX_K8S_OPERATOR_GIT_COMMIT}" \
+      odh-test-comp-rhoai.git.url="${ODH_TEST_COMP_RHOAI_GIT_URL}" \
+      odh-test-comp-rhoai.git.commit="${ODH_TEST_COMP_RHOAI_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -223,3 +223,6 @@ patch:
     file: additional-images-patch.yaml
   additional-fields:
     file: csv-patch.yaml
+relatedImages:
+  - name: RELATED_IMAGE_ODH_TEST_COMP_RHOAI_IMAGE
+    value: quay.io/rhoai/odh-test-comp-rhoai-rhel9@sha256:c0877beaa5cc0d7dce84b0528ff04ed14a1fe9728e16a3e959814e1410c38a8e


### PR DESCRIPTION
Adds relatedImages entry for 'odh-test-comp-rhoai' to bundle/bundle-patch.yaml.

Image: quay.io/rhoai/odh-test-comp-rhoai-rhel9@sha256:c0877beaa5cc0d7dce84b0528ff04ed14a1fe9728e16a3e959814e1410c38a8e
Jira: https://redhat.atlassian.net/browse/RHOAIENG-66880