### PR TITLE
Make PCC cache commit atomic in process-fbc-fragment (rhoai-3.5)

### DIFF
--- a/.github/workflows/process-fbc-fragment.yaml
+++ b/.github/workflows/process-fbc-fragment.yaml
@@ -187,7 +187,15 @@ jobs:
           git config user.name "Openshift-AI DevOps"
           git config user.email "openshift-ai-devops@redhat.com"
           git add -A
-          git diff --staged --quiet || (git commit -m "Regeneratd the PCC Cache" && git push origin main)
+          # Atomic commit: only commit if PCC catalog files actually changed.
+          # If only shipped_rhoai_versions_granular.txt changed (index hasn't caught up),
+          # revert it so the next run retries regeneration.
+          if git diff --staged --name-only | grep -q "pcc/catalog-"; then
+            git commit -m "Regeneratd the PCC Cache" && git push origin main
+          else
+            echo "No PCC catalog files changed — index may not have caught up yet. Skipping commit to retry on next run."
+            git checkout -- .
+          fi
 
 
       - name: Process FBC Fragment

--- a/.github/workflows/process-fbc-fragment.yaml
+++ b/.github/workflows/process-fbc-fragment.yaml
@@ -194,7 +194,7 @@ jobs:
             git commit -m "Regeneratd the PCC Cache" && git push origin main
           else
             echo "No PCC catalog files changed — index may not have caught up yet. Skipping commit to retry on next run."
-            git checkout -- .
+            git checkout HEAD -- .
           fi
 
 

--- a/.github/workflows/process-fbc-fragment.yaml
+++ b/.github/workflows/process-fbc-fragment.yaml
@@ -191,7 +191,7 @@ jobs:
           # If only shipped_rhoai_versions_granular.txt changed (index hasn't caught up),
           # revert it so the next run retries regeneration.
           if git diff --staged --name-only | grep -q "pcc/catalog-"; then
-            git commit -m "Regeneratd the PCC Cache" && git push origin main
+            git commit -m "Regeneratd the PCC Cache" -m "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" && git push origin main
           else
             echo "No PCC catalog files changed — index may not have caught up yet. Skipping commit to retry on next run."
             git checkout HEAD -- .


### PR DESCRIPTION
## Summary
Only commit PCC cache when catalog files actually changed — not just the versions file.

## Root cause
When component images are published to `registry.redhat.io/rhoai/odh-operator-bundle` but `redhat-operator-index` hasn't caught up, the PCC check detects new tags and updates `shipped_rhoai_versions_granular.txt`, but `opm migrate` produces unchanged catalog files. The blind `git add -A` commits only the versions file, locking out all future regeneration attempts.

Triggered by: https://github.com/red-hat-data-services/RHOAI-Build-Config/actions/runs/29015583132 (rhoai-3.5 run that committed stale PCC during 3.3.5 prod push)
Evidence: https://github.com/red-hat-data-services/RHOAI-Build-Config/commit/aaab8d04c2a95ef4d378691b66ccfcb22c5a119d (only versions file committed, no catalogs)

## Fix
Check if any `pcc/catalog-*.yaml` files are staged before committing. If not, revert with `git checkout HEAD -- .` and skip — next run retries automatically until the index catches up.

## Local test results

Test 1: Only versions file changed (index stale)
  Staged: pcc/shipped_rhoai_versions_granular.txt
  Result: SKIP — reverted clean, 0 files changed after revert

Test 2: Both versions file and catalog files changed (index caught up)
  Staged: pcc/catalog-v4.19.yaml pcc/catalog-v4.20.yaml pcc/shipped_rhoai_versions_granular.txt
  Result: COMMIT — correct

Test 3: Nothing changed after clean revert
  Staged: (empty)
  Working tree: 0 files changed
  Result: Clean — correct

Note: Initial implementation used `git checkout -- .` which doesn't properly unstage after `git add -A` (checks out from index, not HEAD). Fixed to use `git checkout HEAD -- .`.

Fixes: RHOAIENG-74801