### PR TITLE
Add 3.5 specific channels and enable eus upgrade path

### DIFF
--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -3,12 +3,30 @@ patch:
     name: rhods-operator
     defaultChannel: stable-3.x
   olm.channels:
-    - name: beta
+    - name: stable-3.x
       package: rhods-operator
       schema: olm.channel
       entries:
-      - name: rhods-operator.3.5.0-ea.2
-        skipRange: '>=3.4.0 <3.5.0 || >=2.25.0 <2.26.0'
+        - name: rhods-operator.3.5.0
+          replaces: rhods-operator.3.4.1
+          skipRange: '>=3.4.0 <3.5.0'
+    - name: stable-3.5
+      package: rhods-operator
+      schema: olm.channel
+      entries:
+        - name: rhods-operator.3.5.0
+          skipRange: '>=3.4.0 <3.5.0'
+    - name: eus-3.5
+      package: rhods-operator
+      schema: olm.channel
+      entries:
+        - name: rhods-operator.3.5.0
+    - name: support-required-upgrade-3.5
+      package: rhods-operator
+      schema: olm.channel
+      entries:
+      - name: rhods-operator.3.5.0
+        skipRange: '>=2.25.8 <2.26.0'
 
   olm.bundle:
     - quay.io/rhoai/odh-operator-bundle@sha256:7074f53a39630f33c82f5fed29103693faf3f4242ac4e90bd54dc3182d0233de


### PR DESCRIPTION
Ref: https://redhat.atlassian.net/browse/RHOAIENG-71446

**Change Summary**

- Add new channels: `stable-3.5`, `eus-3.5`, and `support-required-upgrade-3.5`
- Advance the `stable-3.x` channel head to 3.5.0
- Enable **3.4 (stable) to 3.5 (stable) upgrades** via the `stable-3.x` and `stable-3.5 `channels
- Restrict `eus-3.5` to fresh 3.5.0 installs only **(no upgrade path)**
- Support **RHOAI 2.25 (EUS) to 3.5 (EUS) upgrades exclusively** through the `support-required-upgrade-3.5` channel