### PR TITLE
[RHOAIENG-68310] Add fast-1/fast-2 vLLM image entries to RHOAI-Build-Config additional-images-patch

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -41,11 +41,31 @@ additionalImages:
   # RHAII images are currently in stage registry, but will be promoted to production registry soon. Using stage registry for now to allow testing with the latest images. Once the images are promoted to production registry, the image references will be updated to use registry.redhat.io instead of registry.stage.redhat.io
   - name: RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE
     value: "registry.stage.redhat.io/rhaii/vllm-cuda-rhel9:3.4.0-1776326705@sha256:d3e57d4ca13a17f4d5d1228df4fe47cfe1a9f630250a8b3d26f86d871fdb9e69"
+  - name: RELATED_IMAGE_RHAII_VLLM_CUDA_FAST_1_IMAGE
+    value: "registry.stage.redhat.io/rhaii/vllm-cuda-rhel9:3.4.0-1776326705@sha256:d3e57d4ca13a17f4d5d1228df4fe47cfe1a9f630250a8b3d26f86d871fdb9e69"
+  - name: RELATED_IMAGE_RHAII_VLLM_CUDA_FAST_2_IMAGE
+    value: "registry.stage.redhat.io/rhaii/vllm-cuda-rhel9:3.4.0-1776326705@sha256:d3e57d4ca13a17f4d5d1228df4fe47cfe1a9f630250a8b3d26f86d871fdb9e69"
   - name: RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE
+    value: "registry.stage.redhat.io/rhaii/vllm-rocm-rhel9:3.4.0-1776333560@sha256:cfeac10c571206514c2876f220ce845058511185ebe8944afc32581dc45b34f3"
+  - name: RELATED_IMAGE_RHAII_VLLM_ROCM_FAST_1_IMAGE
+    value: "registry.stage.redhat.io/rhaii/vllm-rocm-rhel9:3.4.0-1776333560@sha256:cfeac10c571206514c2876f220ce845058511185ebe8944afc32581dc45b34f3"
+  - name: RELATED_IMAGE_RHAII_VLLM_ROCM_FAST_2_IMAGE
     value: "registry.stage.redhat.io/rhaii/vllm-rocm-rhel9:3.4.0-1776333560@sha256:cfeac10c571206514c2876f220ce845058511185ebe8944afc32581dc45b34f3"
   - name: RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE
     value: "registry.stage.redhat.io/rhaii/vllm-spyre-rhel9:3.4.0-1776326998@sha256:5c0ed9be230a307d512fa99236b060ac2ecd86973d17c467badc7b5c2d2b5da4"
+  - name: RELATED_IMAGE_RHAII_VLLM_SPYRE_FAST_1_IMAGE
+    value: "registry.stage.redhat.io/rhaii/vllm-spyre-rhel9:3.4.0-1776326998@sha256:5c0ed9be230a307d512fa99236b060ac2ecd86973d17c467badc7b5c2d2b5da4"
+  - name: RELATED_IMAGE_RHAII_VLLM_SPYRE_FAST_2_IMAGE
+    value: "registry.stage.redhat.io/rhaii/vllm-spyre-rhel9:3.4.0-1776326998@sha256:5c0ed9be230a307d512fa99236b060ac2ecd86973d17c467badc7b5c2d2b5da4"
   - name: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE
     value: "registry.stage.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0-1776326833@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
+  - name: RELATED_IMAGE_RHAII_VLLM_CPU_FAST_1_IMAGE
+    value: "registry.stage.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0-1776326833@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
+  - name: RELATED_IMAGE_RHAII_VLLM_CPU_FAST_2_IMAGE
+    value: "registry.stage.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0-1776326833@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
   - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
+    value: "registry.stage.redhat.io/rhaii/vllm-gaudi-rhel9:3.4.0-1776326902@sha256:1adc51d99455d90f758d840cb3bb5747ed29585c1b0830c051f7fe5cca3471e6"
+  - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_FAST_1_IMAGE
+    value: "registry.stage.redhat.io/rhaii/vllm-gaudi-rhel9:3.4.0-1776326902@sha256:1adc51d99455d90f758d840cb3bb5747ed29585c1b0830c051f7fe5cca3471e6"
+  - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_FAST_2_IMAGE
     value: "registry.stage.redhat.io/rhaii/vllm-gaudi-rhel9:3.4.0-1776326902@sha256:1adc51d99455d90f758d840cb3bb5747ed29585c1b0830c051f7fe5cca3471e6"


### PR DESCRIPTION
Adds 10 new RELATED_IMAGE entries for fast-1 and fast-2 vLLM images to bundle/additional-images-patch.yaml:

10 RHAII entries: CUDA, ROCM, Spyre, Gaudi, and CPU for both fast-1 and fast-2
Initial values match the existing stable counterparts. No separate multinode entries are needed (multinode reuses the CUDA fast env vars).

When fast image SHAs equal stable, the kserve-module post-render filter (RHOAIENG-68181) suppresses the fast resources. When the fast image SHAs are updated, the fast resources appear automatically.

Jira: [RHOAIENG-68310](https://redhat.atlassian.net/browse/RHOAIENG-68310)

REF: https://redhat-internal.slack.com/archives/C0BAKMAA3J6/p1783423194315189?thread_ts=1783416356.744609&cid=C0BAKMAA3J6