### PR TITLE
Add release artifacts for RHOAI 3.4.2

### DIFF
--- a/release/3.4.2/prod/prod-release-1782919787/release-charts/prod-release-charts-rhoai-v3-4-1782919787.yaml
+++ b/release/3.4.2/prod/prod-release-1782919787/release-charts/prod-release-charts-rhoai-v3-4-1782919787.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-v3-4-charts-prod-1782919787
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 62ff0a2e146c344830dbcb06c2840f98bff4da9e
+    konflux-release-data/actual-rbc-release-commit: bb961993d3ed55264b26390607f3898e5c9f8133
+    konflux-release-data/artifact-type: charts
+    konflux-release-data/environment: prod
+    appstudio.openshift.io/application: rhoai-v3-4
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-4-charts-prod
+  snapshot: rhoai-v3-4-charts-1782834884
+  data:
+    version: 3.4.2

--- a/release/3.4.2/prod/prod-release-1782919787/release-components/prod-release-components-rhoai-v3-4-1782919787.yaml
+++ b/release/3.4.2/prod/prod-release-1782919787/release-components/prod-release-components-rhoai-v3-4-1782919787.yaml
@@ -1,0 +1,357 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-v3-4-prod-1782919787-1
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 62ff0a2e146c344830dbcb06c2840f98bff4da9e
+    konflux-release-data/artifact-type: components
+    konflux-release-data/environment: prod
+    appstudio.openshift.io/application: rhoai-v3-4
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-4-components-prod
+  snapshot: rhoai-v3-4-1782829383
+  data:
+    version: 3.4.2
+    releaseNotes:
+      cves:
+        - key: 'CVE-2026-5241' # https://redhat.atlassian.net/browse/RHOAIENG-66285
+          component: 'odh-th06-rocm64-torch291-py312-v3-4'
+        - key: 'CVE-2026-5241' # https://redhat.atlassian.net/browse/RHOAIENG-66281
+          component: 'odh-training-rocm62-torch25-py311-v3-4'
+        - key: 'CVE-2026-5241' # https://redhat.atlassian.net/browse/RHOAIENG-66280
+          component: 'odh-training-rocm62-torch24-py311-v3-4'
+        - key: 'CVE-2026-5241' # https://redhat.atlassian.net/browse/RHOAIENG-66277
+          component: 'odh-training-cuda128-torch29-py312-v3-4'
+        - key: 'CVE-2026-5241' # https://redhat.atlassian.net/browse/RHOAIENG-66276
+          component: 'odh-training-cuda121-torch24-py311-v3-4'
+        - key: 'CVE-2026-5241' # https://redhat.atlassian.net/browse/RHOAIENG-66275
+          component: 'odh-training-cuda124-torch25-py311-v3-4'
+        - key: 'CVE-2026-5241' # https://redhat.atlassian.net/browse/RHOAIENG-66266
+          component: 'odh-th06-cpu-torch210-py312-v3-4'
+        - key: 'CVE-2026-5241' # https://redhat.atlassian.net/browse/RHOAIENG-66265
+          component: 'odh-training-rocm64-torch28-py312-v3-4'
+        - key: 'CVE-2026-5241' # https://redhat.atlassian.net/browse/RHOAIENG-66264
+          component: 'odh-th06-cuda130-torch210-py312-v3-4'
+        - key: 'CVE-2026-34993' # https://redhat.atlassian.net/browse/RHOAIENG-66034
+          component: 'odh-training-cuda124-torch25-py311-v3-4'
+        - key: 'CVE-2026-34993' # https://redhat.atlassian.net/browse/RHOAIENG-66031
+          component: 'odh-training-rocm64-torch28-py312-v3-4'
+        - key: 'CVE-2026-34993' # https://redhat.atlassian.net/browse/RHOAIENG-66026
+          component: 'odh-training-rocm62-torch24-py311-v3-4'
+        - key: 'CVE-2026-34993' # https://redhat.atlassian.net/browse/RHOAIENG-66024
+          component: 'odh-mlserver-v3-4'
+        - key: 'CVE-2026-34993' # https://redhat.atlassian.net/browse/RHOAIENG-66020
+          component: 'odh-training-cuda128-torch29-py312-v3-4'
+        - key: 'CVE-2026-34993' # https://redhat.atlassian.net/browse/RHOAIENG-66015
+          component: 'odh-training-rocm62-torch25-py311-v3-4'
+        - key: 'CVE-2026-34993' # https://redhat.atlassian.net/browse/RHOAIENG-66013
+          component: 'odh-training-cuda121-torch24-py311-v3-4'
+        - key: 'CVE-2026-34993' # https://redhat.atlassian.net/browse/RHOAIENG-66011
+          component: 'odh-trustyai-garak-lls-provider-dsp-v3-4'
+        - key: 'CVE-2026-34993' # https://redhat.atlassian.net/browse/RHOAIENG-66009
+          component: 'odh-training-rocm64-torch29-py312-v3-4'
+        - key: 'CVE-2026-34993' # https://redhat.atlassian.net/browse/RHOAIENG-66007
+          component: 'odh-training-cuda128-torch28-py312-v3-4'
+        - key: 'CVE-2026-33245' # https://redhat.atlassian.net/browse/RHOAIENG-65876
+          component: 'odh-mod-arch-maas-v3-4'
+        - key: 'CVE-2026-33245' # https://redhat.atlassian.net/browse/RHOAIENG-65872
+          component: 'odh-mod-arch-model-registry-v3-4'
+        - key: 'CVE-2026-33245' # https://redhat.atlassian.net/browse/RHOAIENG-65871
+          component: 'odh-mod-arch-eval-hub-v3-4'
+        - key: 'CVE-2026-33245' # https://redhat.atlassian.net/browse/RHOAIENG-65868
+          component: 'odh-mod-arch-gen-ai-v3-4'
+        - key: 'CVE-2026-33245' # https://redhat.atlassian.net/browse/RHOAIENG-65866
+          component: 'odh-mod-arch-automl-v3-4'
+        - key: 'CVE-2026-33245' # https://redhat.atlassian.net/browse/RHOAIENG-65864
+          component: 'odh-mod-arch-mlflow-v3-4'
+        - key: 'CVE-2026-33245' # https://redhat.atlassian.net/browse/RHOAIENG-65863
+          component: 'odh-mod-arch-autorag-v3-4'
+        - key: 'CVE-2026-2614' # https://redhat.atlassian.net/browse/RHOAIENG-65834
+          component: 'odh-th06-cpu-torch210-py312-v3-4'
+        - key: 'CVE-2026-2614' # https://redhat.atlassian.net/browse/RHOAIENG-65831
+          component: 'odh-training-cuda128-torch29-py312-v3-4'
+        - key: 'CVE-2026-2614' # https://redhat.atlassian.net/browse/RHOAIENG-65824
+          component: 'odh-th06-cuda130-torch210-py312-v3-4'
+        - key: 'CVE-2026-2614' # https://redhat.atlassian.net/browse/RHOAIENG-65821
+          component: 'odh-th06-rocm64-torch291-py312-v3-4'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64931
+          component: 'odh-workbench-jupyter-trustyai-cpu-py312-v3-4'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64930
+          component: 'odh-llama-stack-core-v3-4'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64928
+          component: 'odh-workbench-jupyter-pytorch-rocm-py312-v3-4'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64925
+          component: 'odh-trustyai-garak-lls-provider-dsp-v3-4'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64924
+          component: 'odh-workbench-codeserver-datascience-cpu-py312-v3-4'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64922
+          component: 'odh-pipeline-runtime-datascience-cpu-py312-v3-4'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64918
+          component: 'odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-4'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64917
+          component: 'odh-pipeline-runtime-pytorch-rocm-py312-v3-4'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64916
+          component: 'odh-pipeline-runtime-tensorflow-cuda-py312-v3-4'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64915
+          component: 'odh-workbench-jupyter-datascience-cpu-py312-v3-4'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64914
+          component: 'odh-workbench-jupyter-tensorflow-rocm-py312-v3-4'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64911
+          component: 'odh-pipeline-runtime-tensorflow-rocm-py312-v3-4'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64910
+          component: 'odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-4'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64909
+          component: 'odh-workbench-jupyter-tensorflow-cuda-py312-v3-4'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64905
+          component: 'odh-workbench-jupyter-pytorch-cuda-py312-v3-4'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64903
+          component: 'odh-pipeline-runtime-pytorch-cuda-py312-v3-4'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64902
+          component: 'odh-trustyai-nemo-guardrails-server-v3-4'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64109
+          component: 'odh-training-rocm62-torch24-py311-v3-4'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64107
+          component: 'odh-training-rocm64-torch29-py312-v3-4'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64106
+          component: 'odh-training-cuda128-torch28-py312-v3-4'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64104
+          component: 'odh-training-rocm64-torch28-py312-v3-4'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64102
+          component: 'odh-training-cuda128-torch29-py312-v3-4'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64101
+          component: 'odh-training-rocm62-torch25-py311-v3-4'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64099
+          component: 'odh-th06-cuda130-torch210-py312-v3-4'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64098
+          component: 'odh-training-cuda121-torch24-py311-v3-4'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64095
+          component: 'odh-th06-cpu-torch291-py312-v3-4'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64093
+          component: 'odh-th06-cpu-torch210-py312-v3-4'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64091
+          component: 'odh-th06-cuda130-torch291-py312-v3-4'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64090
+          component: 'odh-training-cuda124-torch25-py311-v3-4'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64089
+          component: 'odh-th06-rocm64-torch291-py312-v3-4'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64083
+          component: 'odh-kserve-storage-initializer-v3-4'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64081
+          component: 'odh-mlserver-v3-4'
+      issues:
+          fixed:
+            - id: RHOAIENG-66285
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66281
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66280
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66277
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66276
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66275
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66266
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66265
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66264
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66034
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66031
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66026
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66024
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66020
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66015
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66013
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66011
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66009
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66007
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65876
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65872
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65871
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65868
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65866
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65864
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65863
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65834
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65831
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65824
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65821
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64931
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64930
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64928
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64925
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64924
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64922
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64918
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64917
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64916
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64915
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64914
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64911
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64910
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64909
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64905
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64903
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64902
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64109
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64107
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64106
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64104
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64102
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64101
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64099
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64098
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64095
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64093
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64091
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64090
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64089
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64083
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64081
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-67549
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65547
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64768
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64437
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-63795
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-63792
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-63756
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-61112
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59726
+              public: true
+              source: redhat.atlassian.net

