### PR TITLE
Add release artifacts for RHOAI 2.25.9

### DIFF
--- a/release/2.25.9/stage/RC1/release-components/release-components-stage-rhoai-v2-25-1784040482.yaml
+++ b/release/2.25.9/stage/RC1/release-components/release-components-stage-rhoai-v2-25-1784040482.yaml
@@ -1,0 +1,16 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    appstudio.openshift.io/application: rhoai-v2-25
+    konflux-release-data/artifact-type: components
+    konflux-release-data/environment: stage
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+  name: rhoai-v2-25-stage-1784040482
+  namespace: rhoai-tenant
+spec:
+  data:
+    version: 2.25.9
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-components-stage
+  snapshot: rhoai-v2-25-1784040482

--- a/release/2.25.9/stage/RC1/release-fbc/release-fbc-stage-ocp-416-rhoai-v2-25-1784063275.yaml
+++ b/release/2.25.9/stage/RC1/release-fbc/release-fbc-stage-ocp-416-rhoai-v2-25-1784063275.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-416-stage-1784063275
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-416
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-416
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-416-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-416-1784063275
+  data:
+    version: 2.25.9

--- a/release/2.25.9/stage/RC1/release-fbc/release-fbc-stage-ocp-417-rhoai-v2-25-1784063275.yaml
+++ b/release/2.25.9/stage/RC1/release-fbc/release-fbc-stage-ocp-417-rhoai-v2-25-1784063275.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-417-stage-1784063275
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-417
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-417
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-417-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-417-1784063275
+  data:
+    version: 2.25.9

--- a/release/2.25.9/stage/RC1/release-fbc/release-fbc-stage-ocp-418-rhoai-v2-25-1784063275.yaml
+++ b/release/2.25.9/stage/RC1/release-fbc/release-fbc-stage-ocp-418-rhoai-v2-25-1784063275.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-418-stage-1784063275
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-418
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-418
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-418-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-418-1784063275
+  data:
+    version: 2.25.9

--- a/release/2.25.9/stage/RC1/release-fbc/release-fbc-stage-ocp-419-rhoai-v2-25-1784063275.yaml
+++ b/release/2.25.9/stage/RC1/release-fbc/release-fbc-stage-ocp-419-rhoai-v2-25-1784063275.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-419-stage-1784063275
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-419
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-419
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-419-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-419-1784063275
+  data:
+    version: 2.25.9

--- a/release/2.25.9/stage/RC1/release-fbc/release-fbc-stage-ocp-420-rhoai-v2-25-1784063275.yaml
+++ b/release/2.25.9/stage/RC1/release-fbc/release-fbc-stage-ocp-420-rhoai-v2-25-1784063275.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-420-stage-1784063275
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-420
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-420
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-420-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-420-1784063275
+  data:
+    version: 2.25.9

--- a/release/2.25.9/stage/RC1/release-fbc/release-fbc-stage-ocp-421-rhoai-v2-25-1784063275.yaml
+++ b/release/2.25.9/stage/RC1/release-fbc/release-fbc-stage-ocp-421-rhoai-v2-25-1784063275.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-421-stage-1784063275
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-421
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-421
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-421-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-421-1784063275
+  data:
+    version: 2.25.9

--- a/release/2.25.9/stage/RC1/release-fbc/release-fbc-stage-ocp-422-rhoai-v2-25-1784063275.yaml
+++ b/release/2.25.9/stage/RC1/release-fbc/release-fbc-stage-ocp-422-rhoai-v2-25-1784063275.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-422-stage-1784063275
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-422
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-422
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-422-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-422-1784063275
+  data:
+    version: 2.25.9

