### PR TITLE
Remove rhods-operator.3.4.1 from skip-bundles for OCP 4.22

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -34,5 +34,4 @@ config:
         - rhods-operator.3.2.1
         - rhods-operator.3.4.0-ea.1
         - rhods-operator.3.4.0-ea.2
-        - rhods-operator.3.4.1
         - rhods-operator.3.5.0-ea.1


### PR DESCRIPTION
## Summary
Remove `rhods-operator.3.4.1` from the `skip-bundles` list for OCP v4.22 in `config/config.yaml`.

## Problem
The FBC build for rhoai-3.4.2 on OCP 4.22 fails with:
```
multiple channel heads found in graph: rhods-operator.3.4.0, rhods-operator.3.4.2
```

Root cause: commit a804240059 (June 25) added `rhods-operator.3.4.1` to `skip-bundles` for v4.22 to unblock nightly builds when 3.4.1 wasn't yet in the published OCP 4.22 index. The PCC regeneration and fbc-processor respect this skip, so 3.4.1 never appears in the v4.22 catalog.

Now that 3.4.2 is being released with `replaces: rhods-operator.3.4.1`, the missing 3.4.1 breaks the OLM upgrade graph (two disconnected heads: 3.4.0 and 3.4.2).

## Fix
Remove `rhods-operator.3.4.1` from skip-bundles for v4.22. The next PCC regeneration + fbc-processor run will include 3.4.1 in the v4.22 catalog, restoring the upgrade chain: 3.4.0 → 3.4.1 → 3.4.2.

## Related
- Release branch catalog fix: https://github.com/red-hat-data-services/RHOAI-Build-Config/pull/24898
- Main branch stage catalog fix: https://github.com/red-hat-data-services/RHOAI-Build-Config/pull/24899
- Failing job: https://github.com/red-hat-data-services/rhods-devops-infra/actions/runs/28352491396/job/83988058730