### PR TITLE
Onboard rhoai to 3.4.2

### DIFF
--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -1,5 +1,5 @@
 patch:
-  version: 3.4.1
+  version: 3.4.2
   relatedImages:
     - name: RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE
       value: "quay.io/rhoai/odh-kf-notebook-controller-rhel9@sha256:8fdab8122b0433dfa1045f22074c891d2b84fd21a073f406d12d5bcbe9b9b805"

--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -7,16 +7,16 @@ patch:
       package: rhods-operator
       schema: olm.channel
       entries:
-        - name: rhods-operator.3.4.1
-          replaces: rhods-operator.3.4.0
-          skipRange: '>=3.3.0 <3.4.1'
+        - name: rhods-operator.3.4.2
+          replaces: rhods-operator.3.4.1
+          skipRange: '>=3.3.0 <3.4.2'
     - name: stable-3.x
       package: rhods-operator
       schema: olm.channel
       entries:
-        - name: rhods-operator.3.4.1
-          replaces: rhods-operator.3.4.0
-          skipRange: '>=3.3.0 <3.4.1'
+        - name: rhods-operator.3.4.2
+          replaces: rhods-operator.3.4.1
+          skipRange: '>=3.3.0 <3.4.2'
 
   olm.bundle:
     - quay.io/rhoai/odh-operator-bundle@sha256:5ed3c5a7fd3d95d03213bccad1ae0ef0b9d76848b94a25e615bdacdc7045e8e5


### PR DESCRIPTION
## Summary
- Bump rhoai-version from 3.4.1 to 3.4.2 in Tekton pipelines
- Update bundle-patch version
- Update catalog-patch OLM channels (name, replaces, skipRange)

## Files Changed
- .tekton/*.yaml — rhoai-version parameter bump
- bundle/bundle-patch.yaml — version field
- catalog/catalog-patch.yaml — OLM channel entries (stable-3.4, stable-3.x)