### PR TITLE
Add odh-llm-d-router-endpoint-picker to bundle relatedImages

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -201,6 +201,8 @@ ARG ODH_AI_GATEWAY_OPERATOR_GIT_URL=
 ARG ODH_AI_GATEWAY_OPERATOR_GIT_COMMIT=
 ARG ODH_AUTHBRIDGE_PROXY_GIT_URL=
 ARG ODH_AUTHBRIDGE_PROXY_GIT_COMMIT=
+ARG ODH_LLM_D_ROUTER_ENDPOINT_PICKER_GIT_URL=
+ARG ODH_LLM_D_ROUTER_ENDPOINT_PICKER_GIT_COMMIT=
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -412,7 +414,9 @@ LABEL \
       odh-ai-gateway-operator.git.url="${ODH_AI_GATEWAY_OPERATOR_GIT_URL}" \
       odh-ai-gateway-operator.git.commit="${ODH_AI_GATEWAY_OPERATOR_GIT_COMMIT}" \
       odh-authbridge-proxy.git.url="${ODH_AUTHBRIDGE_PROXY_GIT_URL}" \
-      odh-authbridge-proxy.git.commit="${ODH_AUTHBRIDGE_PROXY_GIT_COMMIT}"
+      odh-authbridge-proxy.git.commit="${ODH_AUTHBRIDGE_PROXY_GIT_COMMIT}" \
+      odh-llm-d-router-endpoint-picker.git.url="${ODH_LLM_D_ROUTER_ENDPOINT_PICKER_GIT_URL}" \
+      odh-llm-d-router-endpoint-picker.git.commit="${ODH_LLM_D_ROUTER_ENDPOINT_PICKER_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -227,3 +227,6 @@ patch:
     file: additional-images-patch.yaml
   additional-fields:
     file: csv-patch.yaml
+relatedImages:
+  - name: RELATED_IMAGE_ODH_LLM_D_ROUTER_ENDPOINT_PICKER_IMAGE
+    value: quay.io/rhoai/odh-llm-d-router-endpoint-picker-rhel9@sha256:2fc56094baf2744cf058411e39a265be80ed7979c7362fad9f00500b6e22807b


### PR DESCRIPTION
Adds relatedImages entry for 'odh-llm-d-router-endpoint-picker' to bundle/bundle-patch.yaml.

Image: quay.io/rhoai/odh-llm-d-router-endpoint-picker-rhel9@sha256:2fc56094baf2744cf058411e39a265be80ed7979c7362fad9f00500b6e22807b
Jira: https://redhat.atlassian.net/browse/RHOAIENG-69343