--- a/release/3.4.2/prod/prod-release-1782919787/release-fbc/prod-release-fbc-ocp-419-rhoai-v3-4-1782919787.yaml
+++ b/release/3.4.2/prod/prod-release-1782919787/release-fbc/prod-release-fbc-ocp-419-rhoai-v3-4-1782919787.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-419-prod-1782919787
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 62ff0a2e146c344830dbcb06c2840f98bff4da9e
+    konflux-release-data/ocp-version: ocp-419
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: prod
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-419
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-4-ocp-419-fbc-prod
+  snapshot: rhoai-fbc-fragment-ocp-419-1782917080
+  data:
+    version: 3.4.2

--- a/release/3.4.2/prod/prod-release-1782919787/release-fbc/prod-release-fbc-ocp-420-rhoai-v3-4-1782919787.yaml
+++ b/release/3.4.2/prod/prod-release-1782919787/release-fbc/prod-release-fbc-ocp-420-rhoai-v3-4-1782919787.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-420-prod-1782919787
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 62ff0a2e146c344830dbcb06c2840f98bff4da9e
+    konflux-release-data/ocp-version: ocp-420
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: prod
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-420
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-4-ocp-420-fbc-prod
+  snapshot: rhoai-fbc-fragment-ocp-420-1782917080
+  data:
+    version: 3.4.2

--- a/release/3.4.2/prod/prod-release-1782919787/release-fbc/prod-release-fbc-ocp-421-rhoai-v3-4-1782919787.yaml
+++ b/release/3.4.2/prod/prod-release-1782919787/release-fbc/prod-release-fbc-ocp-421-rhoai-v3-4-1782919787.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-421-prod-1782919787
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 62ff0a2e146c344830dbcb06c2840f98bff4da9e
+    konflux-release-data/ocp-version: ocp-421
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: prod
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-421
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-4-ocp-421-fbc-prod
+  snapshot: rhoai-fbc-fragment-ocp-421-1782917080
+  data:
+    version: 3.4.2

--- a/release/3.4.2/prod/prod-release-1782919787/release-fbc/prod-release-fbc-ocp-422-rhoai-v3-4-1782919787.yaml
+++ b/release/3.4.2/prod/prod-release-1782919787/release-fbc/prod-release-fbc-ocp-422-rhoai-v3-4-1782919787.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-422-prod-1782919787
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 62ff0a2e146c344830dbcb06c2840f98bff4da9e
+    konflux-release-data/ocp-version: ocp-422
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: prod
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-422
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-4-ocp-422-fbc-prod
+  snapshot: rhoai-fbc-fragment-ocp-422-1782917080
+  data:
+    version: 3.4.2

--- a/release/3.4.2/stage/RC1/stage-release-62ff0a2e/release-charts/release-charts-stage-rhoai-v3-4-1782834884.yaml
+++ b/release/3.4.2/stage/RC1/stage-release-62ff0a2e/release-charts/release-charts-stage-rhoai-v3-4-1782834884.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    appstudio.openshift.io/application: rhoai-v3-4
+    konflux-release-data/actual-rbc-release-commit: bb961993d3ed55264b26390607f3898e5c9f8133
+    konflux-release-data/artifact-type: charts
+    konflux-release-data/environment: stage
+    konflux-release-data/rbc-release-commit: 62ff0a2e146c344830dbcb06c2840f98bff4da9e
+  name: rhoai-v3-4-charts-stage-1782834884
+  namespace: rhoai-tenant
+spec:
+  data:
+    version: 3.4.2
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-4-charts-stage
+  snapshot: rhoai-v3-4-charts-1782834884

--- a/release/3.4.2/stage/RC1/stage-release-62ff0a2e/release-components/release-components-stage-rhoai-v3-4-1782829383.yaml
+++ b/release/3.4.2/stage/RC1/stage-release-62ff0a2e/release-components/release-components-stage-rhoai-v3-4-1782829383.yaml
@@ -1,0 +1,16 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    appstudio.openshift.io/application: rhoai-v3-4
+    konflux-release-data/artifact-type: components
+    konflux-release-data/environment: stage
+    konflux-release-data/rbc-release-commit: 62ff0a2e146c344830dbcb06c2840f98bff4da9e
+  name: rhoai-v3-4-stage-1782829383
+  namespace: rhoai-tenant
+spec:
+  data:
+    version: 3.4.2
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-4-components-stage
+  snapshot: rhoai-v3-4-1782829383

--- a/release/3.4.2/stage/RC1/stage-release-62ff0a2e/release-fbc/release-fbc-stage-ocp-419-rhoai-v3-4-1782917080.yaml
+++ b/release/3.4.2/stage/RC1/stage-release-62ff0a2e/release-fbc/release-fbc-stage-ocp-419-rhoai-v3-4-1782917080.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-419-stage-1782917080
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 62ff0a2e146c344830dbcb06c2840f98bff4da9e
+    konflux-release-data/ocp-version: ocp-419
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-419
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-4-ocp-419-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-419-1782917080
+  data:
+    version: 3.4.2

--- a/release/3.4.2/stage/RC1/stage-release-62ff0a2e/release-fbc/release-fbc-stage-ocp-420-rhoai-v3-4-1782917080.yaml
+++ b/release/3.4.2/stage/RC1/stage-release-62ff0a2e/release-fbc/release-fbc-stage-ocp-420-rhoai-v3-4-1782917080.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-420-stage-1782917080
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 62ff0a2e146c344830dbcb06c2840f98bff4da9e
+    konflux-release-data/ocp-version: ocp-420
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-420
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-4-ocp-420-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-420-1782917080
+  data:
+    version: 3.4.2

