### PR TITLE
Add odh-llm-d-router-disagg-sidecar to bundle relatedImages

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -203,6 +203,8 @@ ARG ODH_AUTHBRIDGE_PROXY_GIT_URL=
 ARG ODH_AUTHBRIDGE_PROXY_GIT_COMMIT=
 ARG ODH_LLM_D_ROUTER_ENDPOINT_PICKER_GIT_URL=
 ARG ODH_LLM_D_ROUTER_ENDPOINT_PICKER_GIT_COMMIT=
+ARG ODH_LLM_D_ROUTER_DISAGG_SIDECAR_GIT_URL=
+ARG ODH_LLM_D_ROUTER_DISAGG_SIDECAR_GIT_COMMIT=
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -416,7 +418,9 @@ LABEL \
       odh-authbridge-proxy.git.url="${ODH_AUTHBRIDGE_PROXY_GIT_URL}" \
       odh-authbridge-proxy.git.commit="${ODH_AUTHBRIDGE_PROXY_GIT_COMMIT}" \
       odh-llm-d-router-endpoint-picker.git.url="${ODH_LLM_D_ROUTER_ENDPOINT_PICKER_GIT_URL}" \
-      odh-llm-d-router-endpoint-picker.git.commit="${ODH_LLM_D_ROUTER_ENDPOINT_PICKER_GIT_COMMIT}"
+      odh-llm-d-router-endpoint-picker.git.commit="${ODH_LLM_D_ROUTER_ENDPOINT_PICKER_GIT_COMMIT}" \
+      odh-llm-d-router-disagg-sidecar.git.url="${ODH_LLM_D_ROUTER_DISAGG_SIDECAR_GIT_URL}" \
+      odh-llm-d-router-disagg-sidecar.git.commit="${ODH_LLM_D_ROUTER_DISAGG_SIDECAR_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -230,3 +230,5 @@ patch:
 relatedImages:
   - name: RELATED_IMAGE_ODH_LLM_D_ROUTER_ENDPOINT_PICKER_IMAGE
     value: quay.io/rhoai/odh-llm-d-router-endpoint-picker-rhel9@sha256:2fc56094baf2744cf058411e39a265be80ed7979c7362fad9f00500b6e22807b
+  - name: RELATED_IMAGE_ODH_LLM_D_ROUTER_DISAGG_SIDECAR_IMAGE
+    value: quay.io/rhoai/odh-llm-d-router-disagg-sidecar-rhel9@sha256:c98f566a8f8a73eac48bc08aed14921c597186804cafd28fa600c9ee62287fb6


### PR DESCRIPTION
Adds relatedImages entry for 'odh-llm-d-router-disagg-sidecar' to bundle/bundle-patch.yaml.

Image: quay.io/rhoai/odh-llm-d-router-disagg-sidecar-rhel9@sha256:c98f566a8f8a73eac48bc08aed14921c597186804cafd28fa600c9ee62287fb6
Jira: https://redhat.atlassian.net/browse/RHOAIENG-69738