--- a/release/2.25.9/stage/RC1/snapshot-components/snapshot-components-stage-rhoai-v2-25-1784040482.yaml
+++ b/release/2.25.9/stage/RC1/snapshot-components/snapshot-components-stage-rhoai-v2-25-1784040482.yaml
@@ -1,0 +1,468 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  labels:
+    konflux-release-data/artifact-type: components
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    test.appstudio.openshift.io/type: override
+  name: rhoai-v2-25-1784040482
+  namespace: rhoai-tenant
+spec:
+  application: rhoai-v2-25
+  components:
+  - containerImage: quay.io/rhoai/odh-operator-bundle@sha256:fe898f9123f3a269ae4b0f76edf49d50effac87120dce699211f1d5eecd9518b
+    name: odh-operator-bundle-v2-25
+    source:
+      git:
+        revision: a5e8c6f2afd3421749ce4452ae490cfa5fbd3693
+        url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+  - containerImage: quay.io/rhoai/odh-built-in-detector-rhel9@sha256:c03787647f683cf1e04bc2d5a8a9105474ebc46eb8757c602fffa58d9e49f1d7
+    name: odh-built-in-detector-v2-25
+    source:
+      git:
+        revision: bbe01a3b9ea309bf25b9b71c56c326e3ce2821f2
+        url: https://github.com/red-hat-data-services/guardrails-detectors
+  - containerImage: quay.io/rhoai/odh-caikit-nlp-rhel9@sha256:dfb9e5d6acf3dce99b7570d0604d2fe7d2d647d918f09de7a33369af32a8726f
+    name: odh-caikit-nlp-v2-25
+    source:
+      git:
+        revision: 572b234b9b8926cd687669775c62adfe4d30470e
+        url: https://github.com/red-hat-data-services/caikit-nlp
+  - containerImage: quay.io/rhoai/odh-caikit-tgis-serving-rhel9@sha256:08a41370e02392eb1d89062140280317e6043a47a13979dd4510842750eca70b
+    name: odh-caikit-tgis-serving-v2-25
+    source:
+      git:
+        revision: 39e14ca94ba7906c4fdcb80421d89dc66f8b4776
+        url: https://github.com/red-hat-data-services/caikit-tgis-serving
+  - containerImage: quay.io/rhoai/odh-codeflare-operator-rhel9@sha256:f38beff3610a8dc5464fd3cbf91a62ab8736a7793858e367d5c986f3e2d83f96
+    name: odh-codeflare-operator-v2-25
+    source:
+      git:
+        revision: 9c5b04acb5cae8687adb77f69e89e2f8e3559bcf
+        url: https://github.com/red-hat-data-services/codeflare-operator
+  - containerImage: quay.io/rhoai/odh-dashboard-rhel9@sha256:7a643b274b907e18705dc7cf19983311771bda7d53d360591f028370f10a511a
+    name: odh-dashboard-v2-25
+    source:
+      git:
+        revision: fd5507343e0b9f1b6bd9a47aab47ded9fccd6359
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-data-science-pipelines-argo-argoexec-rhel9@sha256:ceceee936bdfb089f1afa20515477fd0f415c588801d45d04ead3cce57a329bb
+    name: odh-data-science-pipelines-argo-argoexec-v2-25
+    source:
+      git:
+        revision: b932691b3676dbdc58cae41bfa8dc2c5c517b2aa
+        url: https://github.com/red-hat-data-services/argo-workflows
+  - containerImage: quay.io/rhoai/odh-data-science-pipelines-argo-workflowcontroller-rhel9@sha256:f2532671eabf9382993126019e7c87cc4703d4ba4a8e4503c7cc3a4d1cb12f3f
+    name: odh-data-science-pipelines-argo-workflowcontroller-v2-25
+    source:
+      git:
+        revision: b932691b3676dbdc58cae41bfa8dc2c5c517b2aa
+        url: https://github.com/red-hat-data-services/argo-workflows
+  - containerImage: quay.io/rhoai/odh-data-science-pipelines-operator-controller-rhel9@sha256:57743b92edc0a8ab16f59a97c7d9266acd8cdd68bce63f7657f01e858c0aa221
+    name: odh-data-science-pipelines-operator-controller-v2-25
+    source:
+      git:
+        revision: 0e74804a791a5899b00a30811ba26cecd5100718
+        url: https://github.com/red-hat-data-services/data-science-pipelines-operator
+  - containerImage: quay.io/rhoai/odh-feast-operator-rhel9@sha256:2a27f093171b891d6507f1e03a681360f27cdb0eb141987867e234a5c677ef24
+    name: odh-feast-operator-v2-25
+    source:
+      git:
+        revision: b07bc33a5b738cc28571dec47f3fa76e44a07629
+        url: https://github.com/red-hat-data-services/feast
+  - containerImage: quay.io/rhoai/odh-feature-server-rhel9@sha256:293ca62dec57324ed18e2e3105e29e54735c6482bfc5fad27298a2baca338dcd
+    name: odh-feature-server-v2-25
+    source:
+      git:
+        revision: b07bc33a5b738cc28571dec47f3fa76e44a07629
+        url: https://github.com/red-hat-data-services/feast
+  - containerImage: quay.io/rhoai/odh-fms-guardrails-orchestrator-rhel9@sha256:d75053946c42feac1e3677e2a12975394dcc19679475fb071e19fb1178b64875
+    name: odh-fms-guardrails-orchestrator-v2-25
+    source:
+      git:
+        revision: 95ee3161b793247bee72d5cfdbe0779f781975ca
+        url: https://github.com/red-hat-data-services/fms-guardrails-orchestrator
+  - containerImage: quay.io/rhoai/odh-guardrails-detector-huggingface-runtime-rhel9@sha256:e4caac38c7f60bcad32d49b02aa3651a3ccc96a9e4753d6b54d3fade89bb99be
+    name: odh-guardrails-detector-huggingface-runtime-v2-25
+    source:
+      git:
+        revision: bbe01a3b9ea309bf25b9b71c56c326e3ce2821f2
+        url: https://github.com/red-hat-data-services/guardrails-detectors
+  - containerImage: quay.io/rhoai/odh-kf-notebook-controller-rhel9@sha256:5a13040716990ed1015b717370f86ffec4d7de79e00c7911335b253edc3d970e
+    name: odh-kf-notebook-controller-v2-25
+    source:
+      git:
+        revision: 62664a98e55cd0be59375c5dbead2f665e67a45c
+        url: https://github.com/red-hat-data-services/kubeflow
+  - containerImage: quay.io/rhoai/odh-kserve-agent-rhel9@sha256:8f42dc7fefa505643418db2bde6243394060512aeb8e0bf9a68a38b702eabed7
+    name: odh-kserve-agent-v2-25
+    source:
+      git:
+        revision: 66f46c729bb91aa6d0a7c8afcf660b9875e4eccc
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kserve-controller-rhel9@sha256:95e109824068e08dd6ffcd46c67805714168b2ea08a821f0772c3e9dcf9a8af6
+    name: odh-kserve-controller-v2-25
+    source:
+      git:
+        revision: 66f46c729bb91aa6d0a7c8afcf660b9875e4eccc
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kserve-router-rhel9@sha256:eedd49aa7d6376f931e53bf84db6e542418631fe906bf23f57fd38b854851945
+    name: odh-kserve-router-v2-25
+    source:
+      git:
+        revision: 66f46c729bb91aa6d0a7c8afcf660b9875e4eccc
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kserve-storage-initializer-rhel9@sha256:59686a8b1bef4a855a957bde572f70cfbaff6bab5e0fa0f6e40038888789f3a5
+    name: odh-kserve-storage-initializer-v2-25
+    source:
+      git:
+        revision: 66f46c729bb91aa6d0a7c8afcf660b9875e4eccc
+        url: https://github.com/red-hat-data-services/kserve
+  - containerImage: quay.io/rhoai/odh-kuberay-operator-controller-rhel9@sha256:bd377fab82677bd2cec49c22782b53c18aa11182d3652eb89a1bebf5e97b37de
+    name: odh-kuberay-operator-controller-v2-25
+    source:
+      git:
+        revision: 3b889e25da53d6d38cb644ff95918340ac8f9c52
+        url: https://github.com/red-hat-data-services/kuberay
+  - containerImage: quay.io/rhoai/odh-kueue-controller-rhel9@sha256:28d7cc2f1179794e3a10dd5f53ab3e68cdce0115636aefd0a7e33d596d00ceb1
+    name: odh-kueue-controller-v2-25
+    source:
+      git:
+        revision: dc65d380662f0e696af713122a2e5d75705cbf03
+        url: https://github.com/red-hat-data-services/kueue
+  - containerImage: quay.io/rhoai/odh-llama-stack-core-rhel9@sha256:b04831d8e5999c9d0c32b8c10ac9e1fd1e39f4df6caa2ac00333b9cc6c1b0c40
+    name: odh-llama-stack-core-v2-25
+    source:
+      git:
+        revision: 87ec1bdd899e68c817d638071abb8b2fb45d09ad
+        url: https://gitlab.com/redhat/rhel-ai/llama-stack/containers
+  - containerImage: quay.io/rhoai/odh-llama-stack-k8s-operator-rhel9@sha256:c07a64780e25b3c311633342606b98a24b03fd7a455dde21c2ab88344add88f0
+    name: odh-llama-stack-k8s-operator-v2-25
+    source:
+      git:
+        revision: 5feccfd490b98c5ce35fabaefd1b8994b659a71f
+        url: https://github.com/red-hat-data-services/ogx-k8s-operator
+  - containerImage: quay.io/rhoai/odh-llm-d-inference-scheduler-rhel9@sha256:7163053fd1eac1e4d2f18e361cb3c2bfd81a77c5b79830d42445c697c3210dcf
+    name: odh-llm-d-inference-scheduler-v2-25
+    source:
+      git:
+        revision: 4e5d31b89615ce5a9b9692711b8e8bb1b32d1460
+        url: https://github.com/red-hat-data-services/llm-d-inference-scheduler
+  - containerImage: quay.io/rhoai/odh-llm-d-routing-sidecar-rhel9@sha256:d810a7244e18ec31a317df5536c901d33abb381a1c3a009342570507d1574b0b
+    name: odh-llm-d-routing-sidecar-v2-25
+    source:
+      git:
+        revision: 9e8ab668345fb684d8d53f56d03a8d4a2804ba79
+        url: https://github.com/red-hat-data-services/llm-d-routing-sidecar
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-api-server-v2-rhel9@sha256:f0d15542abcaef0a202d272edb3871bb201d756bdf8bd31099ace85ed65e32fb
+    name: odh-ml-pipelines-api-server-v2-v2-25
+    source:
+      git:
+        revision: fea733d18b3d16934765fb22fd84b1208bf36254
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-driver-rhel9@sha256:0537ea050f6cd63fd026429ed071f5db0576ecaf4f9b1f7d4edc2f389e77eb48
+    name: odh-ml-pipelines-driver-v2-25
+    source:
+      git:
+        revision: fea733d18b3d16934765fb22fd84b1208bf36254
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-launcher-rhel9@sha256:c66b45210ca502967eccada8709e2f0439316df9f370bb76a18822700c0d6f29
+    name: odh-ml-pipelines-launcher-v2-25
+    source:
+      git:
+        revision: fea733d18b3d16934765fb22fd84b1208bf36254
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-persistenceagent-v2-rhel9@sha256:2a212d97847071dc5e80f6b577a669b1a2e0249e04fb9dedcbf638b540ca29bc
+    name: odh-ml-pipelines-persistenceagent-v2-v2-25
+    source:
+      git:
+        revision: fea733d18b3d16934765fb22fd84b1208bf36254
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-runtime-generic-rhel9@sha256:6dfead87dd92f9b037967f192199008b35b0437e7f5e95b6493480d6be90c41b
+    name: odh-ml-pipelines-runtime-generic-v2-25
+    source:
+      git:
+        revision: e65fb9870c3324edd3a5b3ae9003ffa5f948338c
+        url: https://github.com/red-hat-data-services/ilab-on-ocp
+  - containerImage: quay.io/rhoai/odh-ml-pipelines-scheduledworkflow-v2-rhel9@sha256:8004bea9275f5f61dfd17722c23fbd6b0022fe88438b7d82bf14d83694770786
+    name: odh-ml-pipelines-scheduledworkflow-v2-v2-25
+    source:
+      git:
+        revision: fea733d18b3d16934765fb22fd84b1208bf36254
+        url: https://github.com/red-hat-data-services/data-science-pipelines
+  - containerImage: quay.io/rhoai/odh-mlmd-grpc-server-rhel9@sha256:f5198b20888fe26a99ef6faeea86a92f38b0cb66859744a4383bfc56c84317df
+    name: odh-mlmd-grpc-server-v2-25
+    source:
+      git:
+        revision: 3d6bc2718ca937caa16813bd1b128b3bbbfcc9ae
+        url: https://github.com/red-hat-data-services/ml-metadata
+  - containerImage: quay.io/rhoai/odh-mm-rest-proxy-rhel9@sha256:eb8a3adcf429e848e4cc202f0b95990fbe837fa2e6173e648b3cc825c338931e
+    name: odh-mm-rest-proxy-v2-25
+    source:
+      git:
+        revision: d0357aaef2fbb79ec5f75174dcfb9ab1c63c9b53
+        url: https://github.com/red-hat-data-services/rest-proxy
+  - containerImage: quay.io/rhoai/odh-mod-arch-model-registry-rhel9@sha256:47dd76c6e854460774b49d53dd5c60b84b5488fa47b939b744fde370d646ecb6
+    name: odh-mod-arch-model-registry-v2-25
+    source:
+      git:
+        revision: fd5507343e0b9f1b6bd9a47aab47ded9fccd6359
+        url: https://github.com/red-hat-data-services/odh-dashboard
+  - containerImage: quay.io/rhoai/odh-model-controller-rhel9@sha256:9f71e13abab3d581689046c37b0756a14706ceee36107153e57cc660082a59d5
+    name: odh-model-controller-v2-25
+    source:
+      git:
+        revision: 47c81b305b0c395c53ce74964fb32e760afd5cc4
+        url: https://github.com/red-hat-data-services/odh-model-controller
+  - containerImage: quay.io/rhoai/odh-model-metadata-collection-rhel9@sha256:0cfd730530fc06542f255ce68d5cadff16fcc4627442d3cf3dd9ad34270cdb34
+    name: odh-model-metadata-collection-v2-25
+    source:
+      git:
+        revision: af7479c3d38bb5ee1e344d11e76d760aad9079f2
+        url: https://github.com/red-hat-data-services/model-metadata-collection
+  - containerImage: quay.io/rhoai/odh-model-registry-job-async-upload-rhel9@sha256:596f75ca60ee8215d6459a936f2f0d5a87661c9e743204ea7af7fb4ef6456f76
+    name: odh-model-registry-job-async-upload-v2-25
+    source:
+      git:
+        revision: 1cf16ad388e0a1056e6b0fddac8a906203cb6852
+        url: https://github.com/red-hat-data-services/model-registry
+  - containerImage: quay.io/rhoai/odh-model-registry-operator-rhel9@sha256:1e75adfa4b776076550a8b07acb04c1133e416400f9d3e30b5f63ebb3514c9a0
+    name: odh-model-registry-operator-v2-25
+    source:
+      git:
+        revision: a6e74b36eb6919d47f4ff2b039d792caba14e936
+        url: https://github.com/red-hat-data-services/model-registry-operator
+  - containerImage: quay.io/rhoai/odh-model-registry-rhel9@sha256:49f321c1a977930d6a8c8346bfc25f226a6937d3ec1b1d32e18ab959461ce946
+    name: odh-model-registry-v2-25
+    source:
+      git:
+        revision: 66e947b84f23285bd417c30847213824435b6ee3
+        url: https://github.com/red-hat-data-services/model-registry
+  - containerImage: quay.io/rhoai/odh-modelmesh-rhel9@sha256:3e499ee92e1a2ebdcf2c66533444e4057d1ea6c256e45f0564692aebd351f3ad
+    name: odh-modelmesh-v2-25
+    source:
+      git:
+        revision: 7b8ab742f97fec03fb7ba9ddd549385e7a299e41
+        url: https://github.com/red-hat-data-services/modelmesh
+  - containerImage: quay.io/rhoai/odh-modelmesh-runtime-adapter-rhel9@sha256:fcd70a625dda1305bd7cfba529c836c134d05dee3bf508f1b42bf29f7dc99109
+    name: odh-modelmesh-runtime-adapter-v2-25
+    source:
+      git:
+        revision: dfb69dc5414940366e199455598a3c21f61dbb67
+        url: https://github.com/red-hat-data-services/modelmesh-runtime-adapter
+  - containerImage: quay.io/rhoai/odh-modelmesh-serving-controller-rhel9@sha256:7d6649385414514d35660d05953c1435b704f1d1eab7312b7e6aa08f4adc7757
+    name: odh-modelmesh-serving-controller-v2-25
+    source:
+      git:
+        revision: c732d18aa84426021493de0bf3038832c12c8cab
+        url: https://github.com/red-hat-data-services/modelmesh-serving
+  - containerImage: quay.io/rhoai/odh-must-gather-rhel9@sha256:4f570856d50a84fe1d25fdcfbc30688b8d22b9f61056c83f6b0dfedcb73d3212
+    name: odh-must-gather-v2-25
+    source:
+      git:
+        revision: 573dc67177788677a272d881f58460688526fe9a
+        url: https://github.com/red-hat-data-services/must-gather
+  - containerImage: quay.io/rhoai/odh-notebook-controller-rhel9@sha256:b09e1677fc199e5ea12e2ab46a797cab73ff341589683529f7ece264d9379210
+    name: odh-notebook-controller-v2-25
+    source:
+      git:
+        revision: 62664a98e55cd0be59375c5dbead2f665e67a45c
+        url: https://github.com/red-hat-data-services/kubeflow
+  - containerImage: quay.io/rhoai/odh-openvino-model-server-rhel9@sha256:c35501369e6f43bae20a3cda8885b331e2aca23259f85a47963adfa5ec1dd88c
+    name: odh-openvino-model-server-v2-25
+    source:
+      git:
+        revision: 64b9e4df52a13fb2c69a6b5848169fccd787ff71
+        url: https://github.com/red-hat-data-services/openvino_model_server
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-datascience-cpu-py312-rhel9@sha256:4c2ddde2ad9b5bf5b3459e21d44ff12d8d640171010705b0f24a4e166cfaff37
+    name: odh-pipeline-runtime-datascience-cpu-py312-v2-25
+    source:
+      git:
+        revision: d30e9530e1a1e0ee218e4089e48288023f47ea96
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-minimal-cpu-py312-rhel9@sha256:134c394d8d7d4d0d62054c2843a5e7ef68ce84638af4417ec1e773ad09c1c651
+    name: odh-pipeline-runtime-minimal-cpu-py312-v2-25
+    source:
+      git:
+        revision: d30e9530e1a1e0ee218e4089e48288023f47ea96
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-pytorch-cuda-py312-rhel9@sha256:7995cba564bbf469a9472a18a965846f47992052b2468a08d103c8a35f18c63a
+    name: odh-pipeline-runtime-pytorch-cuda-py312-v2-25
+    source:
+      git:
+        revision: 78619bf311ad07d30abf32fcc544eefdb7edecba
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9@sha256:b35d39172be1228a3cee63de2446f99bced55601b11afc0919eb0cfe52c5e850
+    name: odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v2-25
+    source:
+      git:
+        revision: 08f4fe374e340279312bbbc8f9e85fa86c2233d3
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9@sha256:d05a38ad52c5e2dee120241b63163e40bc768fd05329628b54a7157368c5b24c
+    name: odh-pipeline-runtime-pytorch-rocm-py312-v2-25
+    source:
+      git:
+        revision: ab66e21dae12fc0f219785caba3e9091387f566e
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9@sha256:5fbd11be592021a8252d6c62d4544265586d53d52f28e14d290e8cc7f90ac2c9
+    name: odh-pipeline-runtime-tensorflow-cuda-py312-v2-25
+    source:
+      git:
+        revision: 78619bf311ad07d30abf32fcc544eefdb7edecba
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9@sha256:a7cfdbd071fd029cd0febfdb2ccee668e3d78517ee5aa0e631d66e0ee353cf49
+    name: odh-pipeline-runtime-tensorflow-rocm-py312-v2-25
+    source:
+      git:
+        revision: ab66e21dae12fc0f219785caba3e9091387f566e
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-rhel9-operator@sha256:7823f8d08db32ae9dba9ab9b2024a353084ee8dd6e6fb560502bbd7bd5feaa73
+    name: odh-operator-v2-25
+    source:
+      git:
+        revision: 1d68e6f4e4931268171a09c831f2d31e2a93baef
+        url: https://github.com/red-hat-data-services/rhods-operator
+  - containerImage: quay.io/rhoai/odh-ta-lmes-driver-rhel9@sha256:4e65a73fdaee2b64439055a8b8773eef5433fb9eb62997ca0b90bbef069ff089
+    name: odh-ta-lmes-driver-v2-25
+    source:
+      git:
+        revision: 88514dc01cedd3593060010f7f2f056022692924
+        url: https://github.com/red-hat-data-services/trustyai-service-operator
+  - containerImage: quay.io/rhoai/odh-ta-lmes-job-rhel9@sha256:ef1425918b3d64bcfbc3383e67944b3f2abb94e7eb8ffe413be85c04c2ef0db6
+    name: odh-ta-lmes-job-v2-25
+    source:
+      git:
+        revision: 573b0c4216db513c9fd558bb42b0a53988af6857
+        url: https://github.com/red-hat-data-services/lm-evaluation-harness
+  - containerImage: quay.io/rhoai/odh-training-cuda121-torch24-py311-rhel9@sha256:a26cc307ad4a500c7506ab46c72509dad2665f59222e5ff96f3b29346cf28c62
+    name: odh-training-cuda121-torch24-py311-v2-25
+    source:
+      git:
+        revision: db30887e8abc64a4e09a9996f872a31f6e0d6892
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-cuda124-torch25-py311-rhel9@sha256:d867cac76f4679e30c9a7490b54369410772836f0b7c733aa6f15be12e3a5ce0
+    name: odh-training-cuda124-torch25-py311-v2-25
+    source:
+      git:
+        revision: db30887e8abc64a4e09a9996f872a31f6e0d6892
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-operator-rhel9@sha256:acd56f78c232a5c40cefc8580881c3b14811c023a59593c2eba13f26404658d9
+    name: odh-training-operator-v2-25
+    source:
+      git:
+        revision: 8645079aefbe25ded28be2d59a9407ba2e3d4c2b
+        url: https://github.com/red-hat-data-services/training-operator
+  - containerImage: quay.io/rhoai/odh-training-rocm62-torch24-py311-rhel9@sha256:b017080351880616c38f618432476d717c837e2bce402a429a8c4d754c396239
+    name: odh-training-rocm62-torch24-py311-v2-25
+    source:
+      git:
+        revision: db30887e8abc64a4e09a9996f872a31f6e0d6892
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-training-rocm62-torch25-py311-rhel9@sha256:ee438595be05c7631e322a21ccda7a77450cf5267c1b9d02f27f529fc761522e
+    name: odh-training-rocm62-torch25-py311-v2-25
+    source:
+      git:
+        revision: db30887e8abc64a4e09a9996f872a31f6e0d6892
+        url: https://github.com/red-hat-data-services/distributed-workloads
+  - containerImage: quay.io/rhoai/odh-trustyai-service-operator-rhel9@sha256:5ba0baa3e9b23c56d9468edd704ec9b92be3bae0164a62524acdb539584d40ec
+    name: odh-trustyai-service-operator-v2-25
+    source:
+      git:
+        revision: 88514dc01cedd3593060010f7f2f056022692924
+        url: https://github.com/red-hat-data-services/trustyai-service-operator
+  - containerImage: quay.io/rhoai/odh-trustyai-service-rhel9@sha256:7f2a6d7cdfc2c3cc393fac5af6144c3fef831318ad0bbb0bda8e0e46b6d11737
+    name: odh-trustyai-service-v2-25
+    source:
+      git:
+        revision: f33fc2dd07514c630b61a24923008c34edced2b0
+        url: https://github.com/red-hat-data-services/trustyai-explainability
+  - containerImage: quay.io/rhoai/odh-trustyai-vllm-orchestrator-gateway-rhel9@sha256:6456ac570c805f162e2673ce2b088b0c539090c8e3ab163956d10ae9e6cdbc98
+    name: odh-trustyai-vllm-orchestrator-gateway-v2-25
+    source:
+      git:
+        revision: 5ca499f7e225d50043b97089175609622da52846
+        url: https://github.com/red-hat-data-services/vllm-orchestrator-gateway
+  - containerImage: quay.io/rhoai/odh-vllm-cpu-rhel9@sha256:b0b97126e3079dabbdd3e72d6d431657059298de2d955ad1ffaa38791d3ba56d
+    name: odh-vllm-cpu-v2-25
+    source:
+      git:
+        revision: 39c96753a087248dcd367373b65159531efcdaf8
+        url: https://github.com/red-hat-data-services/vllm-cpu
+  - containerImage: quay.io/rhoai/odh-vllm-cuda-rhel9@sha256:ca0bf2704b8d6ad958ce2e91a469e01a86a42c837eded349d369123ed6b7c349
+    name: odh-vllm-cuda-v2-25
+    source:
+      git:
+        revision: 10a618a122b99aec9d519059e00fd99bbe438ea6
+        url: https://github.com/red-hat-data-services/vllm
+  - containerImage: quay.io/rhoai/odh-vllm-gaudi-rhel9@sha256:a1967439e6c1329cfc526873619099eb32199862dd428f8109ac432d270b3aaa
+    name: odh-vllm-gaudi-v2-25
+    source:
+      git:
+        revision: 1dc53a0cb469ca8c4da9018d8722a0420ee8ec6f
+        url: https://github.com/red-hat-data-services/vllm-gaudi
+  - containerImage: quay.io/rhoai/odh-vllm-rocm-rhel9@sha256:439de0978bb3f9410d4a8eefa9c4f76dc4c2b17a306028ac0d5f13fadc1dac62
+    name: odh-vllm-rocm-v2-25
+    source:
+      git:
+        revision: d5d166dba152346026695abf8595310ccbe2f04c
+        url: https://github.com/red-hat-data-services/vllm-rocm
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9@sha256:8d2c5801735f97b2d39e3de6600bd6c18b2bf635441e0769594ae3736f3061b2
+    name: odh-workbench-jupyter-datascience-cpu-py312-v2-25
+    source:
+      git:
+        revision: d30e9530e1a1e0ee218e4089e48288023f47ea96
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9@sha256:a9cb5703fd143037b61b7e2c8ab7dfdb4ceb069588b702b4fd9953a20a7f601b
+    name: odh-workbench-jupyter-minimal-cpu-py312-v2-25
+    source:
+      git:
+        revision: d30e9530e1a1e0ee218e4089e48288023f47ea96
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9@sha256:1233d26472b49ae0e42885d58a22b3e6c4bc5098c49192ebbe9def0744a610b1
+    name: odh-workbench-jupyter-minimal-cuda-py312-v2-25
+    source:
+      git:
+        revision: ab66e21dae12fc0f219785caba3e9091387f566e
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9@sha256:3471581c98a00c0a85ba8cda5c6f35811e1b39a2a9241536245765516cb3fb63
+    name: odh-workbench-jupyter-minimal-rocm-py312-v2-25
+    source:
+      git:
+        revision: ab66e21dae12fc0f219785caba3e9091387f566e
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9@sha256:1bce5fd6e273ca1bf982b3b7a1bf6b4a0fcf4958b5266a4fa16849eadefe3f4b
+    name: odh-workbench-jupyter-pytorch-cuda-py312-v2-25
+    source:
+      git:
+        revision: 78619bf311ad07d30abf32fcc544eefdb7edecba
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9@sha256:8093ad07e76e356814677d3aaf55eb3350e3f93edb6db99ab274c6dad973e4e0
+    name: odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v2-25
+    source:
+      git:
+        revision: 08f4fe374e340279312bbbc8f9e85fa86c2233d3
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9@sha256:4b95321bff8dab46e6d4f5f42d3b93bc2e98bf87f847d51107a4621677eb19f7
+    name: odh-workbench-jupyter-pytorch-rocm-py312-v2-25
+    source:
+      git:
+        revision: ab66e21dae12fc0f219785caba3e9091387f566e
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9@sha256:3974c17d94505f5c9cbb6c6d8b19a8739f2435353cb4d62e0c2cb65fdd93b2eb
+    name: odh-workbench-jupyter-tensorflow-cuda-py312-v2-25
+    source:
+      git:
+        revision: 78619bf311ad07d30abf32fcc544eefdb7edecba
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9@sha256:0f51a6611303e703e451fbf3e896eb9772fe20fee978c4a0a66cd9ad72dc3a11
+    name: odh-workbench-jupyter-tensorflow-rocm-py312-v2-25
+    source:
+      git:
+        revision: ab66e21dae12fc0f219785caba3e9091387f566e
+        url: https://github.com/red-hat-data-services/notebooks
+  - containerImage: quay.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9@sha256:ed4c322ba13b48a80825cd15454874d14b5c50dcd9661960e676e9474b8bd433
+    name: odh-workbench-jupyter-trustyai-cpu-py312-v2-25
+    source:
+      git:
+        revision: 78619bf311ad07d30abf32fcc544eefdb7edecba
+        url: https://github.com/red-hat-data-services/notebooks

