### PR TITLE
Add odh-dashboard-operator to bundle relatedImages

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -209,6 +209,8 @@ ARG ODH_LATENCY_PREDICTOR_TEST_GIT_URL=
 ARG ODH_LATENCY_PREDICTOR_TEST_GIT_COMMIT=
 ARG ODH_LATENCY_PREDICTOR_TRAINING_GIT_URL=
 ARG ODH_LATENCY_PREDICTOR_TRAINING_GIT_COMMIT=
+ARG ODH_DASHBOARD_OPERATOR_GIT_URL=
+ARG ODH_DASHBOARD_OPERATOR_GIT_COMMIT=
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -428,7 +430,9 @@ LABEL \
       odh-latency-predictor-test.git.url="${ODH_LATENCY_PREDICTOR_TEST_GIT_URL}" \
       odh-latency-predictor-test.git.commit="${ODH_LATENCY_PREDICTOR_TEST_GIT_COMMIT}" \
       odh-latency-predictor-training.git.url="${ODH_LATENCY_PREDICTOR_TRAINING_GIT_URL}" \
-      odh-latency-predictor-training.git.commit="${ODH_LATENCY_PREDICTOR_TRAINING_GIT_COMMIT}"
+      odh-latency-predictor-training.git.commit="${ODH_LATENCY_PREDICTOR_TRAINING_GIT_COMMIT}" \
+      odh-dashboard-operator.git.url="${ODH_DASHBOARD_OPERATOR_GIT_URL}" \
+      odh-dashboard-operator.git.commit="${ODH_DASHBOARD_OPERATOR_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -231,10 +231,10 @@ patch:
       value: "quay.io/rhoai/odh-latency-predictor-training-rhel9@sha256:b7af8428538be549f49969d906352175999c2f442b6d36fee127cb7a60511977"
     - name: RELATED_IMAGE_ODH_LATENCY_PREDICTOR_PREDICTION_IMAGE
       value: "quay.io/rhoai/odh-latency-predictor-prediction-rhel9@sha256:76345428d15d0dadeb277e20f413f1a07e62a3b5c25e0ae1df30e5def437f366"
+    - name: RELATED_IMAGE_ODH_DASHBOARD_OPERATOR_IMAGE
+      value: quay.io/rhoai/odh-dashboard-operator-rhel9@sha256:109e5cd124c30d495e967fb266e69814225a0c0e84a20a7f54c0025b30edac06
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:
     file: csv-patch.yaml
-relatedImages:
-  - name: RELATED_IMAGE_ODH_DASHBOARD_OPERATOR_IMAGE
-    value: quay.io/rhoai/odh-dashboard-operator-rhel9@sha256:109e5cd124c30d495e967fb266e69814225a0c0e84a20a7f54c0025b30edac06
+    

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -235,3 +235,6 @@ patch:
     file: additional-images-patch.yaml
   additional-fields:
     file: csv-patch.yaml
+relatedImages:
+  - name: RELATED_IMAGE_ODH_DASHBOARD_OPERATOR_IMAGE
+    value: quay.io/rhoai/odh-dashboard-operator-rhel9@sha256:109e5cd124c30d495e967fb266e69814225a0c0e84a20a7f54c0025b30edac06

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -237,4 +237,3 @@ patch:
     file: additional-images-patch.yaml
   additional-fields:
     file: csv-patch.yaml
-    

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -117,6 +117,7 @@ config:
         rhoai/odh-llm-d-router-disagg-sidecar-rhel9: rhoai/odh-llm-d-router-disagg-sidecar-rhel9
         rhoai/odh-ai-gateway-operator-rhel9: rhoai/odh-ai-gateway-operator-rhel9
         rhoai/odh-authbridge-proxy-rhel9: rhoai/odh-authbridge-proxy-rhel9
+        rhoai/odh-dashboard-operator-rhel9: rhoai/odh-dashboard-operator-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds relatedImages entry for 'odh-dashboard-operator' to bundle/bundle-patch.yaml.

Image: quay.io/rhoai/odh-dashboard-operator-rhel9@sha256:109e5cd124c30d495e967fb266e69814225a0c0e84a20a7f54c0025b30edac06
Jira: https://redhat.atlassian.net/browse/RHOAIENG-71235