### PR TITLE
Update stage pipeline versions for rhoai-2.25 to 2.25.8

### DIFF
--- a/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-416-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-416-push.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "2.25.7"
+    value: "2.25.8"
   - name: ocp-version
     value: "4.16"
   - name: fbc-pipeline-branch

--- a/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-417-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-417-push.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "2.25.7"
+    value: "2.25.8"
   - name: ocp-version
     value: "4.17"
   - name: fbc-pipeline-branch

--- a/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-418-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-418-push.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "2.25.7"
+    value: "2.25.8"
   - name: ocp-version
     value: "4.18"
   - name: fbc-pipeline-branch

--- a/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-419-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-419-push.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "2.25.7"
+    value: "2.25.8"
   - name: ocp-version
     value: "4.19"
   - name: fbc-pipeline-branch

--- a/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-420-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-420-push.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "2.25.7"
+    value: "2.25.8"
   - name: ocp-version
     value: "4.20"
   - name: fbc-pipeline-branch

--- a/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-421-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-421-push.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "2.25.7"
+    value: "2.25.8"
   - name: ocp-version
     value: "4.21"
   - name: fbc-pipeline-branch

--- a/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-422-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-422-push.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "2.25.7"
+    value: "2.25.8"
   - name: ocp-version
     value: "4.22"
   - name: fbc-pipeline-branch

--- a/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-422-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-422-push.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "2.25.8"
+    value: "2.25.7"
   - name: ocp-version
     value: "4.22"
   - name: fbc-pipeline-branch


### PR DESCRIPTION
## Summary
- Bump rhoai-version in stage FBC pipeline definitions for rhoai-2.25
- Updates all .tekton/rhoai-fbc-fragment-rhoai-225-*-push.yaml files on main

## Files Changed
- .tekton/rhoai-fbc-fragment-rhoai-225-ocp-416-push.yaml
- .tekton/rhoai-fbc-fragment-rhoai-225-ocp-417-push.yaml
- .tekton/rhoai-fbc-fragment-rhoai-225-ocp-418-push.yaml
- .tekton/rhoai-fbc-fragment-rhoai-225-ocp-419-push.yaml
- .tekton/rhoai-fbc-fragment-rhoai-225-ocp-420-push.yaml
- .tekton/rhoai-fbc-fragment-rhoai-225-ocp-421-push.yaml