### PR TITLE
Add release artifacts for RHOAI 3.3.5

### DIFF
--- a/release/3.3.5/prod/release-components/prod-release-components-rhoai-v3-3-1783586527.yaml
+++ b/release/3.3.5/prod/release-components/prod-release-components-rhoai-v3-3-1783586527.yaml
@@ -1,0 +1,901 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-v3-3-prod-1783586527-1-2
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 9e62817cf9ed15b3d1ca6fa3dd393670e7a0fecd
+    konflux-release-data/artifact-type: components
+    konflux-release-data/environment: prod
+    appstudio.openshift.io/application: rhoai-v3-3
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-3-components-prod
+  snapshot: rhoai-v3-3-1783094273
+  data:
+    version: 3.3.5
+    releaseNotes:
+      cves:
+        - key: 'CVE-2026-42561' # https://redhat.atlassian.net/browse/RHOAIENG-71848
+          component: 'odh-mlserver-v3-3'
+        - key: 'CVE-2026-39830' # https://redhat.atlassian.net/browse/RHOAIENG-70063
+          component: 'odh-trainer-v3-3'
+        - key: 'CVE-2026-46595' # https://redhat.atlassian.net/browse/RHOAIENG-67971
+          component: 'odh-trainer-v3-3'
+        - key: 'CVE-2026-48526' # https://redhat.atlassian.net/browse/RHOAIENG-66591
+          component: 'odh-kserve-storage-initializer-v3-3'
+        - key: 'CVE-2026-5241' # https://redhat.atlassian.net/browse/RHOAIENG-66258
+          component: 'odh-trustyai-nemo-guardrails-server-v3-3'
+        - key: 'CVE-2026-5241' # https://redhat.atlassian.net/browse/RHOAIENG-66252
+          component: 'odh-training-cuda124-torch25-py311-v3-3'
+        - key: 'CVE-2026-5241' # https://redhat.atlassian.net/browse/RHOAIENG-66250
+          component: 'odh-training-rocm64-torch28-py312-v3-3'
+        - key: 'CVE-2026-5241' # https://redhat.atlassian.net/browse/RHOAIENG-66246
+          component: 'odh-training-rocm62-torch24-py311-v3-3'
+        - key: 'CVE-2026-5241' # https://redhat.atlassian.net/browse/RHOAIENG-66245
+          component: 'odh-training-rocm62-torch25-py311-v3-3'
+        - key: 'CVE-2026-5241' # https://redhat.atlassian.net/browse/RHOAIENG-66241
+          component: 'odh-training-rocm64-torch29-py312-v3-3'
+        - key: 'CVE-2026-5241' # https://redhat.atlassian.net/browse/RHOAIENG-66237
+          component: 'odh-training-cuda121-torch24-py311-v3-3'
+        - key: 'CVE-2026-5241' # https://redhat.atlassian.net/browse/RHOAIENG-66231
+          component: 'odh-training-cuda128-torch28-py312-v3-3'
+        - key: 'CVE-2026-5241' # https://redhat.atlassian.net/browse/RHOAIENG-66230
+          component: 'odh-training-cuda128-torch29-py312-v3-3'
+        - key: 'CVE-2026-34993' # https://redhat.atlassian.net/browse/RHOAIENG-65992
+          component: 'odh-trustyai-garak-lls-provider-dsp-v3-3'
+        - key: 'CVE-2026-34993' # https://redhat.atlassian.net/browse/RHOAIENG-65968
+          component: 'odh-mlserver-v3-3'
+        - key: 'CVE-2026-33245' # https://redhat.atlassian.net/browse/RHOAIENG-65879
+          component: 'odh-mod-arch-maas-v3-3'
+        - key: 'CVE-2026-33245' # https://redhat.atlassian.net/browse/RHOAIENG-65878
+          component: 'odh-mod-arch-gen-ai-v3-3'
+        - key: 'CVE-2026-33245' # https://redhat.atlassian.net/browse/RHOAIENG-65877
+          component: 'odh-dashboard-v3-3'
+        - key: 'CVE-2026-33245' # https://redhat.atlassian.net/browse/RHOAIENG-65869
+          component: 'odh-mod-arch-model-registry-v3-3'
+        - key: 'CVE-2026-2614' # https://redhat.atlassian.net/browse/RHOAIENG-65819
+          component: 'odh-training-cuda128-torch29-py312-v3-3'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64900
+          component: 'odh-training-cuda128-torch29-py312-v3-3'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64898
+          component: 'odh-workbench-jupyter-tensorflow-cuda-py312-v3-3'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64896
+          component: 'odh-pipeline-runtime-tensorflow-cuda-py312-v3-3'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64893
+          component: 'odh-pipeline-runtime-pytorch-rocm-py312-v3-3'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64892
+          component: 'odh-pipeline-runtime-pytorch-cuda-py312-v3-3'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64891
+          component: 'odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-3'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64890
+          component: 'odh-workbench-jupyter-pytorch-rocm-py312-v3-3'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64889
+          component: 'odh-feature-server-v3-3'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64888
+          component: 'odh-trustyai-garak-lls-provider-dsp-v3-3'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64885
+          component: 'odh-pipeline-runtime-datascience-cpu-py312-v3-3'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64882
+          component: 'odh-workbench-jupyter-pytorch-cuda-py312-v3-3'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64878
+          component: 'odh-workbench-codeserver-datascience-cpu-py312-v3-3'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64873
+          component: 'odh-workbench-jupyter-datascience-cpu-py312-v3-3'
+        - key: 'CVE-2026-48710' # https://redhat.atlassian.net/browse/RHOAIENG-64865
+          component: 'odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3'
+        - key: 'CVE-2026-44431' # https://redhat.atlassian.net/browse/RHOAIENG-64537
+          component: 'odh-trustyai-nemo-guardrails-server-v3-3'
+        - key: 'CVE-2026-44431' # https://redhat.atlassian.net/browse/RHOAIENG-64536
+          component: 'odh-trustyai-garak-lls-provider-dsp-v3-3'
+        - key: 'CVE-2026-44431' # https://redhat.atlassian.net/browse/RHOAIENG-64535
+          component: 'odh-training-rocm64-torch29-py312-v3-3'
+        - key: 'CVE-2026-44431' # https://redhat.atlassian.net/browse/RHOAIENG-64534
+          component: 'odh-training-rocm64-torch28-py312-v3-3'
+        - key: 'CVE-2026-44431' # https://redhat.atlassian.net/browse/RHOAIENG-64533
+          component: 'odh-training-cuda128-torch29-py312-v3-3'
+        - key: 'CVE-2026-44431' # https://redhat.atlassian.net/browse/RHOAIENG-64532
+          component: 'odh-training-cuda128-torch28-py312-v3-3'
+        - key: 'CVE-2026-44431' # https://redhat.atlassian.net/browse/RHOAIENG-64531
+          component: 'odh-mlserver-v3-3'
+        - key: 'CVE-2026-44431' # https://redhat.atlassian.net/browse/RHOAIENG-64530
+          component: 'odh-mlflow-v3-3'
+        - key: 'CVE-2026-44431' # https://redhat.atlassian.net/browse/RHOAIENG-64502
+          component: 'odh-training-rocm62-torch25-py311-v3-3'
+        - key: 'CVE-2026-44431' # https://redhat.atlassian.net/browse/RHOAIENG-64500
+          component: 'odh-training-rocm62-torch24-py311-v3-3'
+        - key: 'CVE-2026-44431' # https://redhat.atlassian.net/browse/RHOAIENG-64498
+          component: 'odh-training-cuda124-torch25-py311-v3-3'
+        - key: 'CVE-2026-44431' # https://redhat.atlassian.net/browse/RHOAIENG-64496
+          component: 'odh-training-cuda121-torch24-py311-v3-3'
+        - key: 'CVE-2026-44431' # https://redhat.atlassian.net/browse/RHOAIENG-64470
+          component: 'odh-kserve-storage-initializer-v3-3'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64055
+          component: 'odh-training-cuda124-torch25-py311-v3-3'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64054
+          component: 'odh-training-cuda128-torch29-py312-v3-3'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64052
+          component: 'odh-training-rocm62-torch25-py311-v3-3'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64051
+          component: 'odh-training-rocm64-torch28-py312-v3-3'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64050
+          component: 'odh-training-rocm64-torch29-py312-v3-3'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64047
+          component: 'odh-training-cuda128-torch28-py312-v3-3'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64045
+          component: 'odh-training-rocm62-torch24-py311-v3-3'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64042
+          component: 'odh-training-cuda121-torch24-py311-v3-3'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64035
+          component: 'odh-mlserver-v3-3'
+        - key: 'CVE-2026-8643' # https://redhat.atlassian.net/browse/RHOAIENG-64034
+          component: 'odh-kserve-storage-initializer-v3-3'
+        - key: 'CVE-2026-44432' # https://redhat.atlassian.net/browse/RHOAIENG-63917
+          component: 'odh-trustyai-garak-lls-provider-dsp-v3-3'
+        - key: 'CVE-2026-44432' # https://redhat.atlassian.net/browse/RHOAIENG-63916
+          component: 'odh-training-rocm64-torch29-py312-v3-3'
+        - key: 'CVE-2026-44432' # https://redhat.atlassian.net/browse/RHOAIENG-63915
+          component: 'odh-training-rocm64-torch28-py312-v3-3'
+        - key: 'CVE-2026-44432' # https://redhat.atlassian.net/browse/RHOAIENG-63914
+          component: 'odh-training-cuda128-torch29-py312-v3-3'
+        - key: 'CVE-2026-44432' # https://redhat.atlassian.net/browse/RHOAIENG-63913
+          component: 'odh-training-cuda128-torch28-py312-v3-3'
+        - key: 'CVE-2026-44432' # https://redhat.atlassian.net/browse/RHOAIENG-63912
+          component: 'odh-mlserver-v3-3'
+        - key: 'CVE-2026-44432' # https://redhat.atlassian.net/browse/RHOAIENG-63911
+          component: 'odh-mlflow-v3-3'
+        - key: 'CVE-2026-44432' # https://redhat.atlassian.net/browse/RHOAIENG-63878
+          component: 'odh-training-rocm62-torch25-py311-v3-3'
+        - key: 'CVE-2026-44432' # https://redhat.atlassian.net/browse/RHOAIENG-63876
+          component: 'odh-training-rocm62-torch24-py311-v3-3'
+        - key: 'CVE-2026-44432' # https://redhat.atlassian.net/browse/RHOAIENG-63874
+          component: 'odh-training-cuda124-torch25-py311-v3-3'
+        - key: 'CVE-2026-44432' # https://redhat.atlassian.net/browse/RHOAIENG-63872
+          component: 'odh-training-cuda121-torch24-py311-v3-3'
+        - key: 'CVE-2026-44432' # https://redhat.atlassian.net/browse/RHOAIENG-63851
+          component: 'odh-model-registry-job-async-upload-v3-3'
+        - key: 'CVE-2026-44432' # https://redhat.atlassian.net/browse/RHOAIENG-63845
+          component: 'odh-kserve-storage-initializer-v3-3'
+        - key: 'CVE-2026-39892' # https://redhat.atlassian.net/browse/RHOAIENG-62113
+          component: 'odh-trustyai-nemo-guardrails-server-v3-3'
+        - key: 'CVE-2026-39892' # https://redhat.atlassian.net/browse/RHOAIENG-62112
+          component: 'odh-trustyai-garak-lls-provider-dsp-v3-3'
+        - key: 'CVE-2026-39892' # https://redhat.atlassian.net/browse/RHOAIENG-62102
+          component: 'odh-llama-stack-core-v3-3'
+        - key: 'CVE-2026-41242' # https://redhat.atlassian.net/browse/RHOAIENG-60095
+          component: 'odh-mod-arch-maas-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59323
+          component: 'odh-workbench-jupyter-trustyai-cpu-py312-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59322
+          component: 'odh-workbench-jupyter-tensorflow-rocm-py312-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59321
+          component: 'odh-workbench-jupyter-tensorflow-cuda-py312-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59320
+          component: 'odh-workbench-jupyter-pytorch-rocm-py312-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59319
+          component: 'odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59318
+          component: 'odh-workbench-jupyter-pytorch-cuda-py312-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59317
+          component: 'odh-workbench-jupyter-minimal-rocm-py312-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59316
+          component: 'odh-workbench-jupyter-minimal-cuda-py312-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59315
+          component: 'odh-workbench-jupyter-minimal-cpu-py312-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59314
+          component: 'odh-workbench-jupyter-datascience-cpu-py312-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59313
+          component: 'odh-workbench-codeserver-datascience-cpu-py312-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59312
+          component: 'odh-trustyai-nemo-guardrails-server-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59311
+          component: 'odh-trustyai-garak-lls-provider-dsp-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59309
+          component: 'odh-pipeline-runtime-tensorflow-rocm-py312-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59308
+          component: 'odh-pipeline-runtime-tensorflow-cuda-py312-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59307
+          component: 'odh-pipeline-runtime-pytorch-rocm-py312-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59306
+          component: 'odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59305
+          component: 'odh-pipeline-runtime-pytorch-cuda-py312-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59304
+          component: 'odh-pipeline-runtime-minimal-cpu-py312-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59303
+          component: 'odh-pipeline-runtime-datascience-cpu-py312-v3-3'
+        - key: 'CVE-2026-23490' # https://redhat.atlassian.net/browse/RHOAIENG-59301
+          component: 'odh-llama-stack-core-v3-3'
+        - key: 'CVE-2026-28684' # https://redhat.atlassian.net/browse/RHOAIENG-59257
+          component: 'odh-trustyai-nemo-guardrails-server-v3-3'
+        - key: 'CVE-2026-28684' # https://redhat.atlassian.net/browse/RHOAIENG-59256
+          component: 'odh-trustyai-garak-lls-provider-dsp-v3-3'
+        - key: 'CVE-2026-40192' # https://redhat.atlassian.net/browse/RHOAIENG-58605
+          component: 'odh-trustyai-nemo-guardrails-server-v3-3'
+        - key: 'CVE-2026-40192' # https://redhat.atlassian.net/browse/RHOAIENG-58604
+          component: 'odh-trustyai-garak-lls-provider-dsp-v3-3'
+        - key: 'CVE-2026-1462' # https://redhat.atlassian.net/browse/RHOAIENG-57867
+          component: 'odh-workbench-jupyter-tensorflow-rocm-py312-v3-3'
+        - key: 'CVE-2026-1462' # https://redhat.atlassian.net/browse/RHOAIENG-57866
+          component: 'odh-workbench-jupyter-tensorflow-cuda-py312-v3-3'
+        - key: 'CVE-2026-1462' # https://redhat.atlassian.net/browse/RHOAIENG-57865
+          component: 'odh-pipeline-runtime-tensorflow-rocm-py312-v3-3'
+        - key: 'CVE-2026-1462' # https://redhat.atlassian.net/browse/RHOAIENG-57864
+          component: 'odh-pipeline-runtime-tensorflow-cuda-py312-v3-3'
+        - key: 'CVE-2026-33699' # https://redhat.atlassian.net/browse/RHOAIENG-57780
+          component: 'odh-llama-stack-core-v3-3'
+        - key: 'CVE-2026-35536' # https://redhat.atlassian.net/browse/RHOAIENG-56673
+          component: 'odh-trustyai-nemo-guardrails-server-v3-3'
+        - key: 'CVE-2026-35536' # https://redhat.atlassian.net/browse/RHOAIENG-56664
+          component: 'odh-llama-stack-core-v3-3'
+        - key: 'CVE-2026-34070' # https://redhat.atlassian.net/browse/RHOAIENG-56150
+          component: 'odh-trustyai-nemo-guardrails-server-v3-3'
+        - key: 'CVE-2026-34070' # https://redhat.atlassian.net/browse/RHOAIENG-56148
+          component: 'odh-llama-stack-core-v3-3'
+        - key: 'CVE-2026-27893' # https://redhat.atlassian.net/browse/RHOAIENG-55684
+          component: 'odh-vllm-cpu-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-55453
+          component: 'odh-workbench-jupyter-trustyai-cpu-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-55452
+          component: 'odh-workbench-jupyter-tensorflow-rocm-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-55451
+          component: 'odh-workbench-jupyter-tensorflow-cuda-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-55450
+          component: 'odh-workbench-jupyter-pytorch-rocm-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-55449
+          component: 'odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-55448
+          component: 'odh-workbench-jupyter-pytorch-cuda-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-55447
+          component: 'odh-workbench-jupyter-minimal-rocm-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-55446
+          component: 'odh-workbench-jupyter-minimal-cuda-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-55445
+          component: 'odh-workbench-jupyter-minimal-cpu-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-55444
+          component: 'odh-workbench-jupyter-datascience-cpu-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-55443
+          component: 'odh-workbench-codeserver-datascience-cpu-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-55442
+          component: 'odh-trustyai-nemo-guardrails-server-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-55441
+          component: 'odh-pipeline-runtime-tensorflow-rocm-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-55440
+          component: 'odh-pipeline-runtime-tensorflow-cuda-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-55439
+          component: 'odh-pipeline-runtime-pytorch-rocm-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-55438
+          component: 'odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-55437
+          component: 'odh-pipeline-runtime-pytorch-cuda-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-55436
+          component: 'odh-pipeline-runtime-minimal-cpu-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-55435
+          component: 'odh-pipeline-runtime-datascience-cpu-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-55433
+          component: 'odh-llama-stack-core-v3-3'
+        - key: 'CVE-2026-33186' # https://redhat.atlassian.net/browse/RHOAIENG-55304
+          component: 'odh-feast-operator-v3-3'
+        - key: 'CVE-2026-33236' # https://redhat.atlassian.net/browse/RHOAIENG-54735
+          component: 'odh-trustyai-nemo-guardrails-server-v3-3'
+        - key: 'CVE-2026-33231' # https://redhat.atlassian.net/browse/RHOAIENG-54653
+          component: 'odh-trustyai-nemo-guardrails-server-v3-3'
+        - key: 'CVE-2026-30922' # https://redhat.atlassian.net/browse/RHOAIENG-54270
+          component: 'odh-workbench-jupyter-trustyai-cpu-py312-v3-3'
+        - key: 'CVE-2026-30922' # https://redhat.atlassian.net/browse/RHOAIENG-54269
+          component: 'odh-workbench-jupyter-tensorflow-rocm-py312-v3-3'
+        - key: 'CVE-2026-30922' # https://redhat.atlassian.net/browse/RHOAIENG-54268
+          component: 'odh-workbench-jupyter-tensorflow-cuda-py312-v3-3'
+        - key: 'CVE-2026-30922' # https://redhat.atlassian.net/browse/RHOAIENG-54267
+          component: 'odh-workbench-jupyter-pytorch-rocm-py312-v3-3'
+        - key: 'CVE-2026-30922' # https://redhat.atlassian.net/browse/RHOAIENG-54266
+          component: 'odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3'
+        - key: 'CVE-2026-30922' # https://redhat.atlassian.net/browse/RHOAIENG-54265
+          component: 'odh-workbench-jupyter-pytorch-cuda-py312-v3-3'
+        - key: 'CVE-2026-30922' # https://redhat.atlassian.net/browse/RHOAIENG-54261
+          component: 'odh-workbench-jupyter-datascience-cpu-py312-v3-3'
+        - key: 'CVE-2026-30922' # https://redhat.atlassian.net/browse/RHOAIENG-54260
+          component: 'odh-workbench-codeserver-datascience-cpu-py312-v3-3'
+        - key: 'CVE-2026-30922' # https://redhat.atlassian.net/browse/RHOAIENG-54259
+          component: 'odh-trustyai-nemo-guardrails-server-v3-3'
+        - key: 'CVE-2026-30922' # https://redhat.atlassian.net/browse/RHOAIENG-54258
+          component: 'odh-trustyai-garak-lls-provider-dsp-v3-3'
+        - key: 'CVE-2026-30922' # https://redhat.atlassian.net/browse/RHOAIENG-54256
+          component: 'odh-pipeline-runtime-tensorflow-rocm-py312-v3-3'
+        - key: 'CVE-2026-30922' # https://redhat.atlassian.net/browse/RHOAIENG-54255
+          component: 'odh-pipeline-runtime-tensorflow-cuda-py312-v3-3'
+        - key: 'CVE-2026-30922' # https://redhat.atlassian.net/browse/RHOAIENG-54254
+          component: 'odh-pipeline-runtime-pytorch-rocm-py312-v3-3'
+        - key: 'CVE-2026-30922' # https://redhat.atlassian.net/browse/RHOAIENG-54252
+          component: 'odh-pipeline-runtime-pytorch-cuda-py312-v3-3'
+        - key: 'CVE-2026-30922' # https://redhat.atlassian.net/browse/RHOAIENG-54250
+          component: 'odh-pipeline-runtime-datascience-cpu-py312-v3-3'
+        - key: 'CVE-2026-32640' # https://redhat.atlassian.net/browse/RHOAIENG-53797
+          component: 'odh-trustyai-nemo-guardrails-server-v3-3'
+        - key: 'CVE-2026-28356' # https://redhat.atlassian.net/browse/RHOAIENG-53295
+          component: 'odh-vllm-cpu-v3-3'
+        - key: 'CVE-2026-32597' # https://redhat.atlassian.net/browse/RHOAIENG-53163
+          component: 'odh-trustyai-garak-lls-provider-dsp-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52850
+          component: 'odh-workbench-jupyter-trustyai-cpu-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52849
+          component: 'odh-workbench-jupyter-tensorflow-rocm-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52848
+          component: 'odh-workbench-jupyter-tensorflow-cuda-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52847
+          component: 'odh-workbench-jupyter-pytorch-rocm-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52842
+          component: 'odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52823
+          component: 'odh-workbench-jupyter-pytorch-cuda-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52821
+          component: 'odh-workbench-jupyter-minimal-rocm-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52820
+          component: 'odh-workbench-jupyter-minimal-cuda-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52819
+          component: 'odh-workbench-jupyter-minimal-cpu-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52818
+          component: 'odh-workbench-jupyter-datascience-cpu-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52817
+          component: 'odh-workbench-codeserver-datascience-cpu-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52815
+          component: 'odh-pipeline-runtime-tensorflow-rocm-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52814
+          component: 'odh-pipeline-runtime-tensorflow-cuda-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52813
+          component: 'odh-pipeline-runtime-pytorch-rocm-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52812
+          component: 'odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52811
+          component: 'odh-pipeline-runtime-pytorch-cuda-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52810
+          component: 'odh-pipeline-runtime-minimal-cpu-py312-v3-3'
+        - key: 'CVE-2026-31958' # https://redhat.atlassian.net/browse/RHOAIENG-52809
+          component: 'odh-pipeline-runtime-datascience-cpu-py312-v3-3'
+        - key: 'CVE-2025-61726' # https://redhat.atlassian.net/browse/RHOAIENG-48628
+          component: 'odh-ml-pipelines-scheduledworkflow-v2-v3-3'
+        - key: 'CVE-2025-61726' # https://redhat.atlassian.net/browse/RHOAIENG-48627
+          component: 'odh-ml-pipelines-persistenceagent-v2-v3-3'
+        - key: 'CVE-2025-61726' # https://redhat.atlassian.net/browse/RHOAIENG-48626
+          component: 'odh-ml-pipelines-launcher-v3-3'
+        - key: 'CVE-2025-61726' # https://redhat.atlassian.net/browse/RHOAIENG-48625
+          component: 'odh-ml-pipelines-driver-v3-3'
+        - key: 'CVE-2025-61726' # https://redhat.atlassian.net/browse/RHOAIENG-48624
+          component: 'odh-ml-pipelines-api-server-v2-v3-3'
+        - key: 'CVE-2025-61726' # https://redhat.atlassian.net/browse/RHOAIENG-48616
+          component: 'odh-data-science-pipelines-operator-controller-v3-3'
+        - key: 'CVE-2025-69223' # https://redhat.atlassian.net/browse/RHOAIENG-43649
+          component: 'odh-ta-lmes-job-v3-3'
+      issues:
+          fixed:
+            - id: RHOAIENG-71848
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-70063
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-67971
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66591
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66258
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66252
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66250
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66246
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66245
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66241
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66237
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66231
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-66230
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65992
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65968
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65879
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65878
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65877
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65869
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-65819
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64900
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64898
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64896
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64893
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64892
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64891
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64890
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64889
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64888
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64885
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64882
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64878
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64873
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64865
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64537
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64536
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64535
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64534
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64533
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64532
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64531
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64530
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64502
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64500
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64498
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64496
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64470
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64055
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64054
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64052
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64051
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64050
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64047
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64045
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64042
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64035
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-64034
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-63917
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-63916
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-63915
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-63914
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-63913
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-63912
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-63911
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-63878
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-63876
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-63874
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-63872
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-63851
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-63845
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-62113
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-62112
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-62102
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-60095
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59323
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59322
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59321
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59320
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59319
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59318
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59317
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59316
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59315
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59314
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59313
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59312
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59311
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59309
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59308
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59307
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59306
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59305
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59304
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59303
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59301
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59257
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-59256
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-58605
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-58604
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-57867
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-57866
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-57865
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-57864
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-57780
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56673
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56664
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56150
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-56148
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55684
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55453
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55452
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55451
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55450
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55449
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55448
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55447
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55446
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55445
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55444
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55443
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55442
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55441
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55440
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55439
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55438
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55437
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55436
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55435
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55433
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-55304
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54735
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54653
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54270
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54269
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54268
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54267
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54266
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54265
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54261
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54260
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54259
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54258
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54256
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54255
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54254
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54252
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-54250
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-53797
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-53295
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-53163
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52850
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52849
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52848
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52847
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52842
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52823
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52821
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52820
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52819
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52818
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52817
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52815
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52814
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52813
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52812
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52811
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52810
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-52809
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-48628
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-48627
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-48626
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-48625
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-48624
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-48616
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-43649
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-67054
+              public: true
+              source: redhat.atlassian.net
+            - id: RHOAIENG-51802
+              public: true
+              source: redhat.atlassian.net

