### PR TITLE
Onboard rhoai to 3.3.4

### DIFF
--- a/.tekton/odh-operator-bundle-v3-3-push.yaml
+++ b/.tekton/odh-operator-bundle-v3-3-push.yaml
@@ -41,7 +41,7 @@ spec:
   - name: build-image-index
     value: false
   - name: rhoai-version
-    value: "3.3.3"
+    value: "3.3.4"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-operator-bundle-v3-3-scheduled.yaml
+++ b/.tekton/odh-operator-bundle-v3-3-scheduled.yaml
@@ -40,7 +40,7 @@ spec:
   - name: build-image-index
     value: false
   - name: rhoai-version
-    value: "3.3.3"
+    value: "3.3.4"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/rhoai-fbc-fragment-v3-3-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-v3-3-push.yaml
@@ -47,7 +47,7 @@ spec:
   - name: build-type
     value: "ci"
   - name: rhoai-version
-    value: "3.3.3"
+    value: "3.3.4"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/rhoai-fbc-fragment-v3-3-scheduled.yaml
+++ b/.tekton/rhoai-fbc-fragment-v3-3-scheduled.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-type
     value: "nightly"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "3.3.3"
+    value: "3.3.4"
   - name: workflow_url
     value: "https://github.com/red-hat-data-services/conforma-reporter/actions/workflows/conforma-reporter.yaml"
   - name: smoke_url

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -1,5 +1,5 @@
 patch:
-  version: 3.3.3
+  version: 3.3.4
   relatedImages:
     - name: RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE
       value: "quay.io/rhoai/odh-kf-notebook-controller-rhel9@sha256:8fdab8122b0433dfa1045f22074c891d2b84fd21a073f406d12d5bcbe9b9b805"

--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -7,16 +7,16 @@ patch:
       package: rhods-operator
       schema: olm.channel
       entries:
-      - name: rhods-operator.3.3.3
-        replaces: rhods-operator.3.3.2
-        skipRange: '>=3.3.0 <3.3.3'
+      - name: rhods-operator.3.3.4
+        replaces: rhods-operator.3.3.3
+        skipRange: '>=3.3.0 <3.3.4'
     - name: support-required-upgrade
       package: rhods-operator
       schema: olm.channel
       entries:
-      - name: rhods-operator.3.3.3
-        replaces: rhods-operator.3.3.2
-        skipRange: '>=2.25.6 <2.26.0 || >=3.3.2 <3.3.3'
+      - name: rhods-operator.3.3.4
+        replaces: rhods-operator.3.3.3
+        skipRange: '>=2.25.6 <2.26.0 || >=3.3.2 <3.3.4'
 
   olm.bundle:
     - quay.io/rhoai/odh-operator-bundle@sha256:cf1ddc8da3bf1350b0dc41665df789e38d24c548eb0d03c1b423d61eff38d930


### PR DESCRIPTION
## Summary
- Bump rhoai-version from 3.3.3 to 3.3.4 in Tekton pipelines
- Update bundle-patch version
- Update catalog-patch OLM channels (name, replaces, skipRange)

## Files Changed
- .tekton/*.yaml — rhoai-version parameter bump
- bundle/bundle-patch.yaml — version field
- catalog/catalog-patch.yaml — OLM channel entries (stable-3.3, support-required-upgrade)