--- a/release/3.4.2/stage/RC1/stage-release-62ff0a2e/release-fbc/release-fbc-stage-ocp-421-rhoai-v3-4-1782917080.yaml
+++ b/release/3.4.2/stage/RC1/stage-release-62ff0a2e/release-fbc/release-fbc-stage-ocp-421-rhoai-v3-4-1782917080.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-421-stage-1782917080
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 62ff0a2e146c344830dbcb06c2840f98bff4da9e
+    konflux-release-data/ocp-version: ocp-421
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-421
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-4-ocp-421-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-421-1782917080
+  data:
+    version: 3.4.2

--- a/release/3.4.2/stage/RC1/stage-release-62ff0a2e/release-fbc/release-fbc-stage-ocp-422-rhoai-v3-4-1782917080.yaml
+++ b/release/3.4.2/stage/RC1/stage-release-62ff0a2e/release-fbc/release-fbc-stage-ocp-422-rhoai-v3-4-1782917080.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-422-stage-1782917080
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 62ff0a2e146c344830dbcb06c2840f98bff4da9e
+    konflux-release-data/ocp-version: ocp-422
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-422
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-4-ocp-422-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-422-1782917080
+  data:
+    version: 3.4.2

--- a/release/3.4.2/stage/RC1/stage-release-62ff0a2e/snapshot-charts/snapshot-charts-stage-rhoai-v3-4-1782834884.yaml
+++ b/release/3.4.2/stage/RC1/stage-release-62ff0a2e/snapshot-charts/snapshot-charts-stage-rhoai-v3-4-1782834884.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  labels:
+    konflux-release-data/actual-rbc-release-commit: bb961993d3ed55264b26390607f3898e5c9f8133
+    konflux-release-data/artifact-type: charts
+    konflux-release-data/rbc-release-commit: 62ff0a2e146c344830dbcb06c2840f98bff4da9e
+    test.appstudio.openshift.io/type: override
+  name: rhoai-v3-4-charts-1782834884
+  namespace: rhoai-tenant
+spec:
+  application: rhoai-v3-4
+  components:
+  - containerImage: quay.io/rhoai/rhai-on-openshift-chart@sha256:5a164ed89e67619f6e7ced4ac1bdc9ae778f9649bbf0f81c9541374d6ddb4c72
+    name: rhai-on-openshift-chart-v3-4
+  - containerImage: quay.io/rhoai/rhai-on-xks-chart@sha256:fae51e2e355d3a32f4efa907c5ea33159a78e315d35abc792c76dd672dba1188
+    name: rhai-on-xks-chart-v3-4

