### PR TITLE
feat: add maas and gateway related images to xks helm values patch

### DIFF
--- a/helm/xks-values-patch.yaml
+++ b/helm/xks-values-patch.yaml
@@ -33,6 +33,16 @@ rhaiOperator:
       value: "registry.redhat.io/rhoai/odh-kserve-localmodel-controller-rhel9@sha256:483795ada15c564ed27435a6a655112cba2487352b5b5aa5d8ae7ccdcef5852a"
     - name: RELATED_IMAGE_ODH_KSERVE_LOCALMODELNODE_AGENT_IMAGE
       value: "registry.redhat.io/rhoai/odh-kserve-localmodelnode-agent-rhel9@sha256:6a56ef129a1a866401e1953bb5fa51c25f26a357a517bcb70a1b30f66621143c"
+    - name: RELATED_IMAGE_ODH_MAAS_API_IMAGE
+      value: "registry.redhat.io/rhoai/odh-maas-api-rhel9@sha256:4f00f130d1319513eac9244f59cc2a34f966286cb06f7aba9c478edcad567410"
+    - name: RELATED_IMAGE_ODH_MAAS_CONTROLLER_IMAGE
+      value: "registry.redhat.io/rhoai/odh-maas-controller-rhel9@sha256:a7cba7961a1b9082b942ede4d2aed33401b6be5e9e1a270f00f1e8b2a90c7dce"
+    - name: RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE
+      value: "registry.redhat.io/rhoai/odh-ai-gateway-payload-processing-rhel9@sha256:1e95dcdfdfb7688fa8ab70c2fe644c5ba80a81fdafe786a18f9c038be7915db2"
+    - name: RELATED_IMAGE_POSTGRESQL_16_IMAGE
+      value: "registry.redhat.io/rhel9/postgresql-16:latest@sha256:cb66eb4b438ce3f9db194dd1948ce25dc4142e789025f214324b7baa3c915c05"
+    - name: RELATED_IMAGE_UBI_MINIMAL_IMAGE
+      value: "registry.redhat.io/ubi9/ubi-minimal:9.7@sha256:907b68736aa798b2d38255b7aa070b2a70acb90803864a40f05d0ec47556ddd0"
 
 hooks:
   cliImage: "registry.redhat.io/openshift4/ose-cli-rhel9@sha256:9df03d57077c708fd280afc2c768feb732ed6de54a847c5ca2a929cb3b9b3d44"


### PR DESCRIPTION
## Summary
Add MaaS and AI Gateway related images to the XKS helm values patch for RHOAI 3.5.

## Description
Adds the following related images to `helm/xks-values-patch.yaml` using `registry.redhat.io` references with digests matching the built CSV (`bundle/manifests/rhods-operator.clusterserviceversion.yaml`):

- `RELATED_IMAGE_ODH_MAAS_API_IMAGE`
- `RELATED_IMAGE_ODH_MAAS_CONTROLLER_IMAGE`
- `RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE`
- `RELATED_IMAGE_POSTGRESQL_16_IMAGE`
- `RELATED_IMAGE_UBI_MINIMAL_IMAGE`

These images are required for MaaS (Model-as-a-Service) support on XKS deployments.

**JIRA:** [RHOAIENG-69973](https://redhat.atlassian.net/browse/RHOAIENG-69973)

## How it was tested
- Verified all image digests match the corresponding entries in `bundle/manifests/rhods-operator.clusterserviceversion.yaml`.
- Confirmed all images in `xks-values-patch.yaml` consistently use `registry.redhat.io` as the registry.

Made with [Cursor](https://cursor.com)