### PR TITLE
RHOAI release config: automation-3.5 → rhoai-3.5

### DIFF
--- a/.tekton/odh-operator-bundle-v3-5-push.yaml
+++ b/.tekton/odh-operator-bundle-v3-5-push.yaml
@@ -7,16 +7,17 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    build.appstudio.openshift.io/build-nudge-files: "schedule/catalog-github-trigger.txt"
+    build.appstudio.openshift.io/build-nudge-files: "catalog/catalog-patch.yaml"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push"
-      && target_branch == "rhoai-3.5-ea.2"
-      && "schedule/bundle-tekton-trigger.txt".pathChanged()
+      "non-existent-file.non-existent-ext".pathChanged() && event == "push"
+      && target_branch == "rhoai-3.5"
+      && ( "bundle/**".pathChanged() || ".tekton/odh-operator-bundle-v3-5-push.yaml".pathChanged() )
+      && files.all.exists(p, !p.matches('^bundle/bundle-patch\\.yaml$'))
   labels:
-    appstudio.openshift.io/application: rhoai-v3-5-ea-2
-    appstudio.openshift.io/component: odh-operator-bundle-v3-5-ea-2
+    appstudio.openshift.io/application: rhoai-v3-5
+    appstudio.openshift.io/component: odh-operator-bundle-v3-5
     pipelines.appstudio.openshift.io/type: build
-  name: odh-operator-bundle-v3-5-ea-2-on-schedule
+  name: odh-operator-bundle-v3-5-on-push
   namespace: rhoai-tenant
 spec:
   params:
@@ -27,11 +28,10 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - '{{target_branch}}-nightly'
   - name: output-image
     value: quay.io/rhoai/odh-operator-bundle:{{target_branch}}
   - name: rhoai-version
-    value: "3.5.0-ea.2"
+    value: "3.5.0"
   - name: dockerfile
     value: bundle/Dockerfile
   - name: path-context
@@ -54,7 +54,7 @@ spec:
     - name: pathInRepo
       value: pipelines/container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-operator-bundle-v3-5-ea-2
+    serviceAccountName: build-pipeline-odh-operator-bundle-v3-5
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/odh-operator-bundle-v3-5-scheduled.yaml
+++ b/.tekton/odh-operator-bundle-v3-5-scheduled.yaml
@@ -7,17 +7,16 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    build.appstudio.openshift.io/build-nudge-files: "catalog/catalog-patch.yaml"
+    build.appstudio.openshift.io/build-nudge-files: "schedule/catalog-github-trigger.txt"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      "non-existent-file.non-existent-ext".pathChanged() && event == "push"
-      && target_branch == "rhoai-3.5-ea.2"
-      && ( "bundle/**".pathChanged() || ".tekton/odh-operator-bundle-v3-5-ea-2-push.yaml".pathChanged() )
-      && files.all.exists(p, !p.matches('^bundle/bundle-patch\\.yaml$'))
+      event == "push"
+      && target_branch == "rhoai-3.5"
+      && "schedule/bundle-tekton-trigger.txt".pathChanged()
   labels:
-    appstudio.openshift.io/application: rhoai-v3-5-ea-2
-    appstudio.openshift.io/component: odh-operator-bundle-v3-5-ea-2
+    appstudio.openshift.io/application: rhoai-v3-5
+    appstudio.openshift.io/component: odh-operator-bundle-v3-5
     pipelines.appstudio.openshift.io/type: build
-  name: odh-operator-bundle-v3-5-ea-2-on-push
+  name: odh-operator-bundle-v3-5-on-schedule
   namespace: rhoai-tenant
 spec:
   params:
@@ -28,10 +27,11 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
+    - '{{target_branch}}-nightly'
   - name: output-image
     value: quay.io/rhoai/odh-operator-bundle:{{target_branch}}
   - name: rhoai-version
