### PR TITLE
Add rhods-operator.2.25.8 entry to catalog-patch.yaml

### DIFF
--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -8,6 +8,9 @@ patch:
       - name: rhods-operator.2.25.9
         replaces: rhods-operator.2.25.8
         skipRange: '>=2.16.0 <2.25.9'
+      - name: rhods-operator.2.25.8
+        replaces: rhods-operator.2.25.7
+        skipRange: '>=2.16.0 <2.25.8'
 
   olm.bundle:
     - quay.io/rhoai/odh-operator-bundle@sha256:70308426e2fd6bec810a61583a5466722304e82d250b0e24b57fbb9979c543a4


### PR DESCRIPTION
## Summary
- Adds `rhods-operator.2.25.8` entry to `eus-2.25` channel in `catalog/catalog-patch.yaml`
- The PCC cache for OCP v4.22 doesn't include 2.25.8 (not yet shipped to v4.22 Red Hat operator index), so the `process-fbc-fragment` automation drops it when rebuilding catalogs
- This entry ensures 2.25.8 survives automation runs on all release branches that use `rhoai-2.25` as `PREVIOUS_RELEASE`

## Merge sequence
**Merge this PR first**, then the rhoai-3.4 catalog-patch PR — the rhoai-3.4 automation checks out rhoai-2.25 as PREVIOUS_RELEASE and needs this entry present

## Test plan
- [ ] After merge, verify `process-fbc-fragment` automation includes `rhods-operator.2.25.8` in the output catalog