### PR TITLE
Skip PCC validation when index hasn't caught up (rhoai-2.25)

### DIFF
--- a/.github/workflows/process-fbc-fragment.yaml
+++ b/.github/workflows/process-fbc-fragment.yaml
@@ -163,22 +163,8 @@ jobs:
           done < <(yq e '.config.supported-ocp-versions[].version' ${CONFIG_PATH})
           
           ls -l main/pcc/
-      - name: Validate PCC Cache
-        id: validate-pcc-cache
-        if: ${{ steps.check-if-pcc-cache-valid.outputs.PCC_CACHE_VALID == 'NO' }}
-        env:
-          BRANCH: ${{ steps.get_branch.outputs.branch }}
-        run: |
-          #Declare basic variables
-          BUILD_CONFIG_PATH=main/config/config.yaml
-          SHIPPED_RHOAI_VERSIONS_PATH=main/pcc/shipped_rhoai_versions_granular.txt
-          PCC_FOLDER_PATH=main/pcc
-          GLOBAL_CONFIG_PATH=main/config/config.yaml
-          
-          #Validate PCC
-          python3 utils/utils/validators/catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ${GLOBAL_CONFIG_PATH}
-
       - name: Push latest PCC Cache
+        id: push-pcc-cache
         if: ${{ steps.check-if-pcc-cache-valid.outputs.PCC_CACHE_VALID == 'NO' }}
         working-directory: main
         run: |
@@ -190,11 +176,25 @@ jobs:
           # revert it so the next run retries regeneration.
           if git diff --staged --name-only | grep -q "pcc/catalog-"; then
             git commit -m "Regeneratd the PCC Cache" -m "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" && git push origin main
+            echo "pcc_committed=true" >> $GITHUB_OUTPUT
           else
             echo "No PCC catalog files changed — index may not have caught up yet. Skipping commit to retry on next run."
             git checkout HEAD -- .
+            echo "pcc_committed=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Validate PCC Cache
+        id: validate-pcc-cache
+        if: ${{ steps.push-pcc-cache.outputs.pcc_committed == 'true' }}
+        env:
+          BRANCH: ${{ steps.get_branch.outputs.branch }}
+        run: |
+          BUILD_CONFIG_PATH=main/config/config.yaml
+          SHIPPED_RHOAI_VERSIONS_PATH=main/pcc/shipped_rhoai_versions_granular.txt
+          PCC_FOLDER_PATH=main/pcc
+          GLOBAL_CONFIG_PATH=main/config/config.yaml
+
+          python3 utils/utils/validators/catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ${GLOBAL_CONFIG_PATH}
 
       - name: Process FBC Fragment
         env:


### PR DESCRIPTION
## Summary
Skip PCC validation when the operator index hasn't caught up with newly published bundle images, preventing the workflow from failing and blocking FBC fragment processing.

## Current flow (broken)
1. Check PCC valid → detect new bundle tags → PCC_CACHE_VALID=NO
2. Regenerate PCC → opm migrate (index stale → catalog files unchanged)
3. **Validate PCC → FAILS** (shipped version not in catalog) → workflow stops
4. Push PCC (never reached)
5. Process FBC Fragment (never reached — blocked by validation failure)

Example failure: https://github.com/red-hat-data-services/RHOAI-Build-Config/actions/runs/29423016696
`missing_bundles: catalog-v4.19..v4.22 → rhods-operator.3.5.0-ea.2`

## After fix
1. Check PCC valid → detect new bundle tags → PCC_CACHE_VALID=NO
2. Regenerate PCC → opm migrate (index stale → catalog files unchanged)
3. **Push PCC → SKIP** (no catalog files changed, sets pcc_committed=false)
4. **Validate PCC → SKIP** (only runs when pcc_committed=true)
5. **Process FBC Fragment → RUNS** (no longer blocked)

When the index catches up on a subsequent run:
3. Push PCC → COMMIT (catalog files changed, sets pcc_committed=true)
4. Validate PCC → RUNS (validates the updated PCC)
5. Process FBC Fragment → RUNS

## Local test results
- Scenario 1 (index stale): Push SKIP, Validate SKIP, FBC continues — correct
- Scenario 2 (index caught up): Push COMMIT, Validate RUNS — correct
- Scenario 3 (no new versions): Both skipped by PCC_CACHE_VALID=YES — correct
- Scenario 4 (stale → retry → caught up): Self-heals on next run — correct

Fixes: RHOAIENG-74801