### PR TITLE
Set defaultChannel to stable-3.x for ocp >=4.19

### DIFF
--- a/.github/workflows/process-fbc-fragment.yaml
+++ b/.github/workflows/process-fbc-fragment.yaml
@@ -289,9 +289,13 @@ jobs:
               PREVIOUS_SINGLE_BUNDLE_PATH=${PREVIOUS_BUNDLE_OBJECT_SINGLE_BUNDLE_PATH}
               if [[ $NUMERIC_OCP_VERSION -ge $CSV_META_MIN_OCP_VERSION ]]; then PREVIOUS_SINGLE_BUNDLE_PATH=${PREVIOUS_CSV_META_SINGLE_BUNDLE_PATH}; fi
               python3 utils/utils/fbc-processor/fbc-processor.py -op catalog-patch -b ${PREVIOUS_BUILD_CONFIG_PATH} -c ${OUTPUT_CATALOG_PATH} -p ${PREVIOUS_PATCH_YAML_PATH} -s ${PREVIOUS_SINGLE_BUNDLE_PATH} -o ${OUTPUT_CATALOG_PATH} --push-pipeline-yaml-path ${PREVIOUS_PUSH_PIPELINE_PATH} --push-pipeline-operation enable
-              
-              
-              #cat ${OUTPUT_CATALOG_PATH}
+
+              # Override defaultChannel for OCP >= 4.19
+              echo "RHOAI_VERSION=${RHOAI_VERSION} NUMERIC_OCP_VERSION=${NUMERIC_OCP_VERSION}"
+              if [[ "$RHOAI_VERSION" == "v2.25" ]] && [[ $NUMERIC_OCP_VERSION -ge 419 ]]; then
+                  echo "Overriding defaultChannel to stable-3.x for ${OPENSHIFT_VERSION}"
+                  yq e -i 'select(.schema == "olm.package").defaultChannel = "stable-3.x"' ${OUTPUT_CATALOG_PATH}
+              fi
           done < <(yq eval '.config.supported-ocp-versions.build[].name' $BUILD_CONFIG_PATH)
 
       - name: Validate Catalogs

--- a/.github/workflows/trigger-nightly-fbc-build.yaml
+++ b/.github/workflows/trigger-nightly-fbc-build.yaml
@@ -291,12 +291,17 @@ jobs:
               PREVIOUS_SINGLE_BUNDLE_PATH=${PREVIOUS_BUNDLE_OBJECT_SINGLE_BUNDLE_PATH}
               if [[ $NUMERIC_OCP_VERSION -ge $CSV_META_MIN_OCP_VERSION ]]; then PREVIOUS_SINGLE_BUNDLE_PATH=${PREVIOUS_CSV_META_SINGLE_BUNDLE_PATH}; fi
               python3 utils/utils/fbc-processor/fbc-processor.py -op catalog-patch -b ${PREVIOUS_BUILD_CONFIG_PATH} -c ${OUTPUT_CATALOG_PATH} -p ${PREVIOUS_PATCH_YAML_PATH} -s ${PREVIOUS_SINGLE_BUNDLE_PATH} -o ${OUTPUT_CATALOG_PATH} --push-pipeline-yaml-path ${PREVIOUS_PUSH_PIPELINE_PATH} --push-pipeline-operation disable
-              
-              
-              #cat ${OUTPUT_CATALOG_PATH}
+
+
+              # Override defaultChannel for OCP >= 4.19
+              echo "RHOAI_VERSION=${RHOAI_VERSION} NUMERIC_OCP_VERSION=${NUMERIC_OCP_VERSION}"
+              if [[ "$RHOAI_VERSION" == "v2.25" ]] && [[ $NUMERIC_OCP_VERSION -ge 419 ]]; then
+                  echo "Overriding defaultChannel to stable-3.x for ${OPENSHIFT_VERSION}"
+                  yq e -i 'select(.schema == "olm.package").defaultChannel = "stable-3.x"' ${OUTPUT_CATALOG_PATH}
+              fi
           done < <(yq eval '.config.supported-ocp-versions.build[].name' $BUILD_CONFIG_PATH)
-          
-          # Update the schedule file to trigger the full fbc build 
+
+          # Update the schedule file to trigger the full fbc build
           echo $(date +'%d-%m-%Y %H:%M:%S:%3N') > ${BRANCH}/schedule/catalog-tekton-trigger.txt
 
       - name: Validate Catalogs


### PR DESCRIPTION
For RHOAI v2.25, override the default channel to `stable-3.x` for ocp >=4.19

For more contex refer: https://redhat-internal.slack.com/archives/C0AQLA1FADS/p1781533003521519?thread_ts=1781289758.383299&cid=C0AQLA1FADS

