### PR TITLE
Restore 2.25.9 to all channels for continued z-stream shipping

### DIFF
--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -1,8 +1,28 @@
 patch:
   olm.package:
     name: rhods-operator
-    defaultChannel: eus-2.25
+    defaultChannel: stable
   olm.channels:
+    - name: fast
+      entries:
+      - name: rhods-operator.2.25.9
+        replaces: rhods-operator.2.25.8
+        skipRange: '>=2.24.0 <2.25.9'
+    - name: alpha
+      entries:
+      - name: rhods-operator.2.25.9
+        replaces: rhods-operator.2.25.8
+        skipRange: '>=2.24.0 <2.25.9'
+    - name: stable
+      entries:
+      - name: rhods-operator.2.25.9
+        replaces: rhods-operator.2.25.8
+        skipRange: '>=2.22.0 <2.25.9'
+    - name: stable-2.25
+      entries:
+      - name: rhods-operator.2.25.9
+        replaces: rhods-operator.2.25.8
+        skipRange: '>=2.22.0 <2.25.9'
     - name: eus-2.25
       entries:
       - name: rhods-operator.2.25.9


### PR DESCRIPTION
## Summary
- Reverts channel stripping from commit 7f56ac30 (PR #24645)
- Restores 2.25.9 to all 5 channels: fast, alpha, stable, stable-2.25, eus-2.25
- Restores defaultChannel back to `stable`

## Why
After end of full maintenance support, 2.25 z-streams should still ship in all channels to provide critical patches (e.g. CVEs). The previous change restricted publishing to only the eus-2.25 channel, which would prevent customers on other channels from receiving critical fixes.

## Changes
- defaultChannel: eus-2.25 -> stable
- Restored channels: fast, alpha, stable, stable-2.25
- Existing eus-2.25 channel: unchanged

## Test plan
- [ ] Verify process-fbc-fragment automation produces catalogs with 2.25.9 in all 5 channels
- [ ] Confirm with product team this aligns with z-stream shipping policy