--- a/release/3.3.5/prod/release-fbc/prod-release-fbc-ocp-419-rhoai-v3-3-1783586527.yaml
+++ b/release/3.3.5/prod/release-fbc/prod-release-fbc-ocp-419-rhoai-v3-3-1783586527.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-419-prod-1783586527
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 9e62817cf9ed15b3d1ca6fa3dd393670e7a0fecd
+    konflux-release-data/ocp-version: ocp-419
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: prod
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-419
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-3-ocp-419-fbc-prod
+  snapshot: rhoai-fbc-fragment-ocp-419-1783108273
+  data:
+    version: 3.3.5

--- a/release/3.3.5/prod/release-fbc/prod-release-fbc-ocp-420-rhoai-v3-3-1783586527.yaml
+++ b/release/3.3.5/prod/release-fbc/prod-release-fbc-ocp-420-rhoai-v3-3-1783586527.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-420-prod-1783586527
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 9e62817cf9ed15b3d1ca6fa3dd393670e7a0fecd
+    konflux-release-data/ocp-version: ocp-420
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: prod
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-420
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-3-ocp-420-fbc-prod
+  snapshot: rhoai-fbc-fragment-ocp-420-1783108273
+  data:
+    version: 3.3.5

--- a/release/3.3.5/prod/release-fbc/prod-release-fbc-ocp-421-rhoai-v3-3-1783586527.yaml
+++ b/release/3.3.5/prod/release-fbc/prod-release-fbc-ocp-421-rhoai-v3-3-1783586527.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-421-prod-1783586527
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 9e62817cf9ed15b3d1ca6fa3dd393670e7a0fecd
+    konflux-release-data/ocp-version: ocp-421
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: prod
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-421
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-3-ocp-421-fbc-prod
+  snapshot: rhoai-fbc-fragment-ocp-421-1783108273
+  data:
+    version: 3.3.5

