### PR TITLE
update vllm images from RHAII 3.4.x to 3.5-EA2 [RHOAIENG-75982]

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -38,34 +38,34 @@ additionalImages:
     value: "registry.redhat.io/ubi9/nginx-126:latest@sha256:b440b533a01b21462b9acbc0e1f90f019fe0ed8741843318630f04c00ec89bcf"
   - name: RELATED_IMAGE_UBI_MINIMAL_IMAGE
     value: "registry.redhat.io/ubi9/ubi-minimal:9.7@sha256:907b68736aa798b2d38255b7aa070b2a70acb90803864a40f05d0ec47556ddd0"
-  # RHAII images are currently in stage registry, but will be promoted to production registry soon. Using stage registry for now to allow testing with the latest images. Once the images are promoted to production registry, the image references will be updated to use registry.redhat.io instead of registry.stage.redhat.io
+  # RHAII 3.5 EA2 images from registry.redhat.io/rhaii-early-access/. Will be updated to RHAII 3.5 GA images once available.
   - name: RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-cuda-rhel9:3.4.1-1780356914@sha256:5800e12b2a465f15961fcf34b645d79ed4f91ec9161eab22b1205d12682183c8"
+    value: "registry.redhat.io/rhaii-early-access/vllm-cuda-rhel9:3.5.0-ea.2@sha256:e95153e0bdce2b94d0470d4ac983d3c4b67576280afe99e97ce51700c57f3e5a"
   - name: RELATED_IMAGE_RHAII_VLLM_CUDA_FAST_1_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-cuda-rhel9:3.4.1-1780356914@sha256:5800e12b2a465f15961fcf34b645d79ed4f91ec9161eab22b1205d12682183c8"
+    value: "registry.redhat.io/rhaii-early-access/vllm-cuda-rhel9:3.5.0-ea.2@sha256:e95153e0bdce2b94d0470d4ac983d3c4b67576280afe99e97ce51700c57f3e5a"
   - name: RELATED_IMAGE_RHAII_VLLM_CUDA_FAST_2_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-cuda-rhel9:3.4.1-1780356914@sha256:5800e12b2a465f15961fcf34b645d79ed4f91ec9161eab22b1205d12682183c8"
+    value: "registry.redhat.io/rhaii-early-access/vllm-cuda-rhel9:3.5.0-ea.2@sha256:e95153e0bdce2b94d0470d4ac983d3c4b67576280afe99e97ce51700c57f3e5a"
   - name: RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-rocm-rhel9:3.4.1-1780518446@sha256:df4d60e75188c4cab95795343bd0a8d65bda6ddd824056b3fed832886bcebb75"
+    value: "registry.redhat.io/rhaii-early-access/vllm-rocm-rhel9:3.5.0-ea.2@sha256:7f338d908f857b9a0ccdf21049eb1828482ce9e604b379338b6d295270fd0af6"
   - name: RELATED_IMAGE_RHAII_VLLM_ROCM_FAST_1_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-rocm-rhel9:3.4.1-1780518446@sha256:df4d60e75188c4cab95795343bd0a8d65bda6ddd824056b3fed832886bcebb75"
+    value: "registry.redhat.io/rhaii-early-access/vllm-rocm-rhel9:3.5.0-ea.2@sha256:7f338d908f857b9a0ccdf21049eb1828482ce9e604b379338b6d295270fd0af6"
   - name: RELATED_IMAGE_RHAII_VLLM_ROCM_FAST_2_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-rocm-rhel9:3.4.1-1780518446@sha256:df4d60e75188c4cab95795343bd0a8d65bda6ddd824056b3fed832886bcebb75"
+    value: "registry.redhat.io/rhaii-early-access/vllm-rocm-rhel9:3.5.0-ea.2@sha256:7f338d908f857b9a0ccdf21049eb1828482ce9e604b379338b6d295270fd0af6"
   - name: RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-spyre-rhel9:3.4.1-1780356904@sha256:67443bfcb75942db728bc5317321efb658dc262017e00c4f7b770715648a991b"
