### PR TITLE
Add missing CUDA and GAUDI FAST variant images to xks-values-patch.yaml

### DIFF
--- a/helm/xks-values-patch.yaml
+++ b/helm/xks-values-patch.yaml
@@ -13,6 +13,10 @@ rhaiOperator:
       value: "registry.redhat.io/rhoai/odh-kserve-storage-initializer-rhel9@sha256:02f4a4963a6f1d16b632988fcdd89ae386d1cd5a235f817a28f57027fd5aa06e"
     - name: RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE
       value: "registry.redhat.io/rhaii/vllm-cuda-rhel9@sha256:d3e57d4ca13a17f4d5d1228df4fe47cfe1a9f630250a8b3d26f86d871fdb9e69"
+    - name: RELATED_IMAGE_RHAII_VLLM_CUDA_FAST_1_IMAGE
+      value: "registry.redhat.io/rhaii/vllm-cuda-rhel9@sha256:d3e57d4ca13a17f4d5d1228df4fe47cfe1a9f630250a8b3d26f86d871fdb9e69"
+    - name: RELATED_IMAGE_RHAII_VLLM_CUDA_FAST_2_IMAGE
+      value: "registry.redhat.io/rhaii/vllm-cuda-rhel9@sha256:d3e57d4ca13a17f4d5d1228df4fe47cfe1a9f630250a8b3d26f86d871fdb9e69"
     - name: RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE
       value: "registry.redhat.io/rhaii/vllm-rocm-rhel9@sha256:cfeac10c571206514c2876f220ce845058511185ebe8944afc32581dc45b34f3"
     - name: RELATED_IMAGE_RHAII_VLLM_ROCM_FAST_1_IMAGE
@@ -36,6 +40,10 @@ rhaiOperator:
     - name: RELATED_IMAGE_ODH_VLLM_CPU_FAST_2_IMAGE
       value: "registry.redhat.io/rhaii/vllm-cpu-rhel9@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
     - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
+      value: "registry.redhat.io/rhaii/vllm-gaudi-rhel9@sha256:1adc51d99455d90f758d840cb3bb5747ed29585c1b0830c051f7fe5cca3471e6"
+    - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_FAST_1_IMAGE
+      value: "registry.redhat.io/rhaii/vllm-gaudi-rhel9@sha256:1adc51d99455d90f758d840cb3bb5747ed29585c1b0830c051f7fe5cca3471e6"
+    - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_FAST_2_IMAGE
       value: "registry.redhat.io/rhaii/vllm-gaudi-rhel9@sha256:1adc51d99455d90f758d840cb3bb5747ed29585c1b0830c051f7fe5cca3471e6"
     - name: RELATED_IMAGE_ODH_LLM_D_ROUTER_ENDPOINT_PICKER_IMAGE
       value: "registry.redhat.io/rhoai/odh-llm-d-router-endpoint-picker-rhel9@sha256:19ce9254b59225579ec63b1315a7f88d610edb134d4d4547342bc49dcbc2d1a0"


### PR DESCRIPTION
Missed some images for xks

FAST variants use the same sha256 digest as their base image:
- `RHAII_VLLM_CUDA_FAST_1_IMAGE` / `FAST_2` → same as `RHAII_VLLM_CUDA_IMAGE`
- `RHAII_VLLM_GAUDI_FAST_1_IMAGE` / `FAST_2` → same as `RHAII_VLLM_GAUDI_IMAGE`