-    value: "3.5.0-ea.2"
+    value: "3.5.0"
   - name: dockerfile
     value: bundle/Dockerfile
   - name: path-context
@@ -54,7 +54,7 @@ spec:
     - name: pathInRepo
       value: pipelines/container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-operator-bundle-v3-5-ea-2
+    serviceAccountName: build-pipeline-odh-operator-bundle-v3-5
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhai-on-openshift-chart-v3-5-push.yaml
+++ b/.tekton/rhai-on-openshift-chart-v3-5-push.yaml
@@ -9,13 +9,13 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       "non-existent-file.non-existent-ext".pathChanged() && event == "push"
-      && target_branch == "rhoai-3.5-ea.2"
-      && ( "helm/rhai-on-xks-chart/**".pathChanged() || ".tekton/rhai-on-xks-chart-v3-5-ea-2-push.yaml".pathChanged() )
+      && target_branch == "rhoai-3.5"
+      && ( "helm/rhai-on-openshift-chart/**".pathChanged() || ".tekton/rhai-on-openshift-chart-v3-5-push.yaml".pathChanged() )
   labels:
-    appstudio.openshift.io/application: rhoai-v3-5-ea-2
-    appstudio.openshift.io/component: rhai-on-xks-chart-v3-5-ea-2
+    appstudio.openshift.io/application: rhoai-v3-5
+    appstudio.openshift.io/component: rhai-on-openshift-chart-v3-5
     pipelines.appstudio.openshift.io/type: build
-  name: rhai-on-xks-chart-v3-5-ea-2-on-push
+  name: rhai-on-openshift-chart-v3-5-on-push
   namespace: rhoai-tenant
 spec:
   params:
@@ -27,11 +27,11 @@ spec:
     value:
     - '{{target_branch}}-{{revision}}'
   - name: output-image
-    value: quay.io/rhoai/rhai-on-xks-chart:{{target_branch}}
+    value: quay.io/rhoai/rhai-on-openshift-chart:{{target_branch}}
   - name: rhoai-version
-    value: "3.5.0-ea.2"
+    value: "3.5.0"
   - name: path-context
-    value: "helm/rhai-on-xks-chart"
+    value: "helm/rhai-on-openshift-chart"
   - name: hermetic
     value: false
   - name: build-source-image
@@ -55,7 +55,7 @@ spec:
         limits:
           memory: 4Gi
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhai-on-xks-chart-v3-5-ea-2
+    serviceAccountName: build-pipeline-rhai-on-openshift-chart-v3-5
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhai-on-openshift-chart-v3-5-scheduled.yaml
+++ b/.tekton/rhai-on-openshift-chart-v3-5-scheduled.yaml
@@ -9,13 +9,13 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.5-ea.2"
+      && target_branch == "rhoai-3.5"
       && "schedule/helm-chart-tekton-trigger.txt".pathChanged()
   labels:
-    appstudio.openshift.io/application: rhoai-v3-5-ea-2
-    appstudio.openshift.io/component: rhai-on-openshift-chart-v3-5-ea-2
+    appstudio.openshift.io/application: rhoai-v3-5
+    appstudio.openshift.io/component: rhai-on-openshift-chart-v3-5
     pipelines.appstudio.openshift.io/type: build
-  name: rhai-on-openshift-chart-v3-5-ea-2-on-schedule
+  name: rhai-on-openshift-chart-v3-5-on-schedule
   namespace: rhoai-tenant
 spec:
   params:
@@ -30,7 +30,7 @@ spec:
   - name: output-image
     value: quay.io/rhoai/rhai-on-openshift-chart:{{target_branch}}
   - name: rhoai-version
-    value: "3.5.0-ea.2"
+    value: "3.5.0"
   - name: path-context
     value: "helm/rhai-on-openshift-chart"
   - name: hermetic