+    value: "registry.redhat.io/rhaii-early-access/vllm-spyre-rhel9:3.5.0-ea.2@sha256:585049d89542655047aabd2d634d316199a831b7426fb6a19b80dca5ed1a63f5"
   - name: RELATED_IMAGE_RHAII_VLLM_SPYRE_FAST_1_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-spyre-rhel9:3.4.1-1780356904@sha256:67443bfcb75942db728bc5317321efb658dc262017e00c4f7b770715648a991b"
+    value: "registry.redhat.io/rhaii-early-access/vllm-spyre-rhel9:3.5.0-ea.2@sha256:585049d89542655047aabd2d634d316199a831b7426fb6a19b80dca5ed1a63f5"
   - name: RELATED_IMAGE_RHAII_VLLM_SPYRE_FAST_2_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-spyre-rhel9:3.4.1-1780356904@sha256:67443bfcb75942db728bc5317321efb658dc262017e00c4f7b770715648a991b"
+    value: "registry.redhat.io/rhaii-early-access/vllm-spyre-rhel9:3.5.0-ea.2@sha256:585049d89542655047aabd2d634d316199a831b7426fb6a19b80dca5ed1a63f5"
   - name: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-cpu-rhel9:3.4.1-1780356811@sha256:0ec0f5ff9a5ff263f58db0cfb19e3d7eef24b94c2d8629fe5145f5a8747e28c9"
+    value: "registry.redhat.io/rhaii-early-access/vllm-cpu-rhel9:3.5.0-ea.2@sha256:f7d3636e1bafd71bdf1f4a8b6818d9e00b7c64516ed4e732e942514a60ecd680"
   - name: RELATED_IMAGE_RHAII_VLLM_CPU_FAST_1_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-cpu-rhel9:3.4.1-1780356811@sha256:0ec0f5ff9a5ff263f58db0cfb19e3d7eef24b94c2d8629fe5145f5a8747e28c9"
+    value: "registry.redhat.io/rhaii-early-access/vllm-cpu-rhel9:3.5.0-ea.2@sha256:f7d3636e1bafd71bdf1f4a8b6818d9e00b7c64516ed4e732e942514a60ecd680"
   - name: RELATED_IMAGE_RHAII_VLLM_CPU_FAST_2_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-cpu-rhel9:3.4.1-1780356811@sha256:0ec0f5ff9a5ff263f58db0cfb19e3d7eef24b94c2d8629fe5145f5a8747e28c9"
+    value: "registry.redhat.io/rhaii-early-access/vllm-cpu-rhel9:3.5.0-ea.2@sha256:f7d3636e1bafd71bdf1f4a8b6818d9e00b7c64516ed4e732e942514a60ecd680"
   - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-gaudi-rhel9:3.4.0-1777444681@sha256:71008b2151586551ec0969ffc5b175f726ed6f6bebee29cdc289549e216609bc"
+    value: "registry.redhat.io/rhaii-early-access/vllm-gaudi-rhel9:3.5.0-ea.2@sha256:bb49786e915fe9789ffec6d953827fee90ef30bf9accce3db135ed4a0a26a35d"
   - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_FAST_1_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-gaudi-rhel9:3.4.0-1777444681@sha256:71008b2151586551ec0969ffc5b175f726ed6f6bebee29cdc289549e216609bc"
+    value: "registry.redhat.io/rhaii-early-access/vllm-gaudi-rhel9:3.5.0-ea.2@sha256:bb49786e915fe9789ffec6d953827fee90ef30bf9accce3db135ed4a0a26a35d"
   - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_FAST_2_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-gaudi-rhel9:3.4.0-1777444681@sha256:71008b2151586551ec0969ffc5b175f726ed6f6bebee29cdc289549e216609bc"
+    value: "registry.redhat.io/rhaii-early-access/vllm-gaudi-rhel9:3.5.0-ea.2@sha256:bb49786e915fe9789ffec6d953827fee90ef30bf9accce3db135ed4a0a26a35d"


### PR DESCRIPTION
Updates all 15 RHAII vLLM image references from 3.4.x to 3.5-EA2. Fixes https://redhat.atlassian.net/browse/RHOAIENG-75982.

- Registry: registry.stage.redhat.io/rhaii/ → registry.redhat.io/rhaii-early-access/
- Images: CUDA, ROCm, Gaudi, Spyre, CPU (base + FAST_1 + FAST_2)
- Interim fix until RHAII 3.5 GA images are available