--- a/release/3.3.5/stage/release-components/release-components-stage-rhoai-v3-3-1783094273.yaml
+++ b/release/3.3.5/stage/release-components/release-components-stage-rhoai-v3-3-1783094273.yaml
@@ -1,0 +1,16 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    appstudio.openshift.io/application: rhoai-v3-3
+    konflux-release-data/artifact-type: components
+    konflux-release-data/environment: stage
+    konflux-release-data/rbc-release-commit: 9e62817cf9ed15b3d1ca6fa3dd393670e7a0fecd
+  name: rhoai-v3-3-stage-1783094273
+  namespace: rhoai-tenant
+spec:
+  data:
+    version: 3.3.5
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-3-components-stage
+  snapshot: rhoai-v3-3-1783094273

--- a/release/3.3.5/stage/release-fbc/release-fbc-stage-ocp-419-rhoai-v3-3-1783108273.yaml
+++ b/release/3.3.5/stage/release-fbc/release-fbc-stage-ocp-419-rhoai-v3-3-1783108273.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-419-stage-1783108273
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 9e62817cf9ed15b3d1ca6fa3dd393670e7a0fecd
+    konflux-release-data/ocp-version: ocp-419
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-419
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-3-ocp-419-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-419-1783108273
+  data:
+    version: 3.3.5

