### PR TITLE
Add odh-mlserver-cuda to bundle relatedImages

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -220,6 +220,8 @@ ARG ODH_KSERVE_MODULE_OPERATOR_GIT_URL=
 ARG ODH_KSERVE_MODULE_OPERATOR_GIT_COMMIT=
 ARG ODH_FEAST_MODULE_OPERATOR_GIT_URL=
 ARG ODH_FEAST_MODULE_OPERATOR_GIT_COMMIT=
+ARG ODH_MLSERVER_CUDA_GIT_URL=
+ARG ODH_MLSERVER_CUDA_GIT_COMMIT=
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -451,7 +453,9 @@ LABEL \
       odh-kserve-module-operator.git.url="${ODH_KSERVE_MODULE_OPERATOR_GIT_URL}" \
       odh-kserve-module-operator.git.commit="${ODH_KSERVE_MODULE_OPERATOR_GIT_COMMIT}" \
       odh-feast-module-operator.git.url="${ODH_FEAST_MODULE_OPERATOR_GIT_URL}" \
-      odh-feast-module-operator.git.commit="${ODH_FEAST_MODULE_OPERATOR_GIT_COMMIT}"
+      odh-feast-module-operator.git.commit="${ODH_FEAST_MODULE_OPERATOR_GIT_COMMIT}" \
+      odh-mlserver-cuda.git.url="${ODH_MLSERVER_CUDA_GIT_URL}" \
+      odh-mlserver-cuda.git.commit="${ODH_MLSERVER_CUDA_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -243,6 +243,8 @@ patch:
       value: "quay.io/rhoai/odh-kserve-module-operator-rhel9@sha256:235a9d9471ae55ac4939c0c3cb82d79c8f5379387d936af5f773b2a16bb994ef"
     - name: RELATED_IMAGE_ODH_FEAST_MODULE_OPERATOR_IMAGE
       value: quay.io/rhoai/odh-feast-module-operator-rhel9@sha256:859467aba2e2c1f4b3971fe94f03476e0a2163bd975ac212f168da4d8a337be9
+    - name: RELATED_IMAGE_ODH_MLSERVER_CUDA_IMAGE
+      value: quay.io/rhoai/odh-mlserver-cuda-rhel9@sha256:40e74a1b44e0252ba3986fc01102dcff0e7f300c564cba0b04e4a3d0bc95df50
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -123,6 +123,7 @@ config:
         rhoai/odh-trainer-operator-rhel9: rhoai/odh-trainer-operator-rhel9
         rhoai/odh-kserve-module-operator-rhel9: rhoai/odh-kserve-module-operator-rhel9
         rhoai/odh-feast-module-operator-rhel9: rhoai/odh-feast-module-operator-rhel9
+        rhoai/odh-mlserver-cuda-rhel9: rhoai/odh-mlserver-cuda-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds relatedImages entry for 'odh-mlserver-cuda' to bundle/bundle-patch.yaml.

Image: quay.io/rhoai/odh-mlserver-cuda-rhel9@sha256:40e74a1b44e0252ba3986fc01102dcff0e7f300c564cba0b04e4a3d0bc95df50
Jira: https://redhat.atlassian.net/browse/RHOAIENG-76474