--- a/release/2.25.9/stage/RC1/snapshot-fbc/snapshot-fbc-stage-ocp-416-rhoai-v2-25-1784063275.yaml
+++ b/release/2.25.9/stage/RC1/snapshot-fbc/snapshot-fbc-stage-ocp-416-rhoai-v2-25-1784063275.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-416-1784063275
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-416
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-416
+  components:
+    - name: rhoai-fbc-fragment-ocp-416
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:28a5a70c477a6fe0dc5333a56849ddbd16c0b3388c453f7338678acda3219162
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: b9f86dc5ee8d2c4e4a146593ac54336531889f9a

--- a/release/2.25.9/stage/RC1/snapshot-fbc/snapshot-fbc-stage-ocp-417-rhoai-v2-25-1784063275.yaml
+++ b/release/2.25.9/stage/RC1/snapshot-fbc/snapshot-fbc-stage-ocp-417-rhoai-v2-25-1784063275.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-417-1784063275
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-417
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-417
+  components:
+    - name: rhoai-fbc-fragment-ocp-417
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:cdf5f3b1ac5c69770c39efaa126f72c883bd0da688f3c7d9b81a6c97704d4d9b
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: b9f86dc5ee8d2c4e4a146593ac54336531889f9a

--- a/release/2.25.9/stage/RC1/snapshot-fbc/snapshot-fbc-stage-ocp-418-rhoai-v2-25-1784063275.yaml
+++ b/release/2.25.9/stage/RC1/snapshot-fbc/snapshot-fbc-stage-ocp-418-rhoai-v2-25-1784063275.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-418-1784063275
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-418
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-418
+  components:
+    - name: rhoai-fbc-fragment-ocp-418
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:01e8928c5bcee8944a933dbc2faede797f86f27b7046e20bd925741a11deaf7e
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: b9f86dc5ee8d2c4e4a146593ac54336531889f9a