--- a/release/3.3.5/stage/release-fbc/release-fbc-stage-ocp-420-rhoai-v3-3-1783108273.yaml
+++ b/release/3.3.5/stage/release-fbc/release-fbc-stage-ocp-420-rhoai-v3-3-1783108273.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-420-stage-1783108273
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 9e62817cf9ed15b3d1ca6fa3dd393670e7a0fecd
+    konflux-release-data/ocp-version: ocp-420
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-420
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-3-ocp-420-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-420-1783108273
+  data:
+    version: 3.3.5

--- a/release/3.3.5/stage/release-fbc/release-fbc-stage-ocp-421-rhoai-v3-3-1783108273.yaml
+++ b/release/3.3.5/stage/release-fbc/release-fbc-stage-ocp-421-rhoai-v3-3-1783108273.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-421-stage-1783108273
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 9e62817cf9ed15b3d1ca6fa3dd393670e7a0fecd
+    konflux-release-data/ocp-version: ocp-421
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-421
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v3-3-ocp-421-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-421-1783108273
+  data:
+    version: 3.3.5

--- a/release/3.3.5/stage/snapshot-components/snapshot-components-stage-rhoai-v3-3-1783094273.yaml
+++ b/release/3.3.5/stage/snapshot-components/snapshot-components-stage-rhoai-v3-3-1783094273.yaml
@@ -1,0 +1,510 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  labels:
+    konflux-release-data/artifact-type: components
+    konflux-release-data/rbc-release-commit: 9e62817cf9ed15b3d1ca6fa3dd393670e7a0fecd
+    test.appstudio.openshift.io/type: override
+  name: rhoai-v3-3-1783094273
+  namespace: rhoai-tenant
+spec:
+  application: rhoai-v3-3
+  components:
+  - containerImage: quay.io/rhoai/odh-operator-bundle@sha256:3a0158c32b3c4068ac7a098d5113148087b5f4b44fd1ed7556ba590bd0f4b837
+    name: odh-operator-bundle-v3-3
+    source:
+      git:
+        revision: 81a1d105647b51516d5ed235665bb0f7a1905a01
+        url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+  - containerImage: quay.io/rhoai/odh-built-in-detector-rhel9@sha256:901a8d2332d056f4aaeec7e275dc4bac13dded46e931ef3dccaf01bba427c7a5
+    name: odh-built-in-detector-v3-3
+    source:
+      git:
+        revision: 08d0fdccc153dcb1b7292136dafb9e8c9005705b
+        url: https://github.com/red-hat-data-services/guardrails-detectors
+  - containerImage: quay.io/rhoai/odh-cli-rhel9@sha256:180015410763540725b6902550f31ed1ed844c4aa1853a746e114dd0e3e6eceb
+    name: odh-cli-v3-3
+    source:
+      git:
+        revision: 63689d4d71fcc61e8df9e42bcade49f1f699581f
+        url: https://github.com/red-hat-data-services/odh-cli
+  - containerImage: quay.io/rhoai/odh-dashboard-rhel9@sha256:675852e34205eed80d86d45348a1f150a5db3e81e6d305e41424721e3e7dbb8f
+    name: odh-dashboard-v3-3
+    source:
+      git:
+        revision: 9de37b072105c603b4550caeb5f8344b93f205ce
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-data-science-pipelines-argo-argoexec-rhel9@sha256:8bb6b709e779082ca829332dc017d05a5f8db66529410059543d70213102436c
+    name: odh-data-science-pipelines-argo-argoexec-v3-3
+    source:
+      git:
+        revision: ac312cc49579580633bb027a1b37a0f4372439fc
+        url: https://github.com/red-hat-data-services/argo-workflows
+  - containerImage: quay.io/rhoai/odh-data-science-pipelines-argo-workflowcontroller-rhel9@sha256:6120acd918bd648b0cc2339fdbe1712d1df11b71cbba0bd7bfc7d71194fb52b7
+    name: odh-data-science-pipelines-argo-workflowcontroller-v3-3
+    source:
+      git:
+        revision: ac312cc49579580633bb027a1b37a0f4372439fc
+        url: https://github.com/red-hat-data-services/argo-workflows
+  - containerImage: quay.io/rhoai/odh-data-science-pipelines-operator-controller-rhel9@sha256:4d0b020de0bb738c6b477cd4a1084802a57ded15f03b81bc3e16df1a1d2f7001
+    name: odh-data-science-pipelines-operator-controller-v3-3
+    source:
+      git:
+        revision: 0626a64112b02c354c753548d3ec756f1d218965
+        url: https://github.com/red-hat-data-services/data-science-pipelines-operator
+  - containerImage: quay.io/rhoai/odh-feast-operator-rhel9@sha256:8c119e9a2182466a1dea85a8b86d208e0bb3059db45ec7aa35a249b80bb6d02a
+    name: odh-feast-operator-v3-3
+    source:
+      git:
+        revision: 158587bb58afc291261366278afceb37114abb00
+        url: https://github.com/red-hat-data-services/feast
+  - containerImage: quay.io/rhoai/odh-feature-server-rhel9@sha256:a27cf274a44874324f514f2890fd7ea42e6361b0bfa26f85f4e45661e81a68c9
+    name: odh-feature-server-v3-3
+    source:
+      git:
+        revision: 9ee360c22024e2f70d1ff4323a99ff9e430abd43
+        url: https://github.com/red-hat-data-services/feast
+  - containerImage: quay.io/rhoai/odh-fms-guardrails-orchestrator-rhel9@sha256:3beb03a77030f4520fd7e2235af27f5f9a12396a7088efd092563db963cfd6dd
+    name: odh-fms-guardrails-orchestrator-v3-3
+    source:
+      git:
+        revision: e3e9645b4c115222182431fd9ec406456677654b
+        url: https://github.com/red-hat-data-services/fms-guardrails-orchestrator
+  - containerImage: quay.io/rhoai/odh-guardrails-detector-huggingface-runtime-rhel9@sha256:d8618a9559d3fcaa08679b70716ff75d2dc0e068ae5056cea37094196e89af27
+    name: odh-guardrails-detector-huggingface-runtime-v3-3
+    source:
+      git:
+        revision: 08d0fdccc153dcb1b7292136dafb9e8c9005705b
+        url: https://github.com/red-hat-data-services/guardrails-detectors
+  - containerImage: quay.io/rhoai/odh-kf-notebook-controller-rhel9@sha256:f495fea52fef1a9397d3c67bb12a177f6b2fae1bf65dcfc4fb464297cf640ce8
+    name: odh-kf-notebook-controller-v3-3
+    source:
+      git:
+        revision: d3c9a337eed2ad9d1593fce09b13f132d7f411ba
+        url: https://github.com/red-hat-data-services/kubeflow
+  - containerImage: quay.io/rhoai/odh-kserve-agent-rhel9@sha256:173ced269f1ca96959392d2591841e29564b6f4391b436c7fa8bd0cfcf49550d
+    name: odh-kserve-agent-v3-3
+    source:
+      git:
+        revision: 0dcf5fce9094a59263feed2fcd01b3cebb6f3cb0
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kserve-controller-rhel9@sha256:19e4317a01aa58f6cf369de3f382c556fdfdd203a187c0501aea3e2c2d8d00ac
+    name: odh-kserve-controller-v3-3
+    source:
+      git:
+        revision: 0dcf5fce9094a59263feed2fcd01b3cebb6f3cb0
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kserve-router-rhel9@sha256:c8002ceaddccee9c680e62b1292ceffe4cc4162c503e9b8ef09ddd100f9fdd0a
+    name: odh-kserve-router-v3-3
+    source:
+      git:
+        revision: 0dcf5fce9094a59263feed2fcd01b3cebb6f3cb0
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kserve-storage-initializer-rhel9@sha256:ae2f8b770164a2486a597c96a02b1615681b216be85da1f874e3388b525f5097
+    name: odh-kserve-storage-initializer-v3-3
+    source:
+      git:
+        revision: 0dcf5fce9094a59263feed2fcd01b3cebb6f3cb0
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kube-auth-proxy-rhel9@sha256:50fb680b5b247501fae4e9d6e18b2145d42d6fbb6b42b8092e332eb9496c8a0c
+    name: odh-kube-auth-proxy-v3-3
+    source:
+      git:
+        revision: 405013c1a9e4dcc1c0df8467752664bd0b812291
+        url: https://github.com/red-hat-data-services/kube-auth-proxy
+  - containerImage: quay.io/rhoai/odh-kube-auth-proxy-rhel9@sha256:50fb680b5b247501fae4e9d6e18b2145d42d6fbb6b42b8092e332eb9496c8a0c
+    name: odh-kube-auth-proxy-v3-3
+    source:
+      git:
+        revision: 405013c1a9e4dcc1c0df8467752664bd0b812291
+        url: https://github.com/red-hat-data-services/kube-auth-proxy
+  - containerImage: quay.io/rhoai/odh-kuberay-operator-controller-rhel9@sha256:79aa043d296d9b4f1fed5e6c46ba52c3a3f1ad92e4b54dcd3295c05b608c696e
+    name: odh-kuberay-operator-controller-v3-3
+    source:
+      git:
+        revision: 2982a7b65368b700333999d3de0f34934def5847
+        url: https://github.com/red-hat-data-services/kuberay
+  - containerImage: quay.io/rhoai/odh-llama-stack-core-rhel9@sha256:08efafa4ddfea21e016644d312c104c32bb1134700e53af53737d67d1422e620
+    name: odh-llama-stack-core-v3-3
+    source:
+      git:
+        revision: f8f898396971e2e4e6b50fb89e4de0761d92bed8
+        url: https://github.com/red-hat-data-services/ogx-distribution
+  - containerImage: quay.io/rhoai/odh-llama-stack-k8s-operator-rhel9@sha256:5acc549bbbf2217213374801f7488ba76aea99736a456fdcee9517277882770b
+    name: odh-llama-stack-k8s-operator-v3-3
+    source:
+      git:
+        revision: 0a85f6593f3b3f794bb7a00d98a3e237fb20c921
+        url: https://github.com/red-hat-data-services/ogx-k8s-operator
+  - containerImage: quay.io/rhoai/odh-llm-d-inference-scheduler-rhel9@sha256:d2d16620ecbde23d2e218916c025f7a44cd36a541d8532cc63723f05f81f42b6
+    name: odh-llm-d-inference-scheduler-v3-3
+    source:
+      git:
+        revision: 0a593cea7362e723750b93bc25142f82a25ec22f
+        url: https://github.com/red-hat-data-services/llm-d-inference-scheduler
+  - containerImage: quay.io/rhoai/odh-llm-d-routing-sidecar-rhel9@sha256:675b8bb1c8821d67ce96aedbdb15d9d394910d0394af49c0b61b7c0ba0130659
+    name: odh-llm-d-routing-sidecar-v3-3
+    source:
+      git:
+        revision: 0a593cea7362e723750b93bc25142f82a25ec22f
+        url: https://github.com/red-hat-data-services/llm-d-inference-scheduler
+  - containerImage: quay.io/rhoai/odh-maas-api-rhel9@sha256:4f213e6d2e0d2f58eb08d290d32105ebe00760154197591499bcfefe4cb7dfbd
+    name: odh-maas-api-v3-3
+    source:
+      git:
+        revision: eb570670a7cdb90ed76e9e8b309a65b5a4c024dd
+        url: https://github.com/red-hat-data-services/models-as-a-service
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-api-server-v2-rhel9@sha256:1d26b781967710fce9be209544737345448405dd6757aa6f2b9640fce989175d
+    name: odh-ml-pipelines-api-server-v2-v3-3
+    source:
+      git:
+        revision: f65eefc25a7cce40b1f927020ca3953e945b2b8a
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-driver-rhel9@sha256:ee3e4d716ea6e49e0c43af0fadab4193687f5f482a503972f5750a15ca60ebe4
+    name: odh-ml-pipelines-driver-v3-3
+    source:
+      git:
+        revision: f65eefc25a7cce40b1f927020ca3953e945b2b8a
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-launcher-rhel9@sha256:40ef2482d024dedca0fb4ad662def31d15a264338886cd7fe71f725dccf353c2
+    name: odh-ml-pipelines-launcher-v3-3
+    source:
+      git:
+        revision: f65eefc25a7cce40b1f927020ca3953e945b2b8a
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-persistenceagent-v2-rhel9@sha256:d46e38d93a5d170795b770bdc1ba3584f30539790690310d327c34cf3e04af71
+    name: odh-ml-pipelines-persistenceagent-v2-v3-3
+    source:
+      git:
+        revision: f65eefc25a7cce40b1f927020ca3953e945b2b8a
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-scheduledworkflow-v2-rhel9@sha256:8cb09f772257c6616c12e8c099c9299a08a8bfeb7d301638365a6df35756d434
+    name: odh-ml-pipelines-scheduledworkflow-v2-v3-3
+    source:
+      git:
+        revision: f65eefc25a7cce40b1f927020ca3953e945b2b8a
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-mlflow-operator-rhel9@sha256:03b04d892253af9f82fe16d9a0aa7da5b301d05b0b00950d0177de0f45bc2064
+    name: odh-mlflow-operator-v3-3
+    source:
+      git:
+        revision: b0fe56e437b675be57e64b9c427dbead113fc977
+        url: https://github.com/red-hat-data-services/mlflow-operator
+  - containerImage: quay.io/rhoai/odh-mlflow-rhel9@sha256:57a15791f4459ef8756c52b6102a45185b79fd5cfceb17fb31caf039125d05be
+    name: odh-mlflow-v3-3
+    source:
+      git:
+        revision: ff0f2c5dd9a9d8880e55bd3c41953f0fb7d52b39
+        url: https://github.com/red-hat-data-services/mlflow
+  - containerImage: quay.io/rhoai/odh-mlmd-grpc-server-rhel9@sha256:fbf63c4dccd6f9ed8e735cf422cf94c807453f35ec82e67c335342f70228f29b
+    name: odh-mlmd-grpc-server-v3-3
+    source:
+      git:
+        revision: d5ecbb9ee37329b17f3a12b9a49450f244dc54a5
+        url: https://github.com/red-hat-data-services/ml-metadata
+  - containerImage: quay.io/rhoai/odh-mlserver-rhel9@sha256:d68eb9829326d047e6ea972aea60fcbed0284134220ddecec2c6aaf148ca0645
+    name: odh-mlserver-v3-3
+    source:
+      git:
+        revision: 24597183d0c79e53f2f9827fddcef43f43ed2883
+        url: https://github.com/red-hat-data-services/MLServer
+  - containerImage: quay.io/rhoai/odh-mod-arch-gen-ai-rhel9@sha256:f5e09f1858bf558fd9eac6b98b82465b16311c0bf387a1ec45d736a7561ac5f8
+    name: odh-mod-arch-gen-ai-v3-3
+    source:
+      git:
+        revision: 9de37b072105c603b4550caeb5f8344b93f205ce
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-mod-arch-maas-rhel9@sha256:22e31d3efd7b59472e7e204f7912c2c9b15d059dc31c0eb589ee086e9fe359f4
+    name: odh-mod-arch-maas-v3-3
+    source:
+      git:
+        revision: 9de37b072105c603b4550caeb5f8344b93f205ce
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-mod-arch-model-registry-rhel9@sha256:fcfdefbf6c32fefd53ef94b93e38741b0cbd36d4eef605635c10179442df6c59
+    name: odh-mod-arch-model-registry-v3-3
+    source:
+      git:
+        revision: 1d05e84d2ac454e3df6de924d1cc272dbde8d4ec
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-model-controller-rhel9@sha256:a04a23c2fcc0201c572b000f37d14686c7f65c0f65708c536618a643695d7cde
+    name: odh-model-controller-v3-3
+    source:
+      git:
+        revision: 071217e9b77bb3690d8d20d21a8ca45694c7f1a9
+        url: https://github.com/red-hat-data-services/odh-model-controller
+  - containerImage: quay.io/rhoai/odh-model-metadata-collection-rhel9@sha256:808aaee1ff21672372fded0948f6414b55fcf763b459d1c2b8bc0ae9ed3623d4
+    name: odh-model-metadata-collection-v3-3
+    source:
+      git:
+        revision: f5ade1f1f947a8e638db7742de8f5c7af2ab66be
+        url: https://github.com/red-hat-data-services/model-metadata-collection
+  - containerImage: quay.io/rhoai/odh-model-performance-data-rhel9@sha256:4856c37e03a448ea92329783ff78f1e92164a25d98830bdb2ef8feead29f4abd
+    name: odh-model-performance-data-v3-3
+    source:
+      git:
+        revision: e10246f13e747525f2bcc7c1a94a2967e6914f64
+        url: https://github.com/red-hat-data-services/models-perf-benchmark-data
+  - containerImage: quay.io/rhoai/odh-model-registry-job-async-upload-rhel9@sha256:842ff557ed62551bc4947f38e8007ef9f16bed156b175b7db8c1c835c77cb5c0
+    name: odh-model-registry-job-async-upload-v3-3
+    source:
+      git:
+        revision: 2d7d7f9118f986b09cdc5d3e16411afc959a56fd
+        url: https://github.com/red-hat-data-services/model-registry
+  - containerImage: quay.io/rhoai/odh-model-registry-operator-rhel9@sha256:6ccd4ec7abd30ef881ada28793c5f6e16b45e27edccdc7fc0a53cae4d78c4fd8
+    name: odh-model-registry-operator-v3-3
+    source:
+      git:
+        revision: aee4d01600afff1933ff9e0e076c7562b5e85b26
+        url: https://github.com/red-hat-data-services/model-registry-operator
+  - containerImage: quay.io/rhoai/odh-model-registry-rhel9@sha256:52926b0c364eb754baf82c4227a1704a43dab15e3d8d8211ba69f9b855725e11
+    name: odh-model-registry-v3-3
+    source:
+      git:
+        revision: b0ceb13b6fc4565ea51617daa9f2656c559bbb5c
+        url: https://github.com/red-hat-data-services/model-registry
+  - containerImage: quay.io/rhoai/odh-must-gather-rhel9@sha256:f20e14dc77b1487faab3a96ce92014668ac024c766c896348130b90d438930ed
+    name: odh-must-gather-v3-3
+    source:
+      git:
+        revision: db981125688b4578be6989275927fb8a4994fd1d
+        url: https://github.com/red-hat-data-services/must-gather
+  - containerImage: quay.io/rhoai/odh-notebook-controller-rhel9@sha256:7d6d5d6455d83639ef33968f6a03753905cc03c93883de42d4e27712c791ceb0
+    name: odh-notebook-controller-v3-3
+    source:
+      git:
+        revision: d3c9a337eed2ad9d1593fce09b13f132d7f411ba
+        url: https://github.com/red-hat-data-services/kubeflow
+  - containerImage: quay.io/rhoai/odh-openvino-model-server-rhel9@sha256:25a1d9c978dadb71d3b55e6eec3dc2d63ccf85d33750a7add2b15be942fe8742
+    name: odh-openvino-model-server-v3-3
+    source:
+      git:
+        revision: f51faeb9cb204f7778ff1539f9c0fa9f309f6d99
+        url: https://github.com/red-hat-data-services/openvino_model_server
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-datascience-cpu-py312-rhel9@sha256:d3b535e0ec6507f7d2ad43d58b8adcaf1df8d8a7fe991069fd73998169718dae
+    name: odh-pipeline-runtime-datascience-cpu-py312-v3-3
+    source:
+      git:
+        revision: 601928d3f91ddd82be56e310b92aed808aebef70
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-minimal-cpu-py312-rhel9@sha256:256044dc8bb66b1259faa84a2846a38e174c97ece357f099efe6972d9141c29f
+    name: odh-pipeline-runtime-minimal-cpu-py312-v3-3
+    source:
+      git:
+        revision: 601928d3f91ddd82be56e310b92aed808aebef70
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-pytorch-cuda-py312-rhel9@sha256:d43af1a998de987f70a8ece5d3b51a3a4f360e521ab46cf43c9d8dec52afcd3f
+    name: odh-pipeline-runtime-pytorch-cuda-py312-v3-3
+    source:
+      git:
+        revision: 601928d3f91ddd82be56e310b92aed808aebef70
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9@sha256:ad0f5fd6a9350a73a146a53ab25535f4c9309971ac3247e830b8c202ef009334
+    name: odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-3
+    source:
+      git:
+        revision: 601928d3f91ddd82be56e310b92aed808aebef70
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9@sha256:eb7d5f4ca7894d066efd901440f14b6b9ef93334b581d78b5f89fa4519eaf214
+    name: odh-pipeline-runtime-pytorch-rocm-py312-v3-3
+    source:
+      git:
+        revision: 601928d3f91ddd82be56e310b92aed808aebef70
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9@sha256:9dd3546bf3de3c66e0bc6e1059af2fd16b49d9eb26a98e47e55f5e37387ec83e
+    name: odh-pipeline-runtime-tensorflow-cuda-py312-v3-3
+    source:
+      git:
+        revision: 601928d3f91ddd82be56e310b92aed808aebef70
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9@sha256:7b310b96718d053920142cbc8a054a8276b37430592a19e8e1c4d738f7c4695b
+    name: odh-pipeline-runtime-tensorflow-rocm-py312-v3-3
+    source:
+      git:
+        revision: 601928d3f91ddd82be56e310b92aed808aebef70
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-rhel9-operator@sha256:c3f9d70493c029b77648f44c1980512a741784384b2edcb705ca7fb4738b6e2b
+    name: odh-operator-v3-3
+    source:
+      git:
+        revision: 940f47da8052265e4f4359361c24579b3b13e92e
+        url: https://github.com/red-hat-data-services/rhods-operator
+  - containerImage: quay.io/rhoai/odh-ta-lmes-driver-rhel9@sha256:0b85871252584b596991872610f89964f378b273811625fb31c776fc9b90f883
+    name: odh-ta-lmes-driver-v3-3
+    source:
+      git:
+        revision: c4b553dbd179e24c9a95874ba74e56af3045f2db
+        url: https://github.com/red-hat-data-services/trustyai-service-operator
+  - containerImage: quay.io/rhoai/odh-ta-lmes-job-rhel9@sha256:767fda236b59e89a6bb28774910909a933410755b64fffb5c09b391c68d53653
+    name: odh-ta-lmes-job-v3-3
+    source:
+      git:
+        revision: 841b2e74b34677acf0c61f3df56faa8f50c2c759
+        url: https://github.com/red-hat-data-services/lm-evaluation-harness
+  - containerImage: quay.io/rhoai/odh-trainer-rhel9@sha256:176ef30dba6a4ec236fb320579c1c606345a712a65a092af8ba40ea6388c570a
+    name: odh-trainer-v3-3
+    source:
+      git:
+        revision: 3a12a89653745a277738af6c63f381fc763e4a47
+        url: https://github.com/red-hat-data-services/trainer
+  - containerImage: quay.io/rhoai/odh-training-cuda121-torch24-py311-rhel9@sha256:77939c8b1707fa543e8c9f2220597bb94941a4b2bfc91087dc8051065720ebad
+    name: odh-training-cuda121-torch24-py311-v3-3
+    source:
+      git:
+        revision: 6f9572f617f1aadc059018485343f4a706c2f2c9
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-cuda124-torch25-py311-rhel9@sha256:3e53c82651f20b0beaf72dbfba9c3d9ca63b38aa888784333848e22b064fda1e
+    name: odh-training-cuda124-torch25-py311-v3-3
+    source:
+      git:
+        revision: 6f9572f617f1aadc059018485343f4a706c2f2c9
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-cuda128-torch28-py312-rhel9@sha256:48e4b152e980865bdaf08792bb01d17015aec8080a110b7db076d4ce18661f5a
+    name: odh-training-cuda128-torch28-py312-v3-3
+    source:
+      git:
+        revision: 09766f6df043e664e72a9dfc7e6112cb0b35d2a1
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-cuda128-torch29-py312-rhel9@sha256:f13285d56428a1befdfd05873b63cac0976a561fde8a97d3db95cfcfba613e0a
+    name: odh-training-cuda128-torch29-py312-v3-3
+    source:
+      git:
+        revision: a567229e0b9fc57bb072a47f7f06a65056a449fb
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-operator-rhel9@sha256:8161e8c05006c1e2bf8b419284b7dbd677767cd3493d332e9014ab665545f662
+    name: odh-training-operator-v3-3
+    source:
+      git:
+        revision: 8aed73b757b17aa07af61f9ca4b06d752a22ddb8
+        url: https://github.com/red-hat-data-services/training-operator
+  - containerImage: quay.io/rhoai/odh-training-rocm62-torch24-py311-rhel9@sha256:0fc70fa22d078eb719fbf6004b95c8b07a754c2cd02f5e5d80981f6893181f10
+    name: odh-training-rocm62-torch24-py311-v3-3
+    source:
+      git:
+        revision: 6f9572f617f1aadc059018485343f4a706c2f2c9
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-rocm62-torch25-py311-rhel9@sha256:3621a51b74e9a408effe094dfec070598ca3b433a2d03a6578a0223034f81f4d
+    name: odh-training-rocm62-torch25-py311-v3-3
+    source:
+      git:
+        revision: 6f9572f617f1aadc059018485343f4a706c2f2c9
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-rocm64-torch28-py312-rhel9@sha256:0344f71036f7f4b0fbbe4db934b3c365bce3465eadf35940d1f7603481cd685e
+    name: odh-training-rocm64-torch28-py312-v3-3
+    source:
+      git:
+        revision: 5a00585c68ad7ff4a7b8fd4fd7f7e818393c3de9
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-rocm64-torch29-py312-rhel9@sha256:73465aa2a929568002c40a74d2cadaadc40d8c49f031d404f33e02abb6681549
+    name: odh-training-rocm64-torch29-py312-v3-3
+    source:
+      git:
+        revision: a567229e0b9fc57bb072a47f7f06a65056a449fb
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-trustyai-garak-lls-provider-dsp-rhel9@sha256:929a93be9f833eeb2089c3bb25828f56e71e67fc753418afcd971f86602cb6e2
+    name: odh-trustyai-garak-lls-provider-dsp-v3-3
+    source:
+      git:
+        revision: 77b7afa549918ab8c95a51d50e6d021162fc383c
+        url: https://github.com/red-hat-data-services/llama-stack-provider-trustyai-garak
+  - containerImage: quay.io/rhoai/odh-trustyai-nemo-guardrails-server-rhel9@sha256:599f340b180492404beff2fbe9c5d308938072af104670afa5fdff4d5ac30e30
+    name: odh-trustyai-nemo-guardrails-server-v3-3
+    source:
+      git:
+        revision: 0ce0ea95d7f5668197caaab99314826b473e6a4d
+        url: https://github.com/red-hat-data-services/NeMo-Guardrails
+  - containerImage: quay.io/rhoai/odh-trustyai-service-operator-rhel9@sha256:6c784a57edd43b4ac210433f2fc4f56e67fd93567720e1d1083a51d47994512b
+    name: odh-trustyai-service-operator-v3-3
+    source:
+      git:
+        revision: c4b553dbd179e24c9a95874ba74e56af3045f2db
+        url: https://github.com/red-hat-data-services/trustyai-service-operator
+  - containerImage: quay.io/rhoai/odh-trustyai-service-rhel9@sha256:1305fe774da42b25700c2561bab3ac2905c8b643acee04653a39633573824831
+    name: odh-trustyai-service-v3-3
+    source:
+      git:
+        revision: b3b2ef70c2264956ea6815cf118ca109376c55b6
+        url: https://github.com/red-hat-data-services/trustyai-explainability
+  - containerImage: quay.io/rhoai/odh-trustyai-vllm-orchestrator-gateway-rhel9@sha256:dc1990d2d808e99bc0df918f9cd8f59ab58d2d40020cafaecd9e67c6d434a84e
+    name: odh-trustyai-vllm-orchestrator-gateway-v3-3
+    source:
+      git:
+        revision: be3d02f512e526fd308435264688b9396fd271dd
+        url: https://github.com/red-hat-data-services/vllm-orchestrator-gateway
+  - containerImage: quay.io/rhoai/odh-vllm-cpu-rhel9@sha256:5e13f02ddec5c7d4b8d431d62bb4db66d7e06a456364f9c7930416d30dee46fe
+    name: odh-vllm-cpu-v3-3
+    source:
+      git:
+        revision: da4b4856cbfa8ee463430b8b1a981445f081b6d7
+        url: https://github.com/red-hat-data-services/vllm-cpu
+  - containerImage: quay.io/rhoai/odh-vllm-gaudi-rhel9@sha256:5215f77f4e775b4e84cd5a53501d1655cf92ddf9cdea9154f33c8024f405d67f
+    name: odh-vllm-gaudi-v3-3
+    source:
+      git:
+        revision: cf1d3cc4923d08b2e30e6c120bd783093c841b2f
+        url: https://github.com/red-hat-data-services/vllm-gaudi
+  - containerImage: quay.io/rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9@sha256:667a38c241f4fede7a3f17fb2ccb17739fbc84b9628d646bbee7b1c855f04cfb
+    name: odh-workbench-codeserver-datascience-cpu-py312-v3-3
+    source:
+      git:
+        revision: 601928d3f91ddd82be56e310b92aed808aebef70
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9@sha256:050ff3625446fece8901a316bc4c77b9a8557fabd44726a45ab0ef971fa37098
+    name: odh-workbench-jupyter-datascience-cpu-py312-v3-3
+    source:
+      git:
+        revision: 601928d3f91ddd82be56e310b92aed808aebef70
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9@sha256:b1e96b79bf835f9ac3e5c6ffa57c49ce22f07356d025162e4c0774d019f577d8
+    name: odh-workbench-jupyter-minimal-cpu-py312-v3-3
+    source:
+      git:
+        revision: 601928d3f91ddd82be56e310b92aed808aebef70
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9@sha256:d622c96993c85401e9c234b9c32926a17479ddce01d6fba94c1170bc3d9ec3b2
+    name: odh-workbench-jupyter-minimal-cuda-py312-v3-3
+    source:
+      git:
+        revision: 601928d3f91ddd82be56e310b92aed808aebef70
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9@sha256:e7f87a1d4d8ab645ecd634387247ba8eda2cad8bb60c6d262f6df8d797dde2f3
+    name: odh-workbench-jupyter-minimal-rocm-py312-v3-3
+    source:
+      git:
+        revision: 601928d3f91ddd82be56e310b92aed808aebef70
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9@sha256:4683f011b7130f490377d35fe98f6b12b83a64ef3dfb612e29d8dcf82f4504fc
+    name: odh-workbench-jupyter-pytorch-cuda-py312-v3-3
+    source:
+      git:
+        revision: 601928d3f91ddd82be56e310b92aed808aebef70
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9@sha256:9c9c570c71f4f4e1301539f3d27f7919d89c771e5d9cfb9f003ad86f9a179f0a
+    name: odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3
+    source:
+      git:
+        revision: 601928d3f91ddd82be56e310b92aed808aebef70
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9@sha256:2c0319fa594e1a31b130b67100566030d096287889f6a4602d541533837876db
+    name: odh-workbench-jupyter-pytorch-rocm-py312-v3-3
+    source:
+      git:
+        revision: 601928d3f91ddd82be56e310b92aed808aebef70
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9@sha256:17cc7cb77f57efbc745755d626a24d3dcc05a88656b6da5e7e7e04c4d65fd649
+    name: odh-workbench-jupyter-tensorflow-cuda-py312-v3-3
+    source:
+      git:
+        revision: 601928d3f91ddd82be56e310b92aed808aebef70
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9@sha256:597cd98291568b248f760c412a852d041654a05c760ab0196fb2ecd3e461fe22
+    name: odh-workbench-jupyter-tensorflow-rocm-py312-v3-3
+    source:
+      git:
+        revision: 601928d3f91ddd82be56e310b92aed808aebef70
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9@sha256:8336402efdae7dd7983a88cf769b3b80b6ad6d3709e682e49bc9d8b3e1ca0ff5
+    name: odh-workbench-jupyter-trustyai-cpu-py312-v3-3
+    source:
+      git:
+        revision: 601928d3f91ddd82be56e310b92aed808aebef70
+        url: https://github.com/red-hat-data-services/notebooks

