### PR TITLE
Add skip-bundles for 2.25.8 and 3.3.4 on OCP v4.22

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -31,7 +31,9 @@ config:
     - version: v4.22
       onboarded-since: rhods-operator.2.25.0
       skip-bundles:
+        - rhods-operator.2.25.8
         - rhods-operator.3.2.1
+        - rhods-operator.3.3.4
         - rhods-operator.3.4.0-ea.1
         - rhods-operator.3.4.0-ea.2
         - rhods-operator.3.5.0-ea.1


### PR DESCRIPTION
## Summary
- Adds `rhods-operator.2.25.8` and `rhods-operator.3.3.4` to `skip-bundles` for v4.22 in `config/config.yaml`
- These versions are shipped (present in `registry.redhat.io/rhoai/odh-operator-bundle` tags) but not yet released to the v4.22 Red Hat operator index
- Without skip-bundles, the catalog validator fails because it expects these versions in the v4.22 catalog
- Same pattern as PR #24626 which added `3.4.1` and `3.5.0-ea.1` to skip-bundles

## Test plan
- [ ] Verify `process-fbc-fragment` and `regen-pcc-cache` workflows pass validation after merge