--- a/release/3.4.2/stage/RC1/stage-release-62ff0a2e/snapshot-components/snapshot-components-stage-rhoai-v3-4-1782829383.yaml
+++ b/release/3.4.2/stage/RC1/stage-release-62ff0a2e/snapshot-components/snapshot-components-stage-rhoai-v3-4-1782829383.yaml
@@ -1,0 +1,648 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  labels:
+    konflux-release-data/artifact-type: components
+    konflux-release-data/rbc-release-commit: 62ff0a2e146c344830dbcb06c2840f98bff4da9e
+    test.appstudio.openshift.io/type: override
+  name: rhoai-v3-4-1782829383
+  namespace: rhoai-tenant
+spec:
+  application: rhoai-v3-4
+  components:
+  - containerImage: quay.io/rhoai/odh-operator-bundle@sha256:cb6c88c74e68dbc55c9c976e251da2a38bf97feb2cf3ad0719f458a98f05352a
+    name: odh-operator-bundle-v3-4
+    source:
+      git:
+        revision: bb961993d3ed55264b26390607f3898e5c9f8133
+        url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+  - containerImage: quay.io/rhoai/odh-ai-gateway-payload-processing-rhel9@sha256:f50970346465edcb371d06365f9d794bd4069c7a2a40e033f69bea0a37c2bbf2
+    name: odh-ai-gateway-payload-processing-v3-4
+    source:
+      git:
+        revision: 3f92142b3fc8f4cacdf1167faab7ac44168bd34d
+        url: https://github.com/red-hat-data-services/ai-gateway-payload-processing
+  - containerImage: quay.io/rhoai/odh-automl-rhel9@sha256:7c6d8346d1ca0ce905ce2d0021706cd90570a7c00b587f6187385151896b283a
+    name: odh-automl-v3-4
+    source:
+      git:
+        revision: 31ca14a29e88ab51d832af361aa3548b585feee0
+        url: https://github.com/red-hat-data-services/pipelines-components
+  - containerImage: quay.io/rhoai/odh-autorag-rhel9@sha256:2f55376c6c698ba0f6e7008d70b18723af4c6a87a6fcf76ecf58ed8ae40655c0
+    name: odh-autorag-v3-4
+    source:
+      git:
+        revision: 31ca14a29e88ab51d832af361aa3548b585feee0
+        url: https://github.com/red-hat-data-services/pipelines-components
+  - containerImage: quay.io/rhoai/odh-built-in-detector-rhel9@sha256:d9ed98c9e442c5325adbef0e900ad0547a9550b1275490daf6f5effda14ec7bd
+    name: odh-built-in-detector-v3-4
+    source:
+      git:
+        revision: 4b8149325a84bf540d2461ece5bd7667a94a9723
+        url: https://github.com/red-hat-data-services/guardrails-detectors
+  - containerImage: quay.io/rhoai/odh-cli-rhel9@sha256:4b20127171a13658900d6bfcfdb537f751dcd6a7e34add2d5a22e2f058f93f33
+    name: odh-cli-v3-4
+    source:
+      git:
+        revision: 7493a132f42cd25825b9c8aacf33d217ca385408
+        url: https://github.com/red-hat-data-services/odh-cli
+  - containerImage: quay.io/rhoai/odh-dashboard-rhel9@sha256:ef27b31dd24931f3606ef0d4f923f91cd2ced02dd7f20a75962b4fd07b4b0c80
+    name: odh-dashboard-v3-4
+    source:
+      git:
+        revision: ae06f04f41a2d6a7fc0c7d3feaa6ea741436e36c
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-data-science-pipelines-argo-argoexec-rhel9@sha256:b94cad89c15b097de0a03948946aa8418a73bbd3d8c7fb054f9ee07cca88acf6
+    name: odh-data-science-pipelines-argo-argoexec-v3-4
+    source:
+      git:
+        revision: 7153f81ee590f0f37e7f432dc153b86b023a1ffb
+        url: https://github.com/red-hat-data-services/argo-workflows
+  - containerImage: quay.io/rhoai/odh-data-science-pipelines-argo-workflowcontroller-rhel9@sha256:ec55d5c6e4c4bf2a6f3ce13d12999bd151fd4131e9b7f7b1f5efa4bb61f1a375
+    name: odh-data-science-pipelines-argo-workflowcontroller-v3-4
+    source:
+      git:
+        revision: 7153f81ee590f0f37e7f432dc153b86b023a1ffb
+        url: https://github.com/red-hat-data-services/argo-workflows
+  - containerImage: quay.io/rhoai/odh-data-science-pipelines-operator-controller-rhel9@sha256:ee320f9824d83bc5ec5f9079945ac34707b30d29a26bfcd7fb36343b63337bb7
+    name: odh-data-science-pipelines-operator-controller-v3-4
+    source:
+      git:
+        revision: 48d14c2c0340942e9ce20d0b744017211fd72431
+        url: https://github.com/red-hat-data-services/data-science-pipelines-operator
+  - containerImage: quay.io/rhoai/odh-eval-hub-rhel9@sha256:5504a625065b762c289093e87145a02a1ea48181b497f30fa714e51a1bdcde20
+    name: odh-eval-hub-v3-4
+    source:
+      git:
+        revision: fbbc2744a41493b6729df7ed9293119ab10a739d
+        url: https://github.com/red-hat-data-services/eval-hub
+  - containerImage: quay.io/rhoai/odh-feast-operator-rhel9@sha256:c48e7eb6cf3957621250a6a9e9d680e33bb899fea3dc79b10c8b2eac71c6f474
+    name: odh-feast-operator-v3-4
+    source:
+      git:
+        revision: 1b8a0b308216e5ca5fb8ac439ced213af8764e0d
+        url: https://github.com/red-hat-data-services/feast
+  - containerImage: quay.io/rhoai/odh-feature-server-rhel9@sha256:27ab3584ebdc960bad5fcd25f05386b9fd270aa49e29286097f2681fdcdd8ec2
+    name: odh-feature-server-v3-4
+    source:
+      git:
+        revision: 1b8a0b308216e5ca5fb8ac439ced213af8764e0d
+        url: https://github.com/red-hat-data-services/feast
+  - containerImage: quay.io/rhoai/odh-fms-guardrails-orchestrator-rhel9@sha256:f8e30100501c88b33c242a6599dd969257211a8e4c5113cb80c98890e83a51b0
+    name: odh-fms-guardrails-orchestrator-v3-4
+    source:
+      git:
+        revision: 039120bd7cc600fe6e564857a23a493141937cb1
+        url: https://github.com/red-hat-data-services/fms-guardrails-orchestrator
+  - containerImage: quay.io/rhoai/odh-guardrails-detector-huggingface-runtime-rhel9@sha256:824397e29bd0bba9987391ec55d50c2d79cc204c2b1a52722a8fe7c399a76b80
+    name: odh-guardrails-detector-huggingface-runtime-v3-4
+    source:
+      git:
+        revision: 4b8149325a84bf540d2461ece5bd7667a94a9723
+        url: https://github.com/red-hat-data-services/guardrails-detectors
+  - containerImage: quay.io/rhoai/odh-kf-notebook-controller-rhel9@sha256:cc8b688a859c5fc23ca1fa8c9205b1670872f6f4c8aeeedc36781ffbb85eadc6
+    name: odh-kf-notebook-controller-v3-4
+    source:
+      git:
+        revision: 630e471207d60796e91d0e2c6b5389d10e1a8481
+        url: https://github.com/red-hat-data-services/kubeflow
+  - containerImage: quay.io/rhoai/odh-kserve-agent-rhel9@sha256:00869f9eb48fe189feb9659fd53d8e881b089fea9c81a467112a5fd23e1dfe84
+    name: odh-kserve-agent-v3-4
+    source:
+      git:
+        revision: dd6b1f133ec4c6920d6344f8b96a3236be6062ba
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kserve-autogluon-server-rhel9@sha256:2ed9af6a228dad7368b0c0caf1cabfb31ead68f319453e80adb6d6b49723144c
+    name: odh-kserve-autogluon-server-v3-4
+    source:
+      git:
+        revision: 57c29bf33f0e924bc9750828cbf777468e9c5b63
+        url: https://github.com/red-hat-data-services/kserve-autogluon-server
+  - containerImage: quay.io/rhoai/odh-kserve-controller-rhel9@sha256:e046443ba557cb4c6c1dec0edb366752f7be0ba146caa2a341ee473c67443a99
+    name: odh-kserve-controller-v3-4
+    source:
+      git:
+        revision: dd6b1f133ec4c6920d6344f8b96a3236be6062ba
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kserve-llmisvc-controller-rhel9@sha256:0495227047148ed687f646b660d3b872fce966d01579b3527cc92cdb6ba7bdd7
+    name: odh-kserve-llmisvc-controller-v3-4
+    source:
+      git:
+        revision: dd6b1f133ec4c6920d6344f8b96a3236be6062ba
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kserve-router-rhel9@sha256:420d68be2fec520132a4d9b9bf0306ae705b9b1e453f5955670dcdcc69d89f0a
+    name: odh-kserve-router-v3-4
+    source:
+      git:
+        revision: dd6b1f133ec4c6920d6344f8b96a3236be6062ba
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kserve-storage-initializer-rhel9@sha256:83bebb2ea3ef6285355a45c56af393d3cec4cb9802717c436515f283bf806845
+    name: odh-kserve-storage-initializer-v3-4
+    source:
+      git:
+        revision: dd6b1f133ec4c6920d6344f8b96a3236be6062ba
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kube-auth-proxy-rhel9@sha256:a059f453011028f7f18b3c7ec6406a958aa7a5b9bf6c67d084ea9d5d36d6c970
+    name: odh-kube-auth-proxy-v3-4
+    source:
+      git:
+        revision: d62ed8a6a074eb90c04a517f2edcde508d85cb4d
+        url: https://github.com/red-hat-data-services/kube-auth-proxy
+  - containerImage: quay.io/rhoai/odh-kube-auth-proxy-rhel9@sha256:a059f453011028f7f18b3c7ec6406a958aa7a5b9bf6c67d084ea9d5d36d6c970
+    name: odh-kube-auth-proxy-v3-4
+    source:
+      git:
+        revision: d62ed8a6a074eb90c04a517f2edcde508d85cb4d
+        url: https://github.com/red-hat-data-services/kube-auth-proxy
+  - containerImage: quay.io/rhoai/odh-kuberay-operator-controller-rhel9@sha256:20673767942c8877be4738a5aa338d23a947e7d32748cb1bbb55fc6377213b21
+    name: odh-kuberay-operator-controller-v3-4
+    source:
+      git:
+        revision: 97fef47b985bac6ed2863881b1da373f7944c958
+        url: https://github.com/red-hat-data-services/kuberay
+  - containerImage: quay.io/rhoai/odh-llama-stack-core-rhel9@sha256:7fad9704508055ac1259213310a9b793163f875c8c033b8517f7242d9c4e9d00
+    name: odh-llama-stack-core-v3-4
+    source:
+      git:
+        revision: dfc2be5916b6de5ab63444df48c7386b24bbd78a
+        url: https://github.com/red-hat-data-services/ogx-distribution
+  - containerImage: quay.io/rhoai/odh-llama-stack-k8s-operator-rhel9@sha256:9eb6767db203c1e10aabd6950657777633462e148d0d40bc9591f8c2d5229023
+    name: odh-llama-stack-k8s-operator-v3-4
+    source:
+      git:
+        revision: dfe291b7b850f11bea29f180f1a514dfd1c8f0f9
+        url: https://github.com/red-hat-data-services/ogx-k8s-operator
+  - containerImage: quay.io/rhoai/odh-llm-d-batch-gateway-apiserver-rhel9@sha256:72e510a2bc987db72523caf1b791dc07954471a66f8b7a9dda792c07c4f6005d
+    name: odh-llm-d-batch-gateway-apiserver-v3-4
+    source:
+      git:
+        revision: f2f30ecab915e51a81002f99f0d0acf513d1ecc7
+        url: https://github.com/red-hat-data-services/batch-gateway
+  - containerImage: quay.io/rhoai/odh-llm-d-batch-gateway-gc-rhel9@sha256:ea3f15ab181a21138f3dbe1bfd178c7042b6c5a963951bec0c4af7cb4d872b7a
+    name: odh-llm-d-batch-gateway-gc-v3-4
+    source:
+      git:
+        revision: f2f30ecab915e51a81002f99f0d0acf513d1ecc7
+        url: https://github.com/red-hat-data-services/batch-gateway
+  - containerImage: quay.io/rhoai/odh-llm-d-batch-gateway-processor-rhel9@sha256:9470e428981fd041b506a05dc1b9ebd6d1d925dab578961926da355c2d279363
+    name: odh-llm-d-batch-gateway-processor-v3-4
+    source:
+      git:
+        revision: f2f30ecab915e51a81002f99f0d0acf513d1ecc7
+        url: https://github.com/red-hat-data-services/batch-gateway
+  - containerImage: quay.io/rhoai/odh-llm-d-inference-scheduler-rhel9@sha256:3b630017598a70a380d5ce9f5e15916a1b9cc8f16f392e544182399731d2bda6
+    name: odh-llm-d-inference-scheduler-v3-4
+    source:
+      git:
+        revision: d23ba7930769970cd00d6069c4aaabf2dee46fcc
+        url: https://github.com/red-hat-data-services/llm-d-inference-scheduler
+  - containerImage: quay.io/rhoai/odh-llm-d-kv-cache-rhel9@sha256:8f684d8820aacde27c5baf5937d4068badfba4cc95155c98a684b8d8697d3368
+    name: odh-llm-d-kv-cache-v3-4
+    source:
+      git:
+        revision: 2d71f77a454a433b91ae0e91055f74bbda18cd03
+        url: https://github.com/red-hat-data-services/llm-d-kv-cache
+  - containerImage: quay.io/rhoai/odh-llm-d-routing-sidecar-rhel9@sha256:18dbf82a01a3ea9eba27519884c9427a73a9d3a572d8c7c673aa821806034bb8
+    name: odh-llm-d-routing-sidecar-v3-4
+    source:
+      git:
+        revision: d23ba7930769970cd00d6069c4aaabf2dee46fcc
+        url: https://github.com/red-hat-data-services/llm-d-inference-scheduler
+  - containerImage: quay.io/rhoai/odh-maas-api-rhel9@sha256:43fac73059ec1664537877e1e37f5cb337aee7d94e6f04cd32f2bf5ad6a0ec2c
+    name: odh-maas-api-v3-4
+    source:
+      git:
+        revision: e7fa1f845cfc330cba15c277d5611a3fb3e8145a
+        url: https://github.com/red-hat-data-services/models-as-a-service
+  - containerImage: quay.io/rhoai/odh-maas-controller-rhel9@sha256:745da3f2220415b37e099e0067fe73d6080c6bd16cc340d432666b606a232686
+    name: odh-maas-controller-v3-4
+    source:
+      git:
+        revision: e7fa1f845cfc330cba15c277d5611a3fb3e8145a
+        url: https://github.com/red-hat-data-services/models-as-a-service
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-api-server-v2-rhel9@sha256:f65157102a539e1c192bed88371dcb79b8c4b220d0918bb920f81c04723fb92e
+    name: odh-ml-pipelines-api-server-v2-v3-4
+    source:
+      git:
+        revision: 8cfef8204fcc15f9fa9bc2f9e7752a2e9bb92d3d
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-driver-rhel9@sha256:e14ffa1a6efc36f62b25a1e0efb83792f00293ec6fb6a5659c69f3af85e4316f
+    name: odh-ml-pipelines-driver-v3-4
+    source:
+      git:
+        revision: 8cfef8204fcc15f9fa9bc2f9e7752a2e9bb92d3d
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-launcher-rhel9@sha256:613e796b6fa2551dfa2858bf81a7756afb84881ea5656faa54fafad5d4375359
+    name: odh-ml-pipelines-launcher-v3-4
+    source:
+      git:
+        revision: 8cfef8204fcc15f9fa9bc2f9e7752a2e9bb92d3d
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-persistenceagent-v2-rhel9@sha256:3baf7cc08c529493f26bc7174bbdc207dd485c278f5c0dda36301d8e5115d7f2
+    name: odh-ml-pipelines-persistenceagent-v2-v3-4
+    source:
+      git:
+        revision: 8cfef8204fcc15f9fa9bc2f9e7752a2e9bb92d3d
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-scheduledworkflow-v2-rhel9@sha256:e0a6b9f3f8bb41b73be2be3c79efd8ba5bcccb71965e440a8f27da26185f658f
+    name: odh-ml-pipelines-scheduledworkflow-v2-v3-4
+    source:
+      git:
+        revision: 8cfef8204fcc15f9fa9bc2f9e7752a2e9bb92d3d
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-mlflow-operator-rhel9@sha256:4bcfdd1bb9b0103aeb072315d9130644fd3f3eb24fa8f752c7863a89c27df59b
+    name: odh-mlflow-operator-v3-4
+    source:
+      git:
+        revision: 9d16e0635e65f49c9248595b92cebff144e220c6
+        url: https://github.com/red-hat-data-services/mlflow-operator
+  - containerImage: quay.io/rhoai/odh-mlflow-rhel9@sha256:3760d0ab0576d19db4ddb8e702f0650683ad8f901060544f9a68534110b82c67
+    name: odh-mlflow-v3-4
+    source:
+      git:
+        revision: 6229e4904e3f3bcc165ddaea0bd1bc49b3ec2d51
+        url: https://github.com/red-hat-data-services/mlflow
+  - containerImage: quay.io/rhoai/odh-mlmd-grpc-server-rhel9@sha256:ca59797250374b322b66a3b6ef2f7f9e4045255f729d0b5f6e9033f7bf79ed55
+    name: odh-mlmd-grpc-server-v3-4
+    source:
+      git:
+        revision: ca9a2f9cca8e62a1ecd54b48bc86d744bcab8cf3
+        url: https://github.com/red-hat-data-services/ml-metadata
+  - containerImage: quay.io/rhoai/odh-mlserver-rhel9@sha256:ebb3fe12eb37c4fed6bce99a58e31bb6df37c4183166b8ae6e85f6c22a29b92c
+    name: odh-mlserver-v3-4
+    source:
+      git:
+        revision: 09de58c45f368e5c023afd8e9cdae88c2aad28ff
+        url: https://github.com/red-hat-data-services/MLServer
+  - containerImage: quay.io/rhoai/odh-mod-arch-automl-rhel9@sha256:d9e2c97671a136025565f270cee6009f7cd11bacba070b9c2e98eca69fd2b81f
+    name: odh-mod-arch-automl-v3-4
+    source:
+      git:
+        revision: ae06f04f41a2d6a7fc0c7d3feaa6ea741436e36c
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-mod-arch-autorag-rhel9@sha256:490aca751f526463445419ea6d01da8573f6e8bb0ddc2d6b4b0a3b3320b05c74
+    name: odh-mod-arch-autorag-v3-4
+    source:
+      git:
+        revision: ae06f04f41a2d6a7fc0c7d3feaa6ea741436e36c
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-mod-arch-eval-hub-rhel9@sha256:b1e93b8f6813980d356d4f03cc3bf5e89865184bfddeba4fe0859ec665bf6a4b
+    name: odh-mod-arch-eval-hub-v3-4
+    source:
+      git:
+        revision: ae06f04f41a2d6a7fc0c7d3feaa6ea741436e36c
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-mod-arch-gen-ai-rhel9@sha256:2a54bcce301d118295177469204eed8849cc6ecd9642d638e9c72058165736a6
+    name: odh-mod-arch-gen-ai-v3-4
+    source:
+      git:
+        revision: 2bc2f89b522e34ad648bcf7728b35c73e1cb5316
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-mod-arch-maas-rhel9@sha256:fb70ad923d754e63248e26e117b7c85c5cadbde71c7f7edf6b2ecefb733d3acd
+    name: odh-mod-arch-maas-v3-4
+    source:
+      git:
+        revision: ae06f04f41a2d6a7fc0c7d3feaa6ea741436e36c
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-mod-arch-mlflow-rhel9@sha256:41203ce11f280447a2009fcbcdb7f2e7f9a94d0b90a067e1f4edac2a32c81d57
+    name: odh-mod-arch-mlflow-v3-4
+    source:
+      git:
+        revision: 2bc2f89b522e34ad648bcf7728b35c73e1cb5316
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-mod-arch-model-registry-rhel9@sha256:d02e85c41f94f0ece7eb0ceaf44dd9e274e129cd4c75442feed4f2fc9662a5bd
+    name: odh-mod-arch-model-registry-v3-4
+    source:
+      git:
+        revision: ae06f04f41a2d6a7fc0c7d3feaa6ea741436e36c
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-model-controller-rhel9@sha256:1bc6da3691e102165e5d5205e8de93c3917c8855d1c1588386fb72662f8d5cf4
+    name: odh-model-controller-v3-4
+    source:
+      git:
+        revision: b0e6723585b64d596ee286f480d811285e5d4f04
+        url: https://github.com/red-hat-data-services/odh-model-controller
+  - containerImage: quay.io/rhoai/odh-model-metadata-collection-rhel9@sha256:7d13bfe60239247a73f6b0d1dec8c505f46115c59164cbb9d972bf84703a2407
+    name: odh-model-metadata-collection-v3-4
+    source:
+      git:
+        revision: 4c57016ad43ed096ee809b76ee5b6045d6b1bde0
+        url: https://github.com/red-hat-data-services/model-metadata-collection
+  - containerImage: quay.io/rhoai/odh-model-performance-data-rhel9@sha256:6582c4e18f4cafc9f6ad30565d7dbe9ee3843b79b158093ae455accae095a135
+    name: odh-model-performance-data-v3-4
+    source:
+      git:
+        revision: 34e20b89d586d2ea7a1f452f661243b1f044ea0b
+        url: https://github.com/red-hat-data-services/models-perf-benchmark-data
+  - containerImage: quay.io/rhoai/odh-model-registry-job-async-upload-rhel9@sha256:92f91e4af5d9c39de65a792d1e3a628b0284e0526dc891ed56167118b4d1372d
+    name: odh-model-registry-job-async-upload-v3-4
+    source:
+      git:
+        revision: 95055035b79011a28de1bfbf4556d34552853c1c
+        url: https://github.com/red-hat-data-services/model-registry
+  - containerImage: quay.io/rhoai/odh-model-registry-operator-rhel9@sha256:ae7fec9f9ff4399969ac44397b88554d366ed1c3e4f1c1a37d02ef777974d6d6
+    name: odh-model-registry-operator-v3-4
+    source:
+      git:
+        revision: fe1bfe10d4d041baa94537999806a948c3acbee4
+        url: https://github.com/red-hat-data-services/model-registry-operator
+  - containerImage: quay.io/rhoai/odh-model-registry-rhel9@sha256:a55f369e570937b1531c5ac139e62a03d80597f5af9ac99e7c5e7765b7ac1106
+    name: odh-model-registry-v3-4
+    source:
+      git:
+        revision: 46b7c66aef44d23169034eac8a6c16f26d37a83d
+        url: https://github.com/red-hat-data-services/model-registry
+  - containerImage: quay.io/rhoai/odh-model-serving-api-rhel9@sha256:ff99f89c1046b288305e90783afc854212f2e496d7b7eae94536f33a2a32446f
+    name: odh-model-serving-api-v3-4
+    source:
+      git:
+        revision: b0e6723585b64d596ee286f480d811285e5d4f04
+        url: https://github.com/red-hat-data-services/odh-model-controller
+  - containerImage: quay.io/rhoai/odh-must-gather-rhel9@sha256:d4c9218eb1d9aaa806fedf3008ee6df2116a3128f4451338948f561d61f9452a
+    name: odh-must-gather-v3-4
+    source:
+      git:
+        revision: 90442508e8f449f6bbd0ecf36025155f080a0acf
+        url: https://github.com/red-hat-data-services/must-gather
+  - containerImage: quay.io/rhoai/odh-notebook-controller-rhel9@sha256:b01dff304ccef98eb1a348f6dd799c45beab3731b26ca4bc37ea77ce3a8e275e
+    name: odh-notebook-controller-v3-4
+    source:
+      git:
+        revision: 630e471207d60796e91d0e2c6b5389d10e1a8481
+        url: https://github.com/red-hat-data-services/kubeflow
+  - containerImage: quay.io/rhoai/odh-openvino-model-server-rhel9@sha256:2c8c98b70c0d63a4731bf2c650c1a9fa8b9c20e395ccf743b9ca324a3966e0bf
+    name: odh-openvino-model-server-v3-4
+    source:
+      git:
+        revision: 3ef2f473b8d4335f4ab16f9b039ae5eddb5f4091
+        url: https://github.com/red-hat-data-services/openvino_model_server
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-datascience-cpu-py312-rhel9@sha256:8712328f7c4aa611500daf3736a53405cac8a23a97721c37745a9fb9d8cf321d
+    name: odh-pipeline-runtime-datascience-cpu-py312-v3-4
+    source:
+      git:
+        revision: 2fa49680ab490603b1d0732e277fe3766075e460
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-minimal-cpu-py312-rhel9@sha256:d3eab6a5416f5610aba342acbd9a2daabb604bba2f9fd95a8cdaaf7ac945cc1f
+    name: odh-pipeline-runtime-minimal-cpu-py312-v3-4
+    source:
+      git:
+        revision: 2fa49680ab490603b1d0732e277fe3766075e460
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-pytorch-cuda-py312-rhel9@sha256:b9356a6ea94c6c2b65be33c08e30d7d097807f0c45b14b63b370b3fd3cd3655c
+    name: odh-pipeline-runtime-pytorch-cuda-py312-v3-4
+    source:
+      git:
+        revision: 2fa49680ab490603b1d0732e277fe3766075e460
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9@sha256:10cdc644ad0a3349264d1f0d2966b22f00f2aa234e03af4076e850a6e55f997e
+    name: odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-4
+    source:
+      git:
+        revision: 2fa49680ab490603b1d0732e277fe3766075e460
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9@sha256:6eb7871b040950ff75bd9166d71896b0cb848092f352f15d1b33f5c61de0d9b1
+    name: odh-pipeline-runtime-pytorch-rocm-py312-v3-4
+    source:
+      git:
+        revision: 2fa49680ab490603b1d0732e277fe3766075e460
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9@sha256:8eae4bd527722d0c31bb88413e474e599e3f98422265ed808a1120507b459e8f
+    name: odh-pipeline-runtime-tensorflow-cuda-py312-v3-4
+    source:
+      git:
+        revision: 2fa49680ab490603b1d0732e277fe3766075e460
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9@sha256:aff9d2a1a07a21154116dceae9619bda4c528678920c46e8c857dd1bad484c7f
+    name: odh-pipeline-runtime-tensorflow-rocm-py312-v3-4
+    source:
+      git:
+        revision: 2fa49680ab490603b1d0732e277fe3766075e460
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipelines-components-rhel9@sha256:5689efaeebc7356d586cb51e99b5b0efbcf359942a5230f16498dcdcf7ab5faa
+    name: odh-pipelines-components-v3-4
+    source:
+      git:
+        revision: 31ca14a29e88ab51d832af361aa3548b585feee0
+        url: https://github.com/red-hat-data-services/pipelines-components
+  - containerImage: quay.io/rhoai/odh-rhaii-cluster-validator-rhel9@sha256:cfe99d3457912a535715c797cafebe7ffb9331940dee81c3bc68a46e9da93283
+    name: odh-rhaii-cluster-validator-v3-4
+    source:
+      git:
+        revision: b1f7a85a512c5c93e427a05e2d4d6855e63f41df
+        url: https://github.com/red-hat-data-services/rhaii-cluster-validation
+  - containerImage: quay.io/rhoai/odh-rhaii-validator-tools-rhel9@sha256:00848969f7bbd4f0a9558bcd9ce92b491bb33cc6b2cf3547c1270d93290403b5
+    name: odh-rhaii-validator-tools-v3-4
+    source:
+      git:
+        revision: b1f7a85a512c5c93e427a05e2d4d6855e63f41df
+        url: https://github.com/red-hat-data-services/rhaii-cluster-validation
+  - containerImage: quay.io/rhoai/odh-rhel9-operator@sha256:b6ae9bf92176884b837d9541049eace31e5fa05dfa9b4136e84953e245c04b8c
+    name: odh-operator-v3-4
+    source:
+      git:
+        revision: 1576764a885ecf9422058bae649b029c56c34533
+        url: https://github.com/red-hat-data-services/rhods-operator
+  - containerImage: quay.io/rhoai/odh-spark-operator-rhel9@sha256:be89ec5ec58357d87823d6ce14cc6cde5b1360c48b0105c9fee148392ebf4887
+    name: odh-spark-operator-v3-4
+    source:
+      git:
+        revision: fb243057236303f64617e6635e5a3ca771a73486
+        url: https://github.com/red-hat-data-services/spark-operator
+  - containerImage: quay.io/rhoai/odh-ta-lmes-driver-rhel9@sha256:ca47861e5e6338395d525982c601f77f8c864236896a1f18716a341f42eb0c43
+    name: odh-ta-lmes-driver-v3-4
+    source:
+      git:
+        revision: 4bc852ab19d6b9b4d5c631a4980b6c53166f4217
+        url: https://github.com/red-hat-data-services/trustyai-service-operator
+  - containerImage: quay.io/rhoai/odh-ta-lmes-job-rhel9@sha256:918c3ae2fa10f948f9e51bcc63f2a89fd87b2af666d046876b07e3838d62468d
+    name: odh-ta-lmes-job-v3-4
+    source:
+      git:
+        revision: c4a30c0778f65fb2d0994ca92cc21acf4434a8ed
+        url: https://github.com/red-hat-data-services/lm-evaluation-harness
+  - containerImage: quay.io/rhoai/odh-th06-cpu-torch210-py312-rhel9@sha256:4b762d722faa80d7c6641a631d891f0ddf048950a4f8b6e5b93010d65134687d
+    name: odh-th06-cpu-torch210-py312-v3-4
+    source:
+      git:
+        revision: 39b80cdfa5a17c277947b0d3a433863df379a53e
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-th06-cuda130-torch210-py312-rhel9@sha256:c18bb50a0082f9258afeb95cf9d8bbc6af7a48e712a7587073f2b281ca2200b8
+    name: odh-th06-cuda130-torch210-py312-v3-4
+    source:
+      git:
+        revision: a355dec176b3107ae4e87aa769c3af6a7d3fa273
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-th06-rocm64-torch291-py312-rhel9@sha256:3f3fdca286cfa6ab1f48cdfa109e78e6c8615f823568bb8cc18263db42f1beed
+    name: odh-th06-rocm64-torch291-py312-v3-4
+    source:
+      git:
+        revision: b20746fe2561f365784ec3593537f607fc9ef0c6
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-trainer-rhel9@sha256:d8a66f59f01a7f5095928a3c3c01c6667619bebc0119541b762c686a6f7a50cf
+    name: odh-trainer-v3-4
+    source:
+      git:
+        revision: 2ce500308a5f52f819ce0be6e241e77294c13724
+        url: https://github.com/red-hat-data-services/trainer
+  - containerImage: quay.io/rhoai/odh-training-cuda121-torch24-py311-rhel9@sha256:23f890fa178947e8c905127fbfabdebec1058785f1b10c81330caafa24d02615
+    name: odh-training-cuda121-torch24-py311-v3-4
+    source:
+      git:
+        revision: 2ecdbb279b5e71debc5371988d704d4cf9c8e0e2
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-cuda124-torch25-py311-rhel9@sha256:4cf2fdacb42f088b7ff506e378bfc819dc5f4e0d09974ba784312279ed4d574a
+    name: odh-training-cuda124-torch25-py311-v3-4
+    source:
+      git:
+        revision: 2ecdbb279b5e71debc5371988d704d4cf9c8e0e2
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-cuda128-torch28-py312-rhel9@sha256:ee043dd879e2cb1752d815e1ce2f873bb537c7cf373a8cac89a078727efa79db
+    name: odh-training-cuda128-torch28-py312-v3-4
+    source:
+      git:
+        revision: 2ecdbb279b5e71debc5371988d704d4cf9c8e0e2
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-cuda128-torch29-py312-rhel9@sha256:f4651196061c87ac0151bb13f0589253346ae7d32810e076174f2944fc897d52
+    name: odh-training-cuda128-torch29-py312-v3-4
+    source:
+      git:
+        revision: 2ecdbb279b5e71debc5371988d704d4cf9c8e0e2
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-operator-rhel9@sha256:00f63095dd9f37959775dc99288bad7eb94dd9886815c9336a61324fdb4383ea
+    name: odh-training-operator-v3-4
+    source:
+      git:
+        revision: a4dd909a65c726b9ede137cdf04621161c072903
+        url: https://github.com/red-hat-data-services/training-operator
+  - containerImage: quay.io/rhoai/odh-training-rocm62-torch24-py311-rhel9@sha256:c4d3fd3d503d2e33e13a1a32d27bb9fad15d5e5979e4645e5c849adebf1da848
+    name: odh-training-rocm62-torch24-py311-v3-4
+    source:
+      git:
+        revision: 2ecdbb279b5e71debc5371988d704d4cf9c8e0e2
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-rocm62-torch25-py311-rhel9@sha256:f9e17e2f5603038a14bc87bf419684ddaf0f9bc6e8ddd4fd4744a8d1207aaf4d
+    name: odh-training-rocm62-torch25-py311-v3-4
+    source:
+      git:
+        revision: 2ecdbb279b5e71debc5371988d704d4cf9c8e0e2
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-rocm64-torch28-py312-rhel9@sha256:3f0d442784b1a034d59bc8922caaaa709f89e800e7800843f62addcbbcd84170
+    name: odh-training-rocm64-torch28-py312-v3-4
+    source:
+      git:
+        revision: 2ecdbb279b5e71debc5371988d704d4cf9c8e0e2
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-rocm64-torch29-py312-rhel9@sha256:03f8b0d45f47cf19cf3701506b8450cb193c526e637f4ee125c8cdcbad3d9b4e
+    name: odh-training-rocm64-torch29-py312-v3-4
+    source:
+      git:
+        revision: 2ecdbb279b5e71debc5371988d704d4cf9c8e0e2
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-trustyai-garak-lls-provider-dsp-rhel9@sha256:b7539c9131326a3f07b4b40b2c791024b313f26076ae4c29937f1526e2495511
+    name: odh-trustyai-garak-lls-provider-dsp-v3-4
+    source:
+      git:
+        revision: 014ecc1fabdaa6abd30f0402fe99ce07328e402a
+        url: https://github.com/red-hat-data-services/llama-stack-provider-trustyai-garak
+  - containerImage: quay.io/rhoai/odh-trustyai-nemo-guardrails-server-rhel9@sha256:22125dbbd05d1cfa7af931fdeca9da72c6d267a05c33a1f757daf3095ddcca7c
+    name: odh-trustyai-nemo-guardrails-server-v3-4
+    source:
+      git:
+        revision: 92285e251d761e2a1096bb2f71f698c95db3e839
+        url: https://github.com/red-hat-data-services/NeMo-Guardrails
+  - containerImage: quay.io/rhoai/odh-trustyai-service-operator-rhel9@sha256:1a68dcef3cad4e58d96394634ee6e7c8862bf8c3079f9aeec9bfeb09a4d409f9
+    name: odh-trustyai-service-operator-v3-4
+    source:
+      git:
+        revision: 4bc852ab19d6b9b4d5c631a4980b6c53166f4217
+        url: https://github.com/red-hat-data-services/trustyai-service-operator
+  - containerImage: quay.io/rhoai/odh-trustyai-service-rhel9@sha256:91c22366c0e8ed62eda797dfdca448a946feab471f7d83f540667a080d6c1620
+    name: odh-trustyai-service-v3-4
+    source:
+      git:
+        revision: 3cfcf07ea04962eee79c72e533f79395706756ba
+        url: https://github.com/red-hat-data-services/trustyai-explainability
+  - containerImage: quay.io/rhoai/odh-trustyai-vllm-orchestrator-gateway-rhel9@sha256:45c237f657a9c9f90ad93e9ed27d972cbaebf7b4eb83c65baeee6637d2e3cef0
+    name: odh-trustyai-vllm-orchestrator-gateway-v3-4
+    source:
+      git:
+        revision: 142556b5c652ef75c6193e30498c6c864907ec29
+        url: https://github.com/red-hat-data-services/vllm-orchestrator-gateway
+  - containerImage: quay.io/rhoai/odh-vllm-cpu-rhel9@sha256:3febc78097575fc596777f9c3e47d6363502dd3d5d17affe4277243ee541ba0c
+    name: odh-vllm-cpu-v3-4
+    source:
+      git:
+        revision: f8477cdc2e55d4c3ba3da1b41e1a06c2f84d668e
+        url: https://github.com/red-hat-data-services/vllm-cpu
+  - containerImage: quay.io/rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9@sha256:c1ba278e55494e9c3808ce2acd9e240404751493506c9ca9b18422c970187618
+    name: odh-workbench-codeserver-datascience-cpu-py312-v3-4
+    source:
+      git:
+        revision: 2fa49680ab490603b1d0732e277fe3766075e460
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9@sha256:d07dacbceeaa335854c3aed2d93e149c122a938abf59497c8235c751dae755cb
+    name: odh-workbench-jupyter-datascience-cpu-py312-v3-4
+    source:
+      git:
+        revision: 2fa49680ab490603b1d0732e277fe3766075e460
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9@sha256:1df7d2d4606883f64ada0bd0dfb2a689b854249f5e3dc6985f23670eb21f62ef
+    name: odh-workbench-jupyter-minimal-cpu-py312-v3-4
+    source:
+      git:
+        revision: 2fa49680ab490603b1d0732e277fe3766075e460
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9@sha256:0857bfae48c788d4365338f83bce247b661187a19d89f0759361d2a0b9a2b916
+    name: odh-workbench-jupyter-minimal-cuda-py312-v3-4
+    source:
+      git:
+        revision: 2fa49680ab490603b1d0732e277fe3766075e460
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9@sha256:b9ca1ce1b836b566444d46b1506dab0348fa761253dcd70092b0922102c6618d
+    name: odh-workbench-jupyter-minimal-rocm-py312-v3-4
+    source:
+      git:
+        revision: 2fa49680ab490603b1d0732e277fe3766075e460
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9@sha256:b56799c1aa89bfb95c476ecb2f8d07b705b89706e2160eca788096f0b07ceb36
+    name: odh-workbench-jupyter-pytorch-cuda-py312-v3-4
+    source:
+      git:
+        revision: 2fa49680ab490603b1d0732e277fe3766075e460
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9@sha256:c2e904232a741674b6a3147f945bbe8d9b89068b651db3e442c85fae62b36993
+    name: odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-4
+    source:
+      git:
+        revision: 2fa49680ab490603b1d0732e277fe3766075e460
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9@sha256:f7db877ec4a0fb5df22e298041f7ae818360b1c0aab800f8456e418f5abbf7e9
+    name: odh-workbench-jupyter-pytorch-rocm-py312-v3-4
+    source:
+      git:
+        revision: 2fa49680ab490603b1d0732e277fe3766075e460
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9@sha256:0b3279ff9ebb8ea924420fc69445cfd60f5041b316ae7c4c4ab39795fa405d6b
+    name: odh-workbench-jupyter-tensorflow-cuda-py312-v3-4
+    source:
+      git:
+        revision: 2fa49680ab490603b1d0732e277fe3766075e460
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9@sha256:c3bc391ea406095df5d92ff320dd8afc90df16d1c7810c2ebf032e27d46e0914
+    name: odh-workbench-jupyter-tensorflow-rocm-py312-v3-4
+    source:
+      git:
+        revision: 2fa49680ab490603b1d0732e277fe3766075e460
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9@sha256:3ccd04fd013ee15b9a6f808c0566265252fc6117f27f58a3d9369ea3d1e421ba
+    name: odh-workbench-jupyter-trustyai-cpu-py312-v3-4
+    source:
+      git:
+        revision: 2fa49680ab490603b1d0732e277fe3766075e460
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workload-variant-autoscaler-controller-rhel9@sha256:8dc8a6d106b52f2273d7398d2c327512c13d51b35bf1869e4b4790c70a6e7f5b
+    name: odh-workload-variant-autoscaler-controller-v3-4
+    source:
+      git:
+        revision: c7017cede46c43ba5507cf14418ff08c012dc572
+        url: https://github.com/red-hat-data-services/workload-variant-autoscaler

