### PR TITLE
fix(catalog): resolve multiple channel heads in stable-3.x for rhoai-3.5

### DIFF
--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -8,7 +8,7 @@ patch:
       schema: olm.channel
       entries:
         - name: rhods-operator.3.5.0
-          replaces: rhods-operator.3.4.1
+          replaces: rhods-operator.3.4.2
           skipRange: '>=3.4.0 <3.5.0'
     - name: stable-3.5
       package: rhods-operator


### PR DESCRIPTION
## Summary

- `rhods-operator.3.5.0` was configured to `replaces: rhods-operator.3.4.1` in the `stable-3.x` channel, leaving both `3.4.2` and `3.5.0` as leaf nodes with no successor
- OPM rejects this with `multiple channel heads found in graph: rhods-operator.3.4.2, rhods-operator.3.5.0`, causing all four `build-images` steps to fail
- Fixed by updating `replaces: rhods-operator.3.4.1` → `replaces: rhods-operator.3.4.2` for the `3.5.0` entry in the `stable-3.x` channel across all four OCP versions (v4.19, v4.20, v4.21, v4.22)

## Root cause

Seen in pipeline run `rhoai-fbc-fragment-v3-5-on-push-dr2p5` (commit `474f62c`):
```
failed to rebuild cache: build package index: process package "rhods-operator":
└── invalid channel "stable-3.x":
    └── multiple channel heads found in graph: rhods-operator.3.4.2, rhods-operator.3.5.0
```

## Test plan
- [ ] Verify the Konflux pipeline build passes after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)