@@ -56,7 +56,7 @@ spec:
         limits:
           memory: 4Gi
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhai-on-openshift-chart-v3-5-ea-2
+    serviceAccountName: build-pipeline-rhai-on-openshift-chart-v3-5
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhai-on-xks-chart-v3-5-push.yaml
+++ b/.tekton/rhai-on-xks-chart-v3-5-push.yaml
@@ -8,14 +8,14 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push"
-      && target_branch == "rhoai-3.5-ea.2"
-      && "schedule/helm-chart-tekton-trigger.txt".pathChanged()
+      "non-existent-file.non-existent-ext".pathChanged() && event == "push"
+      && target_branch == "rhoai-3.5"
+      && ( "helm/rhai-on-xks-chart/**".pathChanged() || ".tekton/rhai-on-xks-chart-v3-5-push.yaml".pathChanged() )
   labels:
-    appstudio.openshift.io/application: rhoai-v3-5-ea-2
-    appstudio.openshift.io/component: rhai-on-xks-chart-v3-5-ea-2
+    appstudio.openshift.io/application: rhoai-v3-5
+    appstudio.openshift.io/component: rhai-on-xks-chart-v3-5
     pipelines.appstudio.openshift.io/type: build
-  name: rhai-on-xks-chart-v3-5-ea-2-on-schedule
+  name: rhai-on-xks-chart-v3-5-on-push
   namespace: rhoai-tenant
 spec:
   params:
@@ -26,11 +26,10 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - '{{target_branch}}-nightly'
   - name: output-image
     value: quay.io/rhoai/rhai-on-xks-chart:{{target_branch}}
   - name: rhoai-version
-    value: "3.5.0-ea.2"
+    value: "3.5.0"
   - name: path-context
     value: "helm/rhai-on-xks-chart"
   - name: hermetic
@@ -56,7 +55,7 @@ spec:
         limits:
           memory: 4Gi
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhai-on-xks-chart-v3-5-ea-2
+    serviceAccountName: build-pipeline-rhai-on-xks-chart-v3-5
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhai-on-xks-chart-v3-5-scheduled.yaml
+++ b/.tekton/rhai-on-xks-chart-v3-5-scheduled.yaml
@@ -9,18 +9,15 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "rhoai-3.5-ea.2"
-      && "schedule/catalog-tekton-trigger.txt".pathChanged()
+      && target_branch == "rhoai-3.5"
+      && "schedule/helm-chart-tekton-trigger.txt".pathChanged()
   labels:
-    appstudio.openshift.io/application: rhoai-v3-5-ea-2
-    appstudio.openshift.io/component: rhoai-fbc-fragment-v3-5-ea-2
+    appstudio.openshift.io/application: rhoai-v3-5
+    appstudio.openshift.io/component: rhai-on-xks-chart-v3-5
     pipelines.appstudio.openshift.io/type: build
-  name: rhoai-fbc-fragment-v3-5-ea-2-on-schedule
+  name: rhai-on-xks-chart-v3-5-on-schedule
   namespace: rhoai-tenant
 spec:
-  timeouts:
-    pipeline: 10h
-    tasks: 8h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -31,35 +28,15 @@ spec:
     - '{{target_branch}}-{{revision}}'
     - '{{target_branch}}-nightly'
   - name: output-image
-    value: quay.io/rhoai/rhoai-fbc-fragment:{{target_branch}}
+    value: quay.io/rhoai/rhai-on-xks-chart:{{target_branch}}
   - name: rhoai-version
-    value: "3.5.0-ea.2"
-  - name: build-platforms
-    value:
-    - linux/x86_64
-    - linux/ppc64le
-    - linux/s390x
-    - linux/arm64
-  - name: dockerfile
-    value: Dockerfile
+    value: "3.5.0"
   - name: path-context
-    value: catalog/v4.19
+    value: "helm/rhai-on-xks-chart"
   - name: hermetic
-    value: true
+    value: false
   - name: build-source-image
     value: true
