### PR TITLE
Increase OCP 4.22 FBC pipeline/tasks timeout to 16h and retrigger build

### DIFF
--- a/.tekton/rhoai-fbc-fragment-rhoai-34-ocp-422-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-34-ocp-422-push.yaml
@@ -15,8 +15,8 @@ metadata:
   namespace: rhoai-tenant
 spec:
   timeouts:
-    pipeline: 12h
-    tasks: 10h
+    pipeline: 16h
+    tasks: 16h
   params:
   - name: git-url
     value: '{{source_url}}'

--- a/builds/force-trigger-rhoai-3.4-ocp-422.txt
+++ b/builds/force-trigger-rhoai-3.4-ocp-422.txt
@@ -1,1 +1,1 @@
-Tue Jul  1 00:00:00 EDT 2026
+Tue Jul  1 12:00:00 EDT 2026


### PR DESCRIPTION
## Summary
- Sets `timeouts.pipeline: 16h` and `timeouts.tasks: 16h` for `rhoai-fbc-fragment-rhoai-34-ocp-422-push`
- Updates `builds/force-trigger-rhoai-3.4-ocp-422.txt` to trigger a new build

## Why
PR #25239 set pipeline:12h tasks:10h, but `fbc-fips-check-oci-ta` per-task timeout is now 14h (via [konflux-central#2684](https://github.com/red-hat-data-services/konflux-central/pull/2684)). Since `timeouts.tasks` is a **cumulative** budget for all non-finally tasks, it must be ≥14h + time for prior tasks. Setting both to 16h ensures the per-task 14h limit is the effective constraint.

## Effective timeouts after merge
| Setting | Value | Source |
|---------|-------|--------|
| Pipeline timeout | 16h | This PR (PipelineRun) |
| Cumulative tasks budget | 16h | This PR (PipelineRun) |
| `fbc-fips-check-oci-ta` per-task | 14h | konflux-central#2684 (pipeline spec) |

## Test plan
- [ ] Verify the OCP 4.22 FBC build triggers after merge
- [ ] Verify `fbc-fips-check-oci-ta` runs beyond the old 6h limit