--- a/release/3.4.2/stage/RC1/stage-release-62ff0a2e/snapshot-fbc/snapshot-fbc-stage-ocp-419-rhoai-v3-4-1782917080.yaml
+++ b/release/3.4.2/stage/RC1/stage-release-62ff0a2e/snapshot-fbc/snapshot-fbc-stage-ocp-419-rhoai-v3-4-1782917080.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-419-1782917080
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 62ff0a2e146c344830dbcb06c2840f98bff4da9e
+    konflux-release-data/ocp-version: ocp-419
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-419
+  components:
+    - name: rhoai-fbc-fragment-ocp-419
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:f5a50e930418538e74b614af5f9fb4320a93771a7ec5cf27f1a830dda7e2d8ab
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: a27dd46960ea6b2b3b467f875e83d6fc8710b0e5

--- a/release/3.4.2/stage/RC1/stage-release-62ff0a2e/snapshot-fbc/snapshot-fbc-stage-ocp-420-rhoai-v3-4-1782917080.yaml
+++ b/release/3.4.2/stage/RC1/stage-release-62ff0a2e/snapshot-fbc/snapshot-fbc-stage-ocp-420-rhoai-v3-4-1782917080.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-420-1782917080
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 62ff0a2e146c344830dbcb06c2840f98bff4da9e
+    konflux-release-data/ocp-version: ocp-420
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-420
+  components:
+    - name: rhoai-fbc-fragment-ocp-420
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:783d4aa0eb4841870970ee4ba98fe87b42a1e5dc144b5726f4cfe4ab530de0ee
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: a27dd46960ea6b2b3b467f875e83d6fc8710b0e5

