### PR TITLE
Add odh-kserve-module-operator to bundle relatedImages

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -217,7 +217,8 @@ ARG ODH_WORKBENCHES_OPERATOR_GIT_URL=
 ARG ODH_WORKBENCHES_OPERATOR_GIT_COMMIT=
 ARG ODH_TRAINER_OPERATOR_GIT_URL=
 ARG ODH_TRAINER_OPERATOR_GIT_COMMIT=
-
+ARG ODH_KSERVE_MODULE_OPERATOR_GIT_URL=
+ARG ODH_KSERVE_MODULE_OPERATOR_GIT_COMMIT=
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -445,7 +446,9 @@ LABEL \
       odh-workbenches-operator.git.url="${ODH_WORKBENCHES_OPERATOR_GIT_URL}" \
       odh-workbenches-operator.git.commit="${ODH_WORKBENCHES_OPERATOR_GIT_COMMIT}" \
       odh-trainer-operator.git.url="${ODH_TRAINER_OPERATOR_GIT_URL}" \
-      odh-trainer-operator.git.commit="${ODH_TRAINER_OPERATOR_GIT_COMMIT}"
+      odh-trainer-operator.git.commit="${ODH_TRAINER_OPERATOR_GIT_COMMIT}" \
+      odh-kserve-module-operator.git.url="${ODH_KSERVE_MODULE_OPERATOR_GIT_URL}" \
+      odh-kserve-module-operator.git.commit="${ODH_KSERVE_MODULE_OPERATOR_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -239,6 +239,8 @@ patch:
       value: "quay.io/rhoai/odh-workbenches-operator-rhel9@sha256:dfd63251f5bbb6aef704ef2c75bbd44447d11a2b8eee7f0f38944c265f284640"
     - name: RELATED_IMAGE_ODH_TRAINER_OPERATOR_IMAGE
       value: "quay.io/rhoai/odh-trainer-operator-rhel9@sha256:7db9b5943acadba3804fbb652888be11de6785a4a2941c43d7f565affa51aeb9"
+    - name: RELATED_IMAGE_ODH_KSERVE_MODULE_OPERATOR_IMAGE
+      value: quay.io/rhoai/odh-kserve-module-operator-rhel9@sha256:235a9d9471ae55ac4939c0c3cb82d79c8f5379387d936af5f773b2a16bb994ef
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -121,6 +121,7 @@ config:
         rhoai/odh-mcp-lifecycle-operator-rhel9: rhoai/odh-mcp-lifecycle-operator-rhel9
         rhoai/odh-workbenches-operator-rhel9: rhoai/odh-workbenches-operator-rhel9
         rhoai/odh-trainer-operator-rhel9: rhoai/odh-trainer-operator-rhel9
+        rhoai/odh-kserve-module-operator-rhel9: rhoai/odh-kserve-module-operator-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds relatedImages entry for 'odh-kserve-module-operator' to bundle/bundle-patch.yaml.

Image: quay.io/rhoai/odh-kserve-module-operator-rhel9@sha256:235a9d9471ae55ac4939c0c3cb82d79c8f5379387d936af5f773b2a16bb994ef
Jira: https://redhat.atlassian.net/browse/RHOAIENG-71344