### PR TITLE
Update stage pipeline versions for rhoai-3.4 to 3.4.2

### DIFF
--- a/.tekton/rhoai-fbc-fragment-rhoai-34-ocp-419-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-34-ocp-419-push.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "3.4.1"
+    value: "3.4.2"
   - name: ocp-version
     value: "4.19"
   - name: fbc-pipeline-branch

--- a/.tekton/rhoai-fbc-fragment-rhoai-34-ocp-420-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-34-ocp-420-push.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "3.4.1"
+    value: "3.4.2"
   - name: ocp-version
     value: "4.20"
   - name: fbc-pipeline-branch

--- a/.tekton/rhoai-fbc-fragment-rhoai-34-ocp-421-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-34-ocp-421-push.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "3.4.1"
+    value: "3.4.2"
   - name: ocp-version
     value: "4.21"
   - name: fbc-pipeline-branch

--- a/.tekton/rhoai-fbc-fragment-rhoai-34-ocp-422-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-34-ocp-422-push.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "3.4.1"
+    value: "3.4.2"
   - name: ocp-version
     value: "4.22"
   - name: fbc-pipeline-branch


### PR DESCRIPTION
## Summary
- Bump rhoai-version in stage FBC pipeline definitions for rhoai-3.4
- Updates non-EA .tekton/rhoai-fbc-fragment-rhoai-34-ocp-*-push.yaml files on main

## Files Changed
- .tekton/rhoai-fbc-fragment-rhoai-34-ocp-419-push.yaml
- .tekton/rhoai-fbc-fragment-rhoai-34-ocp-420-push.yaml
- .tekton/rhoai-fbc-fragment-rhoai-34-ocp-421-push.yaml
- .tekton/rhoai-fbc-fragment-rhoai-34-ocp-422-push.yaml