### PR TITLE
Skip PCC validation when index hasn't caught up in stage promoter (main)

### DIFF
--- a/.github/workflows/multi-push-to-stage.yaml
+++ b/.github/workflows/multi-push-to-stage.yaml
@@ -367,25 +367,13 @@ jobs:
       # Ensures the cached catalogs are structurally valid before using
       # them as a base for patching.
       # ---------------------------------------------------------------
-      - name: Validate PCC Cache
-        id: validate-pcc-cache
-        if: ${{ steps.check-if-pcc-cache-valid.outputs.PCC_CACHE_VALID == 'NO' }}
-        run: |
-          #Declare basic variables
-          BUILD_CONFIG_PATH=main/config/config.yaml
-          SHIPPED_RHOAI_VERSIONS_PATH=main/pcc/shipped_rhoai_versions_granular.txt
-          PCC_FOLDER_PATH=main/pcc
-          GLOBAL_CONFIG_PATH=main/config/config.yaml
-
-          #Validate PCC
-          python3 utils/utils/validators/catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ${GLOBAL_CONFIG_PATH}
-
       # ---------------------------------------------------------------
       # If the PCC cache was regenerated, commit and push the updated
       # cache files (shipped_rhoai_versions_granular.txt, catalog YAMLs)
       # to the main branch so future runs can reuse them.
       # ---------------------------------------------------------------
       - name: Push latest PCC Cache
+        id: push-pcc-cache
         if: ${{ steps.check-if-pcc-cache-valid.outputs.PCC_CACHE_VALID == 'NO' }}
         working-directory: main
         run: |
@@ -397,10 +385,23 @@ jobs:
           # revert it so the next run retries regeneration.
           if git diff --staged --name-only | grep -q "pcc/catalog-"; then
             git commit -m "Regeneratd the PCC Cache" -m "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" && git push origin main
+            echo "pcc_committed=true" >> $GITHUB_OUTPUT
           else
             echo "No PCC catalog files changed — index may not have caught up yet. Skipping commit to retry on next run."
             git checkout HEAD -- .
+            echo "pcc_committed=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Validate PCC Cache
+        id: validate-pcc-cache
+        if: ${{ steps.push-pcc-cache.outputs.pcc_committed == 'true' }}
+        run: |
+          BUILD_CONFIG_PATH=main/config/config.yaml
+          SHIPPED_RHOAI_VERSIONS_PATH=main/pcc/shipped_rhoai_versions_granular.txt
+          PCC_FOLDER_PATH=main/pcc
+          GLOBAL_CONFIG_PATH=main/config/config.yaml
+
+          python3 utils/utils/validators/catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ${GLOBAL_CONFIG_PATH}
 
       # ---------------------------------------------------------------
       # Core catalog patching — the heart of this workflow.

--- a/.github/workflows/push-to-stage.yaml
+++ b/.github/workflows/push-to-stage.yaml
@@ -216,21 +216,8 @@ jobs:
           
           ls -l main/pcc/
 
-      - name: Validate PCC Cache
-        id: validate-pcc-cache
-        if: ${{ steps.check-if-pcc-cache-valid.outputs.PCC_CACHE_VALID == 'NO' }}
-        env:
-          BRANCH: ${{ github.event.inputs.release_branch }}
-        run: |
-          #Declare basic variables
-          BUILD_CONFIG_PATH=${BRANCH}/config/build-config.yaml
-          SHIPPED_RHOAI_VERSIONS_PATH=main/pcc/shipped_rhoai_versions.txt
-          PCC_FOLDER_PATH=main/pcc
-          
-          #Validate PCC
-          python3 utils/utils/validators/catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH}
-
       - name: Push latest PCC Cache
+        id: push-pcc-cache
         if: ${{ steps.check-if-pcc-cache-valid.outputs.PCC_CACHE_VALID == 'NO' }}
         working-directory: main
         run: |
@@ -242,10 +229,24 @@ jobs:
           # revert it so the next run retries regeneration.
           if git diff --staged --name-only | grep -q "pcc/catalog-"; then
             git commit -m "Regeneratd the PCC Cache" -m "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" && git push origin main
+            echo "pcc_committed=true" >> $GITHUB_OUTPUT
           else
             echo "No PCC catalog files changed — index may not have caught up yet. Skipping commit to retry on next run."
             git checkout HEAD -- .
+            echo "pcc_committed=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Validate PCC Cache
+        id: validate-pcc-cache
+        if: ${{ steps.push-pcc-cache.outputs.pcc_committed == 'true' }}
+        env:
+          BRANCH: ${{ github.event.inputs.release_branch }}
+        run: |
+          BUILD_CONFIG_PATH=${BRANCH}/config/build-config.yaml
+          SHIPPED_RHOAI_VERSIONS_PATH=main/pcc/shipped_rhoai_versions.txt
+          PCC_FOLDER_PATH=main/pcc
+
+          python3 utils/utils/validators/catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH}
 
       - name: Push To Stage
         id: push-to-stage


### PR DESCRIPTION
## Summary
Skip PCC validation when the operator index hasn't caught up in `push-to-stage.yaml` and `multi-push-to-stage.yaml`. Same fix as the process-fbc-fragment PRs (#26641-#26645).

## Current flow (broken)
1. Check PCC valid → detect new bundle tags → PCC_CACHE_VALID=NO
2. Regenerate PCC → opm migrate (index stale → catalog files unchanged)
3. **Validate PCC → FAILS** (shipped version not in catalog) → workflow stops
4. Push PCC (never reached)
5. Push To Stage (never reached — blocked by validation failure)

## After fix
1. Check PCC valid → detect new bundle tags → PCC_CACHE_VALID=NO
2. Regenerate PCC → opm migrate (index stale → catalog files unchanged)
3. **Push PCC → SKIP** (no catalog files changed, sets pcc_committed=false)
4. **Validate PCC → SKIP** (only runs when pcc_committed=true)
5. **Push To Stage → RUNS** (no longer blocked)

When the index catches up on a subsequent run, both commit and validation run normally.

## Local test results (from process-fbc-fragment PRs — same logic)
- Index stale: Push SKIP, Validate SKIP, workflow continues — correct
- Index caught up: Push COMMIT, Validate RUNS — correct
- No new versions: Both skipped by PCC_CACHE_VALID=YES — correct
- Stale → retry → caught up: Self-heals on next run — correct

Fixes: RHOAIENG-74801