-  - name: build-image-index
-    value: true
-  - name: build-args-file
-    value: catalog/catalog_build_args.map
-  - name: skip-checks
-    value: false
-  - name: build-type
-    value: "nightly"
-  - name: workflow_url
-    value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/conforma-reporter.yaml"
-  - name: smoke_url
-    value: "https://github.com/red-hat-data-services/rhods-devops-infra/actions/workflows/smoke-trigger.yaml"
   pipelineRef:
     resolver: git
     params:
@@ -68,9 +45,18 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/fbc-fragment-build.yaml
+      value: pipelines/helm-chart-build.yaml
+  taskRunSpecs:
+  - pipelineTaskName: build-helm-chart
+    stepSpecs:
+    - name: package-and-push
+      computeResources:
+        requests:
+          memory: 0.3Gi
+        limits:
+          memory: 4Gi
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhoai-fbc-fragment-v3-5-ea-2
+    serviceAccountName: build-pipeline-rhai-on-xks-chart-v3-5
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhoai-fbc-fragment-v3-5-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-v3-5-push.yaml
@@ -9,15 +9,19 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       "non-existent-file.non-existent-ext".pathChanged() && event == "push"
-      && target_branch == "rhoai-3.5-ea.2"
-      && ( "helm/rhai-on-openshift-chart/**".pathChanged() || ".tekton/rhai-on-openshift-chart-v3-5-ea-2-push.yaml".pathChanged() )
+      && target_branch == "rhoai-3.5"
+      && ( "catalog/**".pathChanged() || ".tekton/rhoai-fbc-fragment-v3-5-push.yaml".pathChanged() )
+      && files.all.exists(p, !p.matches('^catalog/catalog-patch\\.yaml$'))
   labels:
-    appstudio.openshift.io/application: rhoai-v3-5-ea-2
-    appstudio.openshift.io/component: rhai-on-openshift-chart-v3-5-ea-2
+    appstudio.openshift.io/application: rhoai-v3-5
+    appstudio.openshift.io/component: rhoai-fbc-fragment-v3-5
     pipelines.appstudio.openshift.io/type: build
-  name: rhai-on-openshift-chart-v3-5-ea-2-on-push
+  name: rhoai-fbc-fragment-v3-5-on-push
   namespace: rhoai-tenant
 spec:
+  timeouts:
+    pipeline: 10h
+    tasks: 8h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -27,15 +31,31 @@ spec:
     value:
     - '{{target_branch}}-{{revision}}'
   - name: output-image
-    value: quay.io/rhoai/rhai-on-openshift-chart:{{target_branch}}
+    value: quay.io/rhoai/rhoai-fbc-fragment:{{target_branch}}
   - name: rhoai-version
-    value: "3.5.0-ea.2"
+    value: "3.5.0"
+  - name: dockerfile
+    value: Dockerfile
   - name: path-context
-    value: "helm/rhai-on-openshift-chart"
+    value: catalog/v4.19
   - name: hermetic
-    value: false
+    value: true
   - name: build-source-image
     value: true
+  - name: build-image-index
+    value: true
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
+  - name: build-args-file
+    value: catalog/catalog_build_args.map
+  - name: skip-checks
+    value: false
+  - name: build-type
+    value: "ci"
   pipelineRef:
     resolver: git
     params:
@@ -44,18 +64,9 @@ spec:
     - name: revision
       value: '{{ target_branch }}'
     - name: pathInRepo