--- a/release/3.4.2/stage/RC1/stage-release-62ff0a2e/snapshot-fbc/snapshot-fbc-stage-ocp-421-rhoai-v3-4-1782917080.yaml
+++ b/release/3.4.2/stage/RC1/stage-release-62ff0a2e/snapshot-fbc/snapshot-fbc-stage-ocp-421-rhoai-v3-4-1782917080.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-421-1782917080
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 62ff0a2e146c344830dbcb06c2840f98bff4da9e
+    konflux-release-data/ocp-version: ocp-421
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-421
+  components:
+    - name: rhoai-fbc-fragment-ocp-421
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:939f1152a61dc5469332083884715ee9fffd0f695be207047af53437067a4d5f
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: a27dd46960ea6b2b3b467f875e83d6fc8710b0e5

--- a/release/3.4.2/stage/RC1/stage-release-62ff0a2e/snapshot-fbc/snapshot-fbc-stage-ocp-422-rhoai-v3-4-1782917080.yaml
+++ b/release/3.4.2/stage/RC1/stage-release-62ff0a2e/snapshot-fbc/snapshot-fbc-stage-ocp-422-rhoai-v3-4-1782917080.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-422-1782917080
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 62ff0a2e146c344830dbcb06c2840f98bff4da9e
+    konflux-release-data/ocp-version: ocp-422
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-422
+  components:
+    - name: rhoai-fbc-fragment-ocp-422
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:2162962685511a80900be48a7008f276392a1dd43deafaf4adfe737f57b08590
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: 4b3eda92bd1d155d213774711bef387745d3fa9d


