### PR TITLE
offboard llm-d 3.5-ea.2

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -261,10 +261,6 @@ LABEL \
       odh-kube-rbac-proxy.git.commit="${ODH_KUBE_RBAC_PROXY_GIT_COMMIT}" \
       odh-kuberay-operator-controller.git.url="${ODH_KUBERAY_OPERATOR_CONTROLLER_GIT_URL}" \
       odh-kuberay-operator-controller.git.commit="${ODH_KUBERAY_OPERATOR_CONTROLLER_GIT_COMMIT}" \
-      odh-llm-d-inference-scheduler.git.url="${ODH_LLM_D_INFERENCE_SCHEDULER_GIT_URL}" \
-      odh-llm-d-inference-scheduler.git.commit="${ODH_LLM_D_INFERENCE_SCHEDULER_GIT_COMMIT}" \
-      odh-llm-d-routing-sidecar.git.url="${ODH_LLM_D_ROUTING_SIDECAR_GIT_URL}" \
-      odh-llm-d-routing-sidecar.git.commit="${ODH_LLM_D_ROUTING_SIDECAR_GIT_COMMIT}" \
       odh-maas-api.git.url="${ODH_MAAS_API_GIT_URL}" \
       odh-maas-api.git.commit="${ODH_MAAS_API_GIT_COMMIT}" \
       odh-mlflow.git.url="${ODH_MLFLOW_GIT_URL}" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -45,10 +45,6 @@ patch:
       value: "quay.io/rhoai/odh-feast-operator-rhel9@sha256:b87e261e8ea7137a2fd7f77b3b0b8e300903aea4ca5d8f1e91baa77ba00abfb5"
     - name: RELATED_IMAGE_ODH_FEATURE_SERVER_IMAGE
       value: "quay.io/rhoai/odh-feature-server-rhel9@sha256:2c9971ef483324f8f7b78befc313ebe48a69ae79515e6c70368313269193fefe"
-    - name: RELATED_IMAGE_ODH_LLM_D_INFERENCE_SCHEDULER_IMAGE
-      value: "quay.io/rhoai/odh-llm-d-inference-scheduler-rhel9@sha256:efdeae362e67425d532b39edf06b06fea23f17adc60569b859a87d7c73b635e5"
-    - name: RELATED_IMAGE_ODH_LLM_D_ROUTING_SIDECAR_IMAGE
-      value: "quay.io/rhoai/odh-llm-d-routing-sidecar-rhel9@sha256:8b59e15a8ca11c96c8e4ffb75772c132b238bf4a1b4fb9f11a0fb2a7429f5161"
     - name: RELATED_IMAGE_ODH_MUST_GATHER_IMAGE
       value: "quay.io/rhoai/odh-must-gather-rhel9@sha256:195fc312e56956dd50375fc0a709c5a875077f1cf9039d5deeaf15e5a78a17b0"
     - name: RELATED_IMAGE_ODH_KSERVE_AGENT_IMAGE

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -25,8 +25,6 @@ config:
         rhoai/odh-model-registry-rhel9: rhoai/odh-model-registry-rhel9
         rhoai/odh-feast-operator-rhel9: rhoai/odh-feast-operator-rhel9
         rhoai/odh-feature-server-rhel9: rhoai/odh-feature-server-rhel9
-        rhoai/odh-llm-d-inference-scheduler-rhel9: rhoai/odh-llm-d-inference-scheduler-rhel9
-        rhoai/odh-llm-d-routing-sidecar-rhel9: rhoai/odh-llm-d-routing-sidecar-rhel9
         rhoai/odh-must-gather-rhel9: rhoai/odh-must-gather-rhel9
         rhoai/odh-kserve-agent-rhel9: rhoai/odh-kserve-agent-rhel9
         rhoai/odh-kserve-controller-rhel9: rhoai/odh-kserve-controller-rhel9


### PR DESCRIPTION
Offboarding llm-d-inference-scheduler and llm-d-routing-sidecar following the succesfull onboarding of llm-d-router-endpoint-picker and llm-d-disagg-sidecar

jira for offboarding https://redhat.atlassian.net/browse/RHOAIENG-65205

onboarding jiras
disagg https://redhat.atlassian.net/browse/RHOAIENG-69738
endpoint-picker https://redhat.atlassian.net/browse/RHOAIENG-69343