### PR TITLE
Add odh-workbenches-operator-rhel9 to bundle relatedImages

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -213,6 +213,8 @@ ARG ODH_MCP_LIFECYCLE_MODULE_OPERATOR_GIT_URL=
 ARG ODH_MCP_LIFECYCLE_MODULE_OPERATOR_GIT_COMMIT=
 ARG ODH_MCP_LIFECYCLE_OPERATOR_GIT_URL=
 ARG ODH_MCP_LIFECYCLE_OPERATOR_GIT_COMMIT=
+ARG ODH_WORKBENCHES_OPERATOR_RHEL9_GIT_URL=
+ARG ODH_WORKBENCHES_OPERATOR_RHEL9_GIT_COMMIT=
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -436,7 +438,9 @@ LABEL \
       odh-mcp-lifecycle-module-operator.git.url="${ODH_MCP_LIFECYCLE_MODULE_OPERATOR_GIT_URL}" \
       odh-mcp-lifecycle-module-operator.git.commit="${ODH_MCP_LIFECYCLE_MODULE_OPERATOR_GIT_COMMIT}" \
       odh-mcp-lifecycle-operator.git.url="${ODH_MCP_LIFECYCLE_OPERATOR_GIT_URL}" \
-      odh-mcp-lifecycle-operator.git.commit="${ODH_MCP_LIFECYCLE_OPERATOR_GIT_COMMIT}"
+      odh-mcp-lifecycle-operator.git.commit="${ODH_MCP_LIFECYCLE_OPERATOR_GIT_COMMIT}" \
+      odh-workbenches-operator-rhel9.git.url="${ODH_WORKBENCHES_OPERATOR_RHEL9_GIT_URL}" \
+      odh-workbenches-operator-rhel9.git.commit="${ODH_WORKBENCHES_OPERATOR_RHEL9_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -235,6 +235,8 @@ patch:
       value: "quay.io/rhoai/odh-mcp-lifecycle-module-operator-rhel9@sha256:74535aa11df149330875e275fe9584fd7a08d8b10345300f1272e042907cf926"
     - name: RELATED_IMAGE_ODH_MCP_LIFECYCLE_OPERATOR_IMAGE
       value: quay.io/rhoai/odh-mcp-lifecycle-operator-rhel9@sha256:de810dd26d35d1a2c796b9a9f4b34e1242694c39d787707f0219840f268241b4
+    - name: RELATED_IMAGE_ODH_WORKBENCHES_OPERATOR_RHEL9_IMAGE
+      value: quay.io/rhoai/odh-workbenches-operator-rhel9-rhel9@sha256:dfd63251f5bbb6aef704ef2c75bbd44447d11a2b8eee7f0f38944c265f284640
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -119,6 +119,7 @@ config:
         rhoai/odh-dashboard-operator-rhel9: rhoai/odh-dashboard-operator-rhel9
         rhoai/odh-mcp-lifecycle-module-operator-rhel9: rhoai/odh-mcp-lifecycle-module-operator-rhel9
         rhoai/odh-mcp-lifecycle-operator-rhel9: rhoai/odh-mcp-lifecycle-operator-rhel9
+        rhoai/odh-workbenches-operator-rhel9-rhel9: rhoai/odh-workbenches-operator-rhel9-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds relatedImages entry for 'odh-workbenches-operator-rhel9' to bundle/bundle-patch.yaml.

Image: quay.io/rhoai/odh-workbenches-operator-rhel9-rhel9@sha256:dfd63251f5bbb6aef704ef2c75bbd44447d11a2b8eee7f0f38944c265f284640
Jira: https://redhat.atlassian.net/browse/RHOAIENG-72970