### PR TITLE
Add missing related images to xks-values-patch.yaml

### DIFF
--- a/helm/xks-values-patch.yaml
+++ b/helm/xks-values-patch.yaml
@@ -15,9 +15,25 @@ rhaiOperator:
       value: "registry.redhat.io/rhaii/vllm-cuda-rhel9@sha256:d3e57d4ca13a17f4d5d1228df4fe47cfe1a9f630250a8b3d26f86d871fdb9e69"
     - name: RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE
       value: "registry.redhat.io/rhaii/vllm-rocm-rhel9@sha256:cfeac10c571206514c2876f220ce845058511185ebe8944afc32581dc45b34f3"
+    - name: RELATED_IMAGE_RHAII_VLLM_ROCM_FAST_1_IMAGE
+      value: "registry.redhat.io/rhaii/vllm-rocm-rhel9@sha256:cfeac10c571206514c2876f220ce845058511185ebe8944afc32581dc45b34f3"
+    - name: RELATED_IMAGE_RHAII_VLLM_ROCM_FAST_2_IMAGE
+      value: "registry.redhat.io/rhaii/vllm-rocm-rhel9@sha256:cfeac10c571206514c2876f220ce845058511185ebe8944afc32581dc45b34f3"
     - name: RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE
       value: "registry.redhat.io/rhaii/vllm-spyre-rhel9@sha256:5c0ed9be230a307d512fa99236b060ac2ecd86973d17c467badc7b5c2d2b5da4"
+    - name: RELATED_IMAGE_RHAII_VLLM_SPYRE_FAST_1_IMAGE
+      value: "registry.redhat.io/rhaii/vllm-spyre-rhel9@sha256:5c0ed9be230a307d512fa99236b060ac2ecd86973d17c467badc7b5c2d2b5da4"
+    - name: RELATED_IMAGE_RHAII_VLLM_SPYRE_FAST_2_IMAGE
+      value: "registry.redhat.io/rhaii/vllm-spyre-rhel9@sha256:5c0ed9be230a307d512fa99236b060ac2ecd86973d17c467badc7b5c2d2b5da4"
     - name: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE
+      value: "registry.redhat.io/rhaii/vllm-cpu-rhel9@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
+    - name: RELATED_IMAGE_RHAII_VLLM_CPU_FAST_1_IMAGE
+      value: "registry.redhat.io/rhaii/vllm-cpu-rhel9@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
+    - name: RELATED_IMAGE_RHAII_VLLM_CPU_FAST_2_IMAGE
+      value: "registry.redhat.io/rhaii/vllm-cpu-rhel9@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
+    - name: RELATED_IMAGE_ODH_VLLM_CPU_FAST_1_IMAGE
+      value: "registry.redhat.io/rhaii/vllm-cpu-rhel9@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
+    - name: RELATED_IMAGE_ODH_VLLM_CPU_FAST_2_IMAGE
       value: "registry.redhat.io/rhaii/vllm-cpu-rhel9@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
     - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
       value: "registry.redhat.io/rhaii/vllm-gaudi-rhel9@sha256:1adc51d99455d90f758d840cb3bb5747ed29585c1b0830c051f7fe5cca3471e6"
@@ -39,6 +55,22 @@ rhaiOperator:
       value: "registry.redhat.io/rhoai/odh-maas-controller-rhel9@sha256:82984a9cf7706cacd3b0beaaad85c9bfa7160e476f8194b4d7e35f07d5f88e6b"
     - name: RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE
       value: "registry.redhat.io/rhoai/odh-ai-gateway-payload-processing-rhel9@sha256:94525cd51d01fd407e3ac975463a992082fa7f57fb26ac640302df977baaa586"
+    - name: RELATED_IMAGE_ODH_KSERVE_MODULE_OPERATOR_IMAGE
+      value: "registry.redhat.io/rhoai/odh-kserve-module-operator-rhel9@sha256:aaaab9ae8e62083dbcebcf187d1867be131e19b1d57a2e61b90a298881663daa"
+    - name: RELATED_IMAGE_ODH_GUARDRAILS_DETECTOR_HUGGINGFACE_RUNTIME_IMAGE
+      value: "registry.redhat.io/rhoai/odh-guardrails-detector-huggingface-runtime-rhel9@sha256:1317e1552acfb0516936e9b2d9c8f0b224fd5cccdaf049568b84c9983069f6d6"
+    - name: RELATED_IMAGE_ODH_MLSERVER_IMAGE
+      value: "registry.redhat.io/rhoai/odh-mlserver-rhel9@sha256:532143a5b143f9c17bb03aaab55aa4d28ed69a5eac4e7e4c046f3c34d925f296"
+    - name: RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE
+      value: "registry.redhat.io/rhoai/odh-model-controller-rhel9@sha256:b11390e243c8fb6037587d2c7f16e44c0d7f7594874e6f73a8253a781ad3fb98"
+    - name: RELATED_IMAGE_ODH_MODEL_SERVING_API_IMAGE
+      value: "registry.redhat.io/rhoai/odh-model-serving-api-rhel9@sha256:a36977a666c06283fb80ceb77e0c75531dacfc01fdcfec4009b83532a86b2eb4"
+    - name: RELATED_IMAGE_ODH_OPENVINO_MODEL_SERVER_IMAGE
+      value: "registry.redhat.io/rhoai/odh-openvino-model-server-rhel9@sha256:2f2d5ad6b8367248bbf7731440086a24f5167f2da731b44767c2542d9b79c45f"
+    - name: RELATED_IMAGE_ODH_VLLM_CPU_IMAGE
+      value: "registry.redhat.io/rhoai/odh-vllm-cpu-rhel9@sha256:8b7f9b9593998f5beb09c724362a83fa430e68f6b91ae055f64eca6f0e45a0cc"
+    - name: RELATED_IMAGE_ODH_WORKLOAD_VARIANT_AUTOSCALER_CONTROLLER_IMAGE
+      value: "registry.redhat.io/rhoai/odh-workload-variant-autoscaler-controller-rhel9@sha256:33624b68e0cb13af907a5e688dc829b61ee5aad23b0ecc33185e78002c831938"
     - name: RELATED_IMAGE_POSTGRESQL_16_IMAGE
       value: "registry.redhat.io/rhel9/postgresql-16@sha256:cb66eb4b438ce3f9db194dd1948ce25dc4142e789025f214324b7baa3c915c05"
     - name: RELATED_IMAGE_UBI_MINIMAL_IMAGE


### PR DESCRIPTION
 Added missing related images to the RHAI Helm chart values.

  **vLLM FAST variants (8 images):**
  - RHAII_VLLM_ROCM_FAST_1/2_IMAGE
  - RHAII_VLLM_SPYRE_FAST_1/2_IMAGE
  - RHAII_VLLM_CPU_FAST_1/2_IMAGE
  - ODH_VLLM_CPU_FAST_1/2_IMAGE

  **OMC-blocked images (8 images):**
  - ODH_KSERVE_MODULE_OPERATOR_IMAGE
  - ODH_GUARDRAILS_DETECTOR_HUGGINGFACE_RUNTIME_IMAGE
  - ODH_MLSERVER_IMAGE
  - ODH_MODEL_CONTROLLER_IMAGE
  - ODH_MODEL_SERVING_API_IMAGE
  - ODH_OPENVINO_MODEL_SERVER_IMAGE
  - ODH_VLLM_CPU_IMAGE
  - ODH_WORKLOAD_VARIANT_AUTOSCALER_CONTROLLER_IMAGE

  FAST variants use the same image reference as their base.
  OMC images sourced from the bundle CSV (rhods-operator.clusterserviceversion.yaml).