### PR TITLE
Make PCC cache commit atomic in stage promoter workflows (main)

### DIFF
--- a/.github/workflows/multi-push-to-stage.yaml
+++ b/.github/workflows/multi-push-to-stage.yaml
@@ -392,7 +392,15 @@ jobs:
           git config user.name "Openshift-AI DevOps"
           git config user.email "openshift-ai-devops@redhat.com"
           git add -A
-          git diff --staged --quiet || (git commit -m "Regeneratd the PCC Cache" && git push origin main)
+          # Atomic commit: only commit if PCC catalog files actually changed.
+          # If only shipped_rhoai_versions_granular.txt changed (index hasn't caught up),
+          # revert it so the next run retries regeneration.
+          if git diff --staged --name-only | grep -q "pcc/catalog-"; then
+            git commit -m "Regeneratd the PCC Cache" -m "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" && git push origin main
+          else
+            echo "No PCC catalog files changed — index may not have caught up yet. Skipping commit to retry on next run."
+            git checkout HEAD -- .
+          fi
 
       # ---------------------------------------------------------------
       # Core catalog patching — the heart of this workflow.

--- a/.github/workflows/push-to-stage.yaml
+++ b/.github/workflows/push-to-stage.yaml
@@ -237,7 +237,15 @@ jobs:
           git config user.name "Openshift-AI DevOps"
           git config user.email "openshift-ai-devops@redhat.com"
           git add -A
-          git diff --staged --quiet || (git commit -m "Regeneratd the PCC Cache" && git push origin main)
+          # Atomic commit: only commit if PCC catalog files actually changed.
+          # If only shipped_rhoai_versions_granular.txt changed (index hasn't caught up),
+          # revert it so the next run retries regeneration.
+          if git diff --staged --name-only | grep -q "pcc/catalog-"; then
+            git commit -m "Regeneratd the PCC Cache" -m "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" && git push origin main
+          else
+            echo "No PCC catalog files changed — index may not have caught up yet. Skipping commit to retry on next run."
+            git checkout HEAD -- .
+          fi
 
       - name: Push To Stage
         id: push-to-stage


### PR DESCRIPTION
## Summary
Apply the same atomic PCC commit fix to `push-to-stage.yaml` and `multi-push-to-stage.yaml` on main. Only commit when PCC catalog files actually changed — not just the versions file.

## Root cause
Same as the process-fbc-fragment fix (PRs #26087-#26092): when bundle images are published but `redhat-operator-index` hasn't caught up, `git add -A` commits only `shipped_rhoai_versions_granular.txt`, locking out future regeneration.

## Fix
Check if any `pcc/catalog-*.yaml` files are staged before committing. If not, revert with `git checkout HEAD -- .` and skip. Also adds workflow run URL to the commit message.

## Local test results

Test 1: Only versions file changed (index stale — stage promoter during prod push)
  Staged: pcc/shipped_rhoai_versions_granular.txt
  Result: SKIP — correct (next run retries)
  After revert: 0 dirty files

Test 2: Both versions + catalogs changed (index caught up)
  Staged: pcc/catalog-v4.19.yaml, pcc/catalog-v4.20.yaml, pcc/catalog-v4.21.yaml, pcc/shipped_rhoai_versions_granular.txt
  Result: COMMIT — correct

Test 3: Only some catalogs changed (partial index update)
  Staged: pcc/catalog-v4.19.yaml, pcc/shipped_rhoai_versions_granular.txt
  Result: COMMIT — correct (at least one catalog changed)

Test 4: PCC_CACHE_VALID=YES (no new versions)
  Result: Nothing staged — step skipped by 'if' condition — correct

Fixes: RHOAIENG-74801