### PR TITLE
Revert "Add odh-feast-module-operator to bundle relatedImages"

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -221,8 +221,6 @@ ARG ODH_TRAINER_OPERATOR_GIT_URL=
 ARG ODH_TRAINER_OPERATOR_GIT_COMMIT=
 ARG ODH_KSERVE_MODULE_OPERATOR_GIT_URL=
 ARG ODH_KSERVE_MODULE_OPERATOR_GIT_COMMIT=
-ARG ODH_FEAST_MODULE_OPERATOR_GIT_URL=
-ARG ODH_FEAST_MODULE_OPERATOR_GIT_COMMIT=
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -454,9 +452,7 @@ LABEL \
       odh-trainer-operator.git.url="${ODH_TRAINER_OPERATOR_GIT_URL}" \
       odh-trainer-operator.git.commit="${ODH_TRAINER_OPERATOR_GIT_COMMIT}" \
       odh-kserve-module-operator.git.url="${ODH_KSERVE_MODULE_OPERATOR_GIT_URL}" \
-      odh-kserve-module-operator.git.commit="${ODH_KSERVE_MODULE_OPERATOR_GIT_COMMIT}" \
-      odh-feast-module-operator.git.url="${ODH_FEAST_MODULE_OPERATOR_GIT_URL}" \
-      odh-feast-module-operator.git.commit="${ODH_FEAST_MODULE_OPERATOR_GIT_COMMIT}"
+      odh-kserve-module-operator.git.commit="${ODH_KSERVE_MODULE_OPERATOR_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -243,8 +243,6 @@ patch:
       value: "quay.io/rhoai/odh-trainer-operator-rhel9@sha256:7db9b5943acadba3804fbb652888be11de6785a4a2941c43d7f565affa51aeb9"
     - name: RELATED_IMAGE_ODH_KSERVE_MODULE_OPERATOR_IMAGE
       value: "quay.io/rhoai/odh-kserve-module-operator-rhel9@sha256:235a9d9471ae55ac4939c0c3cb82d79c8f5379387d936af5f773b2a16bb994ef"
-    - name: RELATED_IMAGE_ODH_FEAST_MODULE_OPERATOR_IMAGE
-      value: quay.io/rhoai/odh-feast-module-operator-rhel9@sha256:167fdd7420c78a07f565d19e5b869199bb5f2f4210475d09ce6cfea3fd0fd8a5
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -123,7 +123,6 @@ config:
         rhoai/odh-core-bff-rhel9: rhoai/odh-core-bff-rhel9
         rhoai/odh-trainer-operator-rhel9: rhoai/odh-trainer-operator-rhel9
         rhoai/odh-kserve-module-operator-rhel9: rhoai/odh-kserve-module-operator-rhel9
-        rhoai/odh-feast-module-operator-rhel9: rhoai/odh-feast-module-operator-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Reverts red-hat-data-services/RHOAI-Build-Config#25911 as fips is still failing https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/rhoai-v3-5/pipelineruns/odh-feast-module-operator-v3-5-on-push-zlpkh/