### PR TITLE
Add odh-latency-predictor-prediction to bundle relatedImages

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -203,6 +203,8 @@ ARG ODH_LLM_D_ROUTER_ENDPOINT_PICKER_GIT_URL=
 ARG ODH_LLM_D_ROUTER_ENDPOINT_PICKER_GIT_COMMIT=
 ARG ODH_LLM_D_ROUTER_DISAGG_SIDECAR_GIT_URL=
 ARG ODH_LLM_D_ROUTER_DISAGG_SIDECAR_GIT_COMMIT=
+ARG ODH_LATENCY_PREDICTOR_PREDICTION_GIT_URL=
+ARG ODH_LATENCY_PREDICTOR_PREDICTION_GIT_COMMIT=
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -416,7 +418,9 @@ LABEL \
       odh-llm-d-router-endpoint-picker.git.url="${ODH_LLM_D_ROUTER_ENDPOINT_PICKER_GIT_URL}" \
       odh-llm-d-router-endpoint-picker.git.commit="${ODH_LLM_D_ROUTER_ENDPOINT_PICKER_GIT_COMMIT}" \
       odh-llm-d-router-disagg-sidecar.git.url="${ODH_LLM_D_ROUTER_DISAGG_SIDECAR_GIT_URL}" \
-      odh-llm-d-router-disagg-sidecar.git.commit="${ODH_LLM_D_ROUTER_DISAGG_SIDECAR_GIT_COMMIT}"
+      odh-llm-d-router-disagg-sidecar.git.commit="${ODH_LLM_D_ROUTER_DISAGG_SIDECAR_GIT_COMMIT}" \
+      odh-latency-predictor-prediction.git.url="${ODH_LATENCY_PREDICTOR_PREDICTION_GIT_URL}" \
+      odh-latency-predictor-prediction.git.commit="${ODH_LATENCY_PREDICTOR_PREDICTION_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -229,10 +229,9 @@ patch:
       value: "quay.io/rhoai/odh-latency-predictor-test-rhel9@sha256:d135b787c24faceee5b101c5d46bfa6d5ae22b03cae829eaf1d26da564f57e8a"
     - name: RELATED_IMAGE_ODH_LATENCY_PREDICTOR_TRAINING_IMAGE
       value: "quay.io/rhoai/odh-latency-predictor-training-rhel9@sha256:b7af8428538be549f49969d906352175999c2f442b6d36fee127cb7a60511977"
+    - name: RELATED_IMAGE_ODH_LATENCY_PREDICTOR_PREDICTION_IMAGE
+      value: quay.io/rhoai/odh-latency-predictor-prediction-rhel9@sha256:76345428d15d0dadeb277e20f413f1a07e62a3b5c25e0ae1df30e5def437f366
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:
-    file: csv-patch.yaml
-relatedImages:
-  - name: RELATED_IMAGE_ODH_LATENCY_PREDICTOR_PREDICTION_IMAGE
-    value: quay.io/rhoai/odh-latency-predictor-prediction-rhel9@sha256:76345428d15d0dadeb277e20f413f1a07e62a3b5c25e0ae1df30e5def437f366
+    file: csv-patch.yaml  

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -230,7 +230,7 @@ patch:
     - name: RELATED_IMAGE_ODH_LATENCY_PREDICTOR_TRAINING_IMAGE
       value: "quay.io/rhoai/odh-latency-predictor-training-rhel9@sha256:b7af8428538be549f49969d906352175999c2f442b6d36fee127cb7a60511977"
     - name: RELATED_IMAGE_ODH_LATENCY_PREDICTOR_PREDICTION_IMAGE
-      value: quay.io/rhoai/odh-latency-predictor-prediction-rhel9@sha256:76345428d15d0dadeb277e20f413f1a07e62a3b5c25e0ae1df30e5def437f366
+      value: "quay.io/rhoai/odh-latency-predictor-prediction-rhel9@sha256:76345428d15d0dadeb277e20f413f1a07e62a3b5c25e0ae1df30e5def437f366"
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -234,4 +234,4 @@ patch:
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:
-    file: csv-patch.yaml  
+    file: csv-patch.yaml

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -229,3 +229,6 @@ patch:
     file: additional-images-patch.yaml
   additional-fields:
     file: csv-patch.yaml
+relatedImages:
+  - name: RELATED_IMAGE_ODH_LATENCY_PREDICTOR_PREDICTION_IMAGE
+    value: quay.io/rhoai/odh-latency-predictor-prediction-rhel9@sha256:76345428d15d0dadeb277e20f413f1a07e62a3b5c25e0ae1df30e5def437f366


### PR DESCRIPTION
Adds relatedImages entry for 'odh-latency-predictor-prediction' to bundle/bundle-patch.yaml.

Image: quay.io/rhoai/odh-latency-predictor-prediction-rhel9@sha256:76345428d15d0dadeb277e20f413f1a07e62a3b5c25e0ae1df30e5def437f366
Jira: https://redhat.atlassian.net/browse/RHOAIENG-68941