--- a/release/3.3.5/stage/snapshot-fbc/snapshot-fbc-stage-ocp-419-rhoai-v3-3-1783108273.yaml
+++ b/release/3.3.5/stage/snapshot-fbc/snapshot-fbc-stage-ocp-419-rhoai-v3-3-1783108273.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-419-1783108273
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 9e62817cf9ed15b3d1ca6fa3dd393670e7a0fecd
+    konflux-release-data/ocp-version: ocp-419
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-419
+  components:
+    - name: rhoai-fbc-fragment-ocp-419
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:2a6ab7b5561f987bd0aed8e4dff70472cfd26708608654f7175066f65354c432
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: e1c7ed360034ad3ce0014667b03077b15c3fa397

--- a/release/3.3.5/stage/snapshot-fbc/snapshot-fbc-stage-ocp-420-rhoai-v3-3-1783108273.yaml
+++ b/release/3.3.5/stage/snapshot-fbc/snapshot-fbc-stage-ocp-420-rhoai-v3-3-1783108273.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-420-1783108273
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 9e62817cf9ed15b3d1ca6fa3dd393670e7a0fecd
+    konflux-release-data/ocp-version: ocp-420
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-420
+  components:
+    - name: rhoai-fbc-fragment-ocp-420
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:4bb3dee63352de9ee52df7dabd4d742e90182ad9309f08709659ca475c884d4f
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: e1c7ed360034ad3ce0014667b03077b15c3fa397

