### PR TITLE
Add skip-bundles for 3.5.0-ea.1 and 3.4.1 to unblock nightly FBC build

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -14,20 +14,25 @@ config:
       skip-bundles:
         - rhods-operator.3.4.0-ea.1
         - rhods-operator.3.4.0-ea.2
+        - rhods-operator.3.5.0-ea.1
     - version: v4.20
       onboarded-since: rhods-operator.2.25.0
       skip-bundles:
         - rhods-operator.3.4.0-ea.1
         - rhods-operator.3.4.0-ea.2
+        - rhods-operator.3.5.0-ea.1
     - version: v4.21
       onboarded-since: rhods-operator.2.25.0
       skip-bundles:
         - rhods-operator.3.2.1
         - rhods-operator.3.4.0-ea.1
         - rhods-operator.3.4.0-ea.2
+        - rhods-operator.3.5.0-ea.1
     - version: v4.22
       onboarded-since: rhods-operator.2.25.0
       skip-bundles:
         - rhods-operator.3.2.1
         - rhods-operator.3.4.0-ea.1
         - rhods-operator.3.4.0-ea.2
+        - rhods-operator.3.4.1
+        - rhods-operator.3.5.0-ea.1


### PR DESCRIPTION
## Summary
- Add `rhods-operator.3.5.0-ea.1` to `skip-bundles` for v4.19, v4.20, v4.21, v4.22
- Add `rhods-operator.3.4.1` to `skip-bundles` for v4.22

## Problem
The "Trigger Nightly FBC Build" GitHub Actions workflow is failing at the "Validate Catalogs" step because:
1. The FBC processor correctly removes `3.5.0-ea.1` from catalogs when adding `3.5.0` GA
2. The validator still expects `3.5.0-ea.1` to be present since it's in `shipped_rhoai_versions_granular.txt`
3. `rhods-operator.3.4.1` is missing from the v4.22 catalog

Since the validator fails, the workflow never pushes the commit that updates `schedule/catalog-tekton-trigger.txt`, so the Tekton PaC pipeline `rhoai-fbc-fragment-v3-5-scheduled` never fires.

## Fix
Add the missing bundles to `skip-bundles` in `config/config.yaml`, following the same pattern used for `3.4.0-ea.1` and `3.4.0-ea.2`.

## Test plan
- [ ] Verify the nightly FBC build workflow passes after merge
- [ ] Verify `rhoai-fbc-fragment-v3-5-scheduled` Tekton pipeline triggers successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)