--- a/release/2.25.9/stage/RC1/snapshot-fbc/snapshot-fbc-stage-ocp-419-rhoai-v2-25-1784063275.yaml
+++ b/release/2.25.9/stage/RC1/snapshot-fbc/snapshot-fbc-stage-ocp-419-rhoai-v2-25-1784063275.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-419-1784063275
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-419
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-419
+  components:
+    - name: rhoai-fbc-fragment-ocp-419
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:a708c3f7a0ed3d901a5b75032cfb359334cc57066311603cf06e842e4848f9f4
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: b9f86dc5ee8d2c4e4a146593ac54336531889f9a

--- a/release/2.25.9/stage/RC1/snapshot-fbc/snapshot-fbc-stage-ocp-420-rhoai-v2-25-1784063275.yaml
+++ b/release/2.25.9/stage/RC1/snapshot-fbc/snapshot-fbc-stage-ocp-420-rhoai-v2-25-1784063275.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-420-1784063275
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-420
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-420
+  components:
+    - name: rhoai-fbc-fragment-ocp-420
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:a8184624256cc8c105269dde5012507bcd5f36a96e91bb50d04a605f8a6b3474
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: b9f86dc5ee8d2c4e4a146593ac54336531889f9a

--- a/release/2.25.9/stage/RC1/snapshot-fbc/snapshot-fbc-stage-ocp-421-rhoai-v2-25-1784063275.yaml
+++ b/release/2.25.9/stage/RC1/snapshot-fbc/snapshot-fbc-stage-ocp-421-rhoai-v2-25-1784063275.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-421-1784063275
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-421
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-421
+  components:
+    - name: rhoai-fbc-fragment-ocp-421
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:5e898f9d1bf3193a3d0f976e04b018f67a9aa78d9826abb21314cd2bae9cadc8
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: b9f86dc5ee8d2c4e4a146593ac54336531889f9a

--- a/release/2.25.9/stage/RC1/snapshot-fbc/snapshot-fbc-stage-ocp-422-rhoai-v2-25-1784063275.yaml
+++ b/release/2.25.9/stage/RC1/snapshot-fbc/snapshot-fbc-stage-ocp-422-rhoai-v2-25-1784063275.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-422-1784063275
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-422
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-422
+  components:
+    - name: rhoai-fbc-fragment-ocp-422
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:d8f733d805a4de8bff96072c953d33927cf4ad8a29b0f868263df67adaf158af
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: b9f86dc5ee8d2c4e4a146593ac54336531889f9a


### PR DESCRIPTION
Stage release artifacts for RHOAI 2.25.9 including components and FBC snapshots/releases for OCP 4.16-4.22.

Stage components generated locally due to the need to exclude the odh-workbench-codeserver-datascience-cpu-py312 component which has not updated since 2.25.7 due to a failing build on ppc64le. The fix requires extra time, we had to proceed with the older version.

Push-to-stage job failed to monitor status of the launched pipelines saying they failed while they were just pending, not failing. They completed successfully eventually.