### PR TITLE
Add skip-bundles for 3.5.0-ea.2 on all OCP versions

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -15,12 +15,14 @@ config:
         - rhods-operator.3.4.0-ea.1
         - rhods-operator.3.4.0-ea.2
         - rhods-operator.3.5.0-ea.1
+        - rhods-operator.3.5.0-ea.2
     - version: v4.20
       onboarded-since: rhods-operator.2.25.0
       skip-bundles:
         - rhods-operator.3.4.0-ea.1
         - rhods-operator.3.4.0-ea.2
         - rhods-operator.3.5.0-ea.1
+        - rhods-operator.3.5.0-ea.2
     - version: v4.21
       onboarded-since: rhods-operator.2.25.0
       skip-bundles:
@@ -28,6 +30,7 @@ config:
         - rhods-operator.3.4.0-ea.1
         - rhods-operator.3.4.0-ea.2
         - rhods-operator.3.5.0-ea.1
+        - rhods-operator.3.5.0-ea.2
     - version: v4.22
       onboarded-since: rhods-operator.2.25.0
       skip-bundles:
@@ -35,3 +38,4 @@ config:
         - rhods-operator.3.4.0-ea.1
         - rhods-operator.3.4.0-ea.2
         - rhods-operator.3.5.0-ea.1
+        - rhods-operator.3.5.0-ea.2


### PR DESCRIPTION
## Summary
Adds `rhods-operator.3.5.0-ea.2` to `skip-bundles` for v4.19-v4.22 in `config/config.yaml`.

## Problem
process-fbc-fragment on rhoai-3.4 and rhoai-3.3 fails at "Validate Catalogs":
```
missing_bundles: v4.19-v4.22 → rhods-operator.3.5.0-ea.2
```
Failing runs:
- https://github.com/red-hat-data-services/RHOAI-Build-Config/actions/runs/29478579356 (rhoai-3.4)
- https://github.com/red-hat-data-services/RHOAI-Build-Config/actions/runs/29479933816 (rhoai-3.3)

The PCC was correctly regenerated with 3.5.0-ea.2 (operator index caught up), but the "Validate Catalogs" step expects this EA bundle in ALL branch output catalogs. Older branches don't include it — same pattern as existing skip-bundles for 3.4.0-ea.1, 3.4.0-ea.2, 3.5.0-ea.1.

## Test plan
- [ ] Verify rhoai-3.4 and rhoai-3.3 process-fbc-fragment runs pass after merge