### PR TITLE
Add odh-core-bff to bundle relatedImages

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -215,6 +215,8 @@ ARG ODH_MCP_LIFECYCLE_OPERATOR_GIT_URL=
 ARG ODH_MCP_LIFECYCLE_OPERATOR_GIT_COMMIT=
 ARG ODH_WORKBENCHES_OPERATOR_GIT_URL=
 ARG ODH_WORKBENCHES_OPERATOR_GIT_COMMIT=
+ARG ODH_CORE_BFF_GIT_URL=
+ARG ODH_CORE_BFF_GIT_COMMIT=
 
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
@@ -441,7 +443,9 @@ LABEL \
       odh-mcp-lifecycle-operator.git.url="${ODH_MCP_LIFECYCLE_OPERATOR_GIT_URL}" \
       odh-mcp-lifecycle-operator.git.commit="${ODH_MCP_LIFECYCLE_OPERATOR_GIT_COMMIT}" \
       odh-workbenches-operator.git.url="${ODH_WORKBENCHES_OPERATOR_GIT_URL}" \
-      odh-workbenches-operator.git.commit="${ODH_WORKBENCHES_OPERATOR_GIT_COMMIT}"
+      odh-workbenches-operator.git.commit="${ODH_WORKBENCHES_OPERATOR_GIT_COMMIT}" \
+      odh-core-bff.git.url="${ODH_CORE_BFF_GIT_URL}" \
+      odh-core-bff.git.commit="${ODH_CORE_BFF_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -239,7 +239,6 @@ patch:
       value: quay.io/rhoai/odh-workbenches-operator-rhel9@sha256:dfd63251f5bbb6aef704ef2c75bbd44447d11a2b8eee7f0f38944c265f284640
     - name: RELATED_IMAGE_ODH_CORE_BFF_IMAGE
       value: quay.io/rhoai/odh-core-bff-rhel9@sha256:a45623a5a8121b4995a03331e2a0006be92a6d9064c29196c5b1fe52a30fa967
-      component: odh-core-bff
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -237,6 +237,9 @@ patch:
       value: quay.io/rhoai/odh-mcp-lifecycle-operator-rhel9@sha256:de810dd26d35d1a2c796b9a9f4b34e1242694c39d787707f0219840f268241b4
     - name: RELATED_IMAGE_ODH_WORKBENCHES_OPERATOR_IMAGE
       value: quay.io/rhoai/odh-workbenches-operator-rhel9@sha256:dfd63251f5bbb6aef704ef2c75bbd44447d11a2b8eee7f0f38944c265f284640
+    - name: RELATED_IMAGE_ODH_CORE_BFF_IMAGE
+      value: quay.io/rhoai/odh-core-bff-rhel9@sha256:a45623a5a8121b4995a03331e2a0006be92a6d9064c29196c5b1fe52a30fa967
+      component: odh-core-bff
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -120,6 +120,7 @@ config:
         rhoai/odh-mcp-lifecycle-module-operator-rhel9: rhoai/odh-mcp-lifecycle-module-operator-rhel9
         rhoai/odh-mcp-lifecycle-operator-rhel9: rhoai/odh-mcp-lifecycle-operator-rhel9
         rhoai/odh-workbenches-operator-rhel9: rhoai/odh-workbenches-operator-rhel9
+        rhoai/odh-core-bff-rhel9: rhoai/odh-core-bff-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
## Summary
- Add `ODH_CORE_BFF_GIT_URL` / `ODH_CORE_BFF_GIT_COMMIT` ARGs and LABELs to Dockerfile
- Add `RELATED_IMAGE_ODH_CORE_BFF_IMAGE` entry to bundle-patch.yaml with `component` field
- Add `rhoai/odh-core-bff-rhel9` registry mapping to build-config.yaml

Replaces the reverted #25492.

Jira: https://redhat.atlassian.net/browse/RHOAIENG-72856