### PR TITLE
Remove odh-agents-operator from bundle relatedImages (offboarding)

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -187,8 +187,6 @@ ARG ODH_OGX_CORE_GIT_URL=
 ARG ODH_OGX_CORE_GIT_COMMIT=
 ARG ODH_OGX_K8S_OPERATOR_GIT_URL=
 ARG ODH_OGX_K8S_OPERATOR_GIT_COMMIT=
-ARG ODH_AGENTS_OPERATOR_GIT_URL=
-ARG ODH_AGENTS_OPERATOR_GIT_COMMIT=
 ARG ODH_MOD_ARCH_AGENT_OPS_GIT_URL=
 ARG ODH_MOD_ARCH_AGENT_OPS_GIT_COMMIT=
 ARG ODH_LLM_D_BATCH_GATEWAY_OPERATOR_GIT_URL=
@@ -413,8 +411,6 @@ LABEL \
       odh-ogx-core.git.commit="${ODH_OGX_CORE_GIT_COMMIT}" \
       odh-ogx-k8s-operator.git.url="${ODH_OGX_K8S_OPERATOR_GIT_URL}" \
       odh-ogx-k8s-operator.git.commit="${ODH_OGX_K8S_OPERATOR_GIT_COMMIT}" \
-      odh-agents-operator.git.url="${ODH_AGENTS_OPERATOR_GIT_URL}" \
-      odh-agents-operator.git.commit="${ODH_AGENTS_OPERATOR_GIT_COMMIT}" \
       odh-mod-arch-agent-ops.git.url="${ODH_MOD_ARCH_AGENT_OPS_GIT_URL}" \
       odh-mod-arch-agent-ops.git.commit="${ODH_MOD_ARCH_AGENT_OPS_GIT_COMMIT}" \
       odh-llm-d-batch-gateway-operator.git.url="${ODH_LLM_D_BATCH_GATEWAY_OPERATOR_GIT_URL}" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -209,8 +209,6 @@ patch:
       value: "quay.io/rhoai/odh-ogx-core-rhel9@sha256:74d2497940617875aaa29a084454b6f9089e64675fd8db7e0ab60def960a7617"
     - name: RELATED_IMAGE_ODH_OGX_K8S_OPERATOR_IMAGE
       value: "quay.io/rhoai/odh-ogx-k8s-operator-rhel9@sha256:83a1e268edddc1095e0f9f574a0f46eff1462e96511acc5d8e5696cad0fffdf4"
-    - name: RELATED_IMAGE_ODH_AGENTS_OPERATOR_IMAGE
-      value: "quay.io/rhoai/odh-agents-operator-rhel9@sha256:2a950baa216a8a1c9239d862f5ff2cc11df76d305870c2c8b5eb1d31304a511e"
     - name: RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE
       value: "quay.io/rhoai/odh-mod-arch-agent-ops-rhel9@sha256:0bed03dbc2b88529198c52c9dcb105df7664fb094d3424adff7b97a08554e3e8"
     - name: RELATED_IMAGE_ODH_LLM_D_BATCH_GATEWAY_OPERATOR_IMAGE

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -109,7 +109,6 @@ config:
         rhoai/odh-latency-predictor-training-rhel9: rhoai/odh-latency-predictor-training-rhel9
         rhoai/odh-ogx-core-rhel9: rhoai/odh-ogx-core-rhel9
         rhoai/odh-ogx-k8s-operator-rhel9: rhoai/odh-ogx-k8s-operator-rhel9
-        rhoai/odh-agents-operator-rhel9: rhoai/odh-agents-operator-rhel9
         rhoai/odh-mod-arch-agent-ops-rhel9: rhoai/odh-mod-arch-agent-ops-rhel9
         rhoai/odh-llm-d-batch-gateway-operator-rhel9: rhoai/odh-llm-d-batch-gateway-operator-rhel9
         rhoai/odh-llm-d-async-rhel9: rhoai/odh-llm-d-async-rhel9


### PR DESCRIPTION
Removes relatedImages entry for 'odh-agents-operator' from bundle/bundle-patch.yaml.

Jira: https://redhat.atlassian.net/browse/RHOAIENG-72392