--- a/release/3.3.5/stage/snapshot-fbc/snapshot-fbc-stage-ocp-421-rhoai-v3-3-1783108273.yaml
+++ b/release/3.3.5/stage/snapshot-fbc/snapshot-fbc-stage-ocp-421-rhoai-v3-3-1783108273.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-421-1783108273
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 9e62817cf9ed15b3d1ca6fa3dd393670e7a0fecd
+    konflux-release-data/ocp-version: ocp-421
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-421
+  components:
+    - name: rhoai-fbc-fragment-ocp-421
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:657bda6d19a0b0b17f266537fd29aa8887f07997201397b27d77845ce054d5b1
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: e1c7ed360034ad3ce0014667b03077b15c3fa397


### PR DESCRIPTION
## Release Artifacts for RHOAI 3.3.5

### Artifact Sources
| Source | Details |
|--------|---------|
| **Prod artifacts** | Local: `prod-release-1783586527` (epoch: 1783586527) |
| **Stage components** | [GHA run 28671029253](https://github.com/red-hat-data-services/rhods-devops-infra/actions/runs/28671029253) (artifact: `stage-release-9e62817c`, epoch: 1783094273) |
| **Stage FBC** | [GHA run 28674909492](https://github.com/red-hat-data-services/rhods-devops-infra/actions/runs/28674909492) (artifact: `stage-release-9e62817c`, epoch: 1783108273) |

### File Summary (12 files, matching 3.3.4 structure)

**Prod (4 files):**
- `release-components/` — 1 file (components release CR)
- `release-fbc/` — 3 files (OCP 4.19, 4.20, 4.21)

**Stage (8 files):**
- `release-components/` — 1 file
- `snapshot-components/` — 1 file
- `release-fbc/` — 3 files (OCP 4.19, 4.20, 4.21)
- `snapshot-fbc/` — 3 files (OCP 4.19, 4.20, 4.21)

### Notes
- No charts artifacts (Helm charts not applicable for 3.3.x)
- Stage component GHA run (`push-to-stage` job) failed, but artifacts were uploaded successfully before failure
- Secret scan: clean