### PR TITLE
Absent from RHOAI Build Config: ['odh-llm-d-async-rhel9', 'odh-llm-d-…

### DIFF
--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -155,9 +155,9 @@ patch:
       value: "quay.io/rhoai/odh-training-rocm64-torch29-py312-rhel9@sha256:8f9ba738fe8411e598496cff70620465a5440c54db4072f7ab5cd3871a38b5ea"
     - name: RELATED_IMAGE_ODH_TRAINING_CUDA128_TORCH29_PY312_IMAGE
       value: "quay.io/rhoai/odh-training-cuda128-torch29-py312-rhel9@sha256:9ec61a637d9e45789d2b7c6cbdfbb85e1f9064e7e217664049fc946e02516f93"
-    - name: "RELATED_IMAGE_ODH_EVAL_HUB_IMAGE"
+    - name: RELATED_IMAGE_ODH_EVAL_HUB_IMAGE
       value: "quay.io/rhoai/odh-eval-hub-rhel9@sha256:1862c31d676890c4a7c779d1754690903d847b9f34bd4e9795bde72d71fd093f"
-    - name: "RELATED_IMAGE_ODH_SPARK_OPERATOR_IMAGE"
+    - name: RELATED_IMAGE_ODH_SPARK_OPERATOR_IMAGE
       value: "quay.io/rhoai/odh-spark-operator-rhel9@sha256:7c80c40210f8c8e2f7b3a5f0c7e4b1e2d3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8"
     - name: RELATED_IMAGE_ODH_CLI_IMAGE
       value: "quay.io/rhoai/odh-cli-rhel9@sha256:48251462258815e02b33615945db76fbdf798e3075ba6274435b99b97b60cf0d"
@@ -204,27 +204,27 @@ patch:
     - name: RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_E2E_IMAGE
       value: "quay.io/rhoai/odh-ai-gateway-payload-processing-e2e-rhel9@sha256:1b645726015586e6509d00f90ba042b81e4c170987b3c5974ec118e9bb1a05a9"
     - name: RELATED_IMAGE_ODH_KSERVE_LOCALMODELNODE_AGENT_IMAGE
-      value: quay.io/rhoai/odh-kserve-localmodelnode-agent-rhel9@sha256:ad3dfc6cb5f33d24778ab6fc71009298cc4ab20518c66666077520c19977028c
+      value: "quay.io/rhoai/odh-kserve-localmodelnode-agent-rhel9@sha256:ad3dfc6cb5f33d24778ab6fc71009298cc4ab20518c66666077520c19977028c"
     - name: RELATED_IMAGE_ODH_OGX_CORE_IMAGE
-      value: quay.io/rhoai/odh-ogx-core-rhel9@sha256:74d2497940617875aaa29a084454b6f9089e64675fd8db7e0ab60def960a7617
+      value: "quay.io/rhoai/odh-ogx-core-rhel9@sha256:74d2497940617875aaa29a084454b6f9089e64675fd8db7e0ab60def960a7617"
     - name: RELATED_IMAGE_ODH_OGX_K8S_OPERATOR_IMAGE
-      value: quay.io/rhoai/odh-ogx-k8s-operator-rhel9@sha256:83a1e268edddc1095e0f9f574a0f46eff1462e96511acc5d8e5696cad0fffdf4
+      value: "quay.io/rhoai/odh-ogx-k8s-operator-rhel9@sha256:83a1e268edddc1095e0f9f574a0f46eff1462e96511acc5d8e5696cad0fffdf4"
     - name: RELATED_IMAGE_ODH_AGENTS_OPERATOR_IMAGE
-      value: quay.io/rhoai/odh-agents-operator-rhel9@sha256:2a950baa216a8a1c9239d862f5ff2cc11df76d305870c2c8b5eb1d31304a511e
+      value: "quay.io/rhoai/odh-agents-operator-rhel9@sha256:2a950baa216a8a1c9239d862f5ff2cc11df76d305870c2c8b5eb1d31304a511e"
     - name: RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE
-      value: quay.io/rhoai/odh-mod-arch-agent-ops-rhel9@sha256:0bed03dbc2b88529198c52c9dcb105df7664fb094d3424adff7b97a08554e3e8
+      value: "quay.io/rhoai/odh-mod-arch-agent-ops-rhel9@sha256:0bed03dbc2b88529198c52c9dcb105df7664fb094d3424adff7b97a08554e3e8"
     - name: RELATED_IMAGE_ODH_LLM_D_BATCH_GATEWAY_OPERATOR_IMAGE
-      value: quay.io/rhoai/odh-llm-d-batch-gateway-operator-rhel9@sha256:9d75138ab2a901d80b813f59137127dac12d6bb97f7531e066956383de087ca9
+      value: "quay.io/rhoai/odh-llm-d-batch-gateway-operator-rhel9@sha256:9d75138ab2a901d80b813f59137127dac12d6bb97f7531e066956383de087ca9"
     - name: RELATED_IMAGE_ODH_AI_GATEWAY_OPERATOR_IMAGE
       value: "quay.io/rhoai/odh-ai-gateway-operator-rhel9@sha256:9005837b608155b2bac646bc9402394a977227d837393ec38de40cef06653243"
     - name: RELATED_IMAGE_ODH_AUTHBRIDGE_PROXY_IMAGE
-      value: quay.io/rhoai/odh-authbridge-proxy-rhel9@sha256:74a09104fc4a27b4e354ccbb81d0a2dfc4544f48f78622c76d2303f3b26ba8ba
+      value: "quay.io/rhoai/odh-authbridge-proxy-rhel9@sha256:74a09104fc4a27b4e354ccbb81d0a2dfc4544f48f78622c76d2303f3b26ba8ba"
     - name: RELATED_IMAGE_ODH_LLM_D_ASYNC_IMAGE
-      value: quay.io/rhoai/odh-llm-d-async-rhel9@sha256:5f79b837aab1e0a594fa3ab8208da4044c5679ccf74a8a25eec8551b72b6d217
+      value: "quay.io/rhoai/odh-llm-d-async-rhel9@sha256:f426fcb2a860b0e082df80112a44ff1882fa625f7ec5a2bfa0826fde5cfd24b2"
     - name: RELATED_IMAGE_ODH_LLM_D_ROUTER_ENDPOINT_PICKER_IMAGE
-      value: quay.io/rhoai/odh-llm-d-router-endpoint-picker-rhel9@sha256:2fc56094baf2744cf058411e39a265be80ed7979c7362fad9f00500b6e22807b
+      value: "quay.io/rhoai/odh-llm-d-router-endpoint-picker-rhel9@sha256:e445660aef947c3395b1fc2fda02d07b52d21ad6ea8f1bf2cc64fea5304d562c"
     - name: RELATED_IMAGE_ODH_LLM_D_ROUTER_DISAGG_SIDECAR_IMAGE
-      value: quay.io/rhoai/odh-llm-d-router-disagg-sidecar-rhel9@sha256:c98f566a8f8a73eac48bc08aed14921c597186804cafd28fa600c9ee62287fb6
+      value: "quay.io/rhoai/odh-llm-d-router-disagg-sidecar-rhel9@sha256:c3ee52b1401d9b00c5c52f1ec9bc1af8b88d19846190a578975af38fc2adcc97"
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:


### PR DESCRIPTION
…router-endpoint-picker-rhel9', 'odh-llm-d-router-disagg-sidecar-rhel9']

in konflux-config-validator (rhoai-3.5-ea.2) trigger log