### PR DESCRIPTION
## Summary
- Adds stage and prod release artifacts for RHOAI 3.4.2
- OCP versions: 4.19, 4.20, 4.21, 4.22 (new in 3.4.2)

## Artifact Sources
| Type | Source | Epoch/Hash |
|------|--------|------------|
| Prod (components, FBC, charts) | Local `generate-prod-release-artifacts.sh` | `1782919787` |
| Stage components & charts | [GHA run #28449870287](https://github.com/red-hat-data-services/rhods-devops-infra/actions/runs/28449870287) | components: `1782829383`, charts: `1782834884` |
| Stage FBC | Local `release-fbc-to-stage.sh` (GHA FBC build step failed) | `1782917080` |

## File Counts (18 total)
| Directory | Files |
|-----------|-------|
| `prod/prod-release-1782919787/release-charts` | 1 |
| `prod/prod-release-1782919787/release-components` | 1 |
| `prod/prod-release-1782919787/release-fbc` | 4 (ocp 419-422) |
| `stage/RC1/stage-release-62ff0a2e/release-charts` | 1 |
| `stage/RC1/stage-release-62ff0a2e/release-components` | 1 |
| `stage/RC1/stage-release-62ff0a2e/release-fbc` | 4 (ocp 419-422) |
| `stage/RC1/stage-release-62ff0a2e/snapshot-charts` | 1 |
| `stage/RC1/stage-release-62ff0a2e/snapshot-components` | 1 |
| `stage/RC1/stage-release-62ff0a2e/snapshot-fbc` | 4 (ocp 419-422) |

Compared with 3.4.1 (15 files) — 3 additional files from new OCP 4.22 support.