### PR TITLE
Replace yq with ruamel.yaml for defaultChannel override

### DIFF
--- a/.github/workflows/process-fbc-fragment.yaml
+++ b/.github/workflows/process-fbc-fragment.yaml
@@ -294,7 +294,19 @@ jobs:
               echo "RHOAI_VERSION=${RHOAI_VERSION} NUMERIC_OCP_VERSION=${NUMERIC_OCP_VERSION}"
               if [[ "$RHOAI_VERSION" == "v2.25" ]] && [[ $NUMERIC_OCP_VERSION -ge 419 ]]; then
                   echo "Overriding defaultChannel to stable-3.x for ${OPENSHIFT_VERSION}"
-                  yq e -i 'select(.schema == "olm.package").defaultChannel = "stable-3.x"' ${OUTPUT_CATALOG_PATH}
+                  python3 -c "
+                  import sys
+                  from ruamel.yaml import YAML
+                  from pathlib import Path
+                  yaml = YAML()
+                  yaml.preserve_quotes = True
+                  f = Path(sys.argv[1])
+                  docs = list(yaml.load_all(f))
+                  for doc in docs:
+                      if doc.get('schema') == 'olm.package':
+                          doc['defaultChannel'] = 'stable-3.x'
+                  yaml.dump_all(docs, f)
+                  " "${OUTPUT_CATALOG_PATH}"
               fi
           done < <(yq eval '.config.supported-ocp-versions.build[].name' $BUILD_CONFIG_PATH)
 

--- a/.github/workflows/trigger-nightly-fbc-build.yaml
+++ b/.github/workflows/trigger-nightly-fbc-build.yaml
@@ -297,7 +297,19 @@ jobs:
               echo "RHOAI_VERSION=${RHOAI_VERSION} NUMERIC_OCP_VERSION=${NUMERIC_OCP_VERSION}"
               if [[ "$RHOAI_VERSION" == "v2.25" ]] && [[ $NUMERIC_OCP_VERSION -ge 419 ]]; then
                   echo "Overriding defaultChannel to stable-3.x for ${OPENSHIFT_VERSION}"
-                  yq e -i 'select(.schema == "olm.package").defaultChannel = "stable-3.x"' ${OUTPUT_CATALOG_PATH}
+                  python3 -c "
+                  import sys
+                  from ruamel.yaml import YAML
+                  from pathlib import Path
+                  yaml = YAML()
+                  yaml.preserve_quotes = True
+                  f = Path(sys.argv[1])
+                  docs = list(yaml.load_all(f))
+                  for doc in docs:
+                      if doc.get('schema') == 'olm.package':
+                          doc['defaultChannel'] = 'stable-3.x'
+                  yaml.dump_all(docs, f)
+                  " "${OUTPUT_CATALOG_PATH}"
               fi
           done < <(yq eval '.config.supported-ocp-versions.build[].name' $BUILD_CONFIG_PATH)
 


### PR DESCRIPTION
yq reformats the entire YAML file when editing in-place, causing thousands of whitespace-only changes. ruamel.yaml preserves the original formatting and only modifies the target value.