### PR TITLE
Add odh-latency-predictor-test to bundle relatedImages

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -203,6 +203,8 @@ ARG ODH_LLM_D_ROUTER_ENDPOINT_PICKER_GIT_URL=
 ARG ODH_LLM_D_ROUTER_ENDPOINT_PICKER_GIT_COMMIT=
 ARG ODH_LLM_D_ROUTER_DISAGG_SIDECAR_GIT_URL=
 ARG ODH_LLM_D_ROUTER_DISAGG_SIDECAR_GIT_COMMIT=
+ARG ODH_LATENCY_PREDICTOR_TEST_GIT_URL=
+ARG ODH_LATENCY_PREDICTOR_TEST_GIT_COMMIT=
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -416,7 +418,9 @@ LABEL \
       odh-llm-d-router-endpoint-picker.git.url="${ODH_LLM_D_ROUTER_ENDPOINT_PICKER_GIT_URL}" \
       odh-llm-d-router-endpoint-picker.git.commit="${ODH_LLM_D_ROUTER_ENDPOINT_PICKER_GIT_COMMIT}" \
       odh-llm-d-router-disagg-sidecar.git.url="${ODH_LLM_D_ROUTER_DISAGG_SIDECAR_GIT_URL}" \
-      odh-llm-d-router-disagg-sidecar.git.commit="${ODH_LLM_D_ROUTER_DISAGG_SIDECAR_GIT_COMMIT}"
+      odh-llm-d-router-disagg-sidecar.git.commit="${ODH_LLM_D_ROUTER_DISAGG_SIDECAR_GIT_COMMIT}" \
+      odh-latency-predictor-test.git.url="${ODH_LATENCY_PREDICTOR_TEST_GIT_URL}" \
+      odh-latency-predictor-test.git.commit="${ODH_LATENCY_PREDICTOR_TEST_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -229,3 +229,6 @@ patch:
     file: additional-images-patch.yaml
   additional-fields:
     file: csv-patch.yaml
+relatedImages:
+  - name: RELATED_IMAGE_ODH_LATENCY_PREDICTOR_TEST_IMAGE
+    value: quay.io/rhoai/odh-latency-predictor-test-rhel9@sha256:d135b787c24faceee5b101c5d46bfa6d5ae22b03cae829eaf1d26da564f57e8a


### PR DESCRIPTION
Adds relatedImages entry for 'odh-latency-predictor-test' to bundle/bundle-patch.yaml.

Image: quay.io/rhoai/odh-latency-predictor-test-rhel9@sha256:d135b787c24faceee5b101c5d46bfa6d5ae22b03cae829eaf1d26da564f57e8a
Jira: https://redhat.atlassian.net/browse/RHOAIENG-68942