-      value: pipelines/helm-chart-build.yaml
-  taskRunSpecs:
-  - pipelineTaskName: build-helm-chart
-    stepSpecs:
-    - name: package-and-push
-      computeResources:
-        requests:
-          memory: 0.3Gi
-        limits:
-          memory: 4Gi
+      value: pipelines/fbc-fragment-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhai-on-openshift-chart-v3-5-ea-2
+    serviceAccountName: build-pipeline-rhoai-fbc-fragment-v3-5
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rhoai-fbc-fragment-v3-5-scheduled.yaml
+++ b/.tekton/rhoai-fbc-fragment-v3-5-scheduled.yaml
@@ -8,15 +8,14 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      "non-existent-file.non-existent-ext".pathChanged() && event == "push"
-      && target_branch == "rhoai-3.5-ea.2"
-      && ( "catalog/**".pathChanged() || ".tekton/rhoai-fbc-fragment-v3-5-ea-2-push.yaml".pathChanged() )
-      && files.all.exists(p, !p.matches('^catalog/catalog-patch\\.yaml$'))
+      event == "push"
+      && target_branch == "rhoai-3.5"
+      && "schedule/catalog-tekton-trigger.txt".pathChanged()
   labels:
-    appstudio.openshift.io/application: rhoai-v3-5-ea-2
-    appstudio.openshift.io/component: rhoai-fbc-fragment-v3-5-ea-2
+    appstudio.openshift.io/application: rhoai-v3-5
+    appstudio.openshift.io/component: rhoai-fbc-fragment-v3-5
     pipelines.appstudio.openshift.io/type: build
-  name: rhoai-fbc-fragment-v3-5-ea-2-on-push
+  name: rhoai-fbc-fragment-v3-5-on-schedule
   namespace: rhoai-tenant
 spec:
   timeouts:
@@ -30,10 +29,17 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
+    - '{{target_branch}}-nightly'
   - name: output-image
     value: quay.io/rhoai/rhoai-fbc-fragment:{{target_branch}}
   - name: rhoai-version
-    value: "3.5.0-ea.2"
+    value: "3.5.0"
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
   - name: dockerfile
     value: Dockerfile
   - name: path-context
@@ -44,18 +50,16 @@ spec:
     value: true
   - name: build-image-index
     value: true
-  - name: build-platforms
-    value:
-    - linux/x86_64
-    - linux/ppc64le
-    - linux/s390x
-    - linux/arm64
   - name: build-args-file
     value: catalog/catalog_build_args.map
   - name: skip-checks
     value: false
   - name: build-type
-    value: "ci"
+    value: "nightly"
+  - name: workflow_url
+    value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/conforma-reporter.yaml"
+  - name: smoke_url
+    value: "https://github.com/red-hat-data-services/rhods-devops-infra/actions/workflows/smoke-trigger.yaml"
   pipelineRef:
     resolver: git
     params:
@@ -66,7 +70,7 @@ spec:
     - name: pathInRepo
       value: pipelines/fbc-fragment-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-rhoai-fbc-fragment-v3-5-ea-2
+    serviceAccountName: build-pipeline-rhoai-fbc-fragment-v3-5
   workspaces:
   - name: git-auth
     secret:

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -1,5 +1,5 @@
 patch:
-  version: 3.5.0-ea.2
+  version: 3.5.0
   relatedImages:
     - name: RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE
       value: "quay.io/rhoai/odh-kf-notebook-controller-rhel9@sha256:8fdab8122b0433dfa1045f22074c891d2b84fd21a073f406d12d5bcbe9b9b805"

--- a/config/trustyai-pig-build-config.yaml
+++ b/config/trustyai-pig-build-config.yaml
@@ -1,5 +1,5 @@
 #!productVersion=3.5.0
-#!scmRevision=rhoai-3.5-ea.2
+#!scmRevision=rhoai-3.5
 
 
 product:


### PR DESCRIPTION
## Summary

Automated updates for the release line: merge changes from the automation branch into the target release branch.

## Branches

- **Target:** `rhoai-3.5`
- **Source:** `automation-3.5`

## Changes

Release-line configuration only (not `main`): Tekton definitions under `.tekton`, `bundle/bundle-patch.yaml`, and `bundle/csv-patch.yaml` when applicable for this release step.

## Review

Please verify image references and bundle metadata for the intended release.

[View diff (compare)](https://github.com/red-hat-data-services/RHOAI-Build-Config/compare/rhoai-3.5...automation-3.5)