### PR TITLE
Add release artifacts for RHOAI 2.25.9 Stage RC2

### DIFF
--- a/release/2.25.9/stage/RC2/release-fbc/release-fbc-stage-ocp-416-rhoai-v2-25-1784218219.yaml
+++ b/release/2.25.9/stage/RC2/release-fbc/release-fbc-stage-ocp-416-rhoai-v2-25-1784218219.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-416-stage-1784218219
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-416
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-416
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-416-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-416-1784218219
+  data:
+    version: 2.25.9

--- a/release/2.25.9/stage/RC2/release-fbc/release-fbc-stage-ocp-417-rhoai-v2-25-1784218219.yaml
+++ b/release/2.25.9/stage/RC2/release-fbc/release-fbc-stage-ocp-417-rhoai-v2-25-1784218219.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-417-stage-1784218219
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-417
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-417
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-417-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-417-1784218219
+  data:
+    version: 2.25.9

--- a/release/2.25.9/stage/RC2/release-fbc/release-fbc-stage-ocp-418-rhoai-v2-25-1784218219.yaml
+++ b/release/2.25.9/stage/RC2/release-fbc/release-fbc-stage-ocp-418-rhoai-v2-25-1784218219.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-418-stage-1784218219
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-418
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-418
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-418-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-418-1784218219
+  data:
+    version: 2.25.9

--- a/release/2.25.9/stage/RC2/release-fbc/release-fbc-stage-ocp-419-rhoai-v2-25-1784218219.yaml
+++ b/release/2.25.9/stage/RC2/release-fbc/release-fbc-stage-ocp-419-rhoai-v2-25-1784218219.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-419-stage-1784218219
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-419
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-419
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-419-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-419-1784218219
+  data:
+    version: 2.25.9

--- a/release/2.25.9/stage/RC2/release-fbc/release-fbc-stage-ocp-420-rhoai-v2-25-1784218219.yaml
+++ b/release/2.25.9/stage/RC2/release-fbc/release-fbc-stage-ocp-420-rhoai-v2-25-1784218219.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-420-stage-1784218219
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-420
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-420
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-420-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-420-1784218219
+  data:
+    version: 2.25.9

--- a/release/2.25.9/stage/RC2/release-fbc/release-fbc-stage-ocp-421-rhoai-v2-25-1784218219.yaml
+++ b/release/2.25.9/stage/RC2/release-fbc/release-fbc-stage-ocp-421-rhoai-v2-25-1784218219.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-421-stage-1784218219
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-421
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-421
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-421-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-421-1784218219
+  data:
+    version: 2.25.9

--- a/release/2.25.9/stage/RC2/release-fbc/release-fbc-stage-ocp-422-rhoai-v2-25-1784218219.yaml
+++ b/release/2.25.9/stage/RC2/release-fbc/release-fbc-stage-ocp-422-rhoai-v2-25-1784218219.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: rhoai-fbc-fragment-ocp-422-stage-1784218219
+  namespace: rhoai-tenant
+  labels:
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-422
+    konflux-release-data/artifact-type: fbc
+    konflux-release-data/environment: stage
+    appstudio.openshift.io/application: rhoai-fbc-fragment-ocp-422
+spec:
+  gracePeriodDays: 30
+  releasePlan: rhoai-onprem-v2-25-ocp-422-fbc-stage
+  snapshot: rhoai-fbc-fragment-ocp-422-1784218219
+  data:
+    version: 2.25.9

--- a/release/2.25.9/stage/RC2/snapshot-fbc/snapshot-fbc-stage-ocp-416-rhoai-v2-25-1784218219.yaml
+++ b/release/2.25.9/stage/RC2/snapshot-fbc/snapshot-fbc-stage-ocp-416-rhoai-v2-25-1784218219.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-416-1784218219
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-416
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-416
+  components:
+    - name: rhoai-fbc-fragment-ocp-416
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:6d649aa93cd6afc8b2fc345032a362fa4ef330d629a576ccaa0d500b376b342b
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: 552401a092380a5dae77328bcfb7f197b4b4cb59

--- a/release/2.25.9/stage/RC2/snapshot-fbc/snapshot-fbc-stage-ocp-417-rhoai-v2-25-1784218219.yaml
+++ b/release/2.25.9/stage/RC2/snapshot-fbc/snapshot-fbc-stage-ocp-417-rhoai-v2-25-1784218219.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-417-1784218219
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-417
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-417
+  components:
+    - name: rhoai-fbc-fragment-ocp-417
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:3e5f11b7827a387c450eaa00ec831146519426139a685d93b6920f838da57940
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: 552401a092380a5dae77328bcfb7f197b4b4cb59

--- a/release/2.25.9/stage/RC2/snapshot-fbc/snapshot-fbc-stage-ocp-418-rhoai-v2-25-1784218219.yaml
+++ b/release/2.25.9/stage/RC2/snapshot-fbc/snapshot-fbc-stage-ocp-418-rhoai-v2-25-1784218219.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-418-1784218219
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-418
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-418
+  components:
+    - name: rhoai-fbc-fragment-ocp-418
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:9a3e3a4a999681d9cf50f9b5f02de55e6b26a52a5b92a4025f42310ee616e5fb
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: 552401a092380a5dae77328bcfb7f197b4b4cb59

--- a/release/2.25.9/stage/RC2/snapshot-fbc/snapshot-fbc-stage-ocp-419-rhoai-v2-25-1784218219.yaml
+++ b/release/2.25.9/stage/RC2/snapshot-fbc/snapshot-fbc-stage-ocp-419-rhoai-v2-25-1784218219.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-419-1784218219
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-419
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-419
+  components:
+    - name: rhoai-fbc-fragment-ocp-419
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:0bb6c64b5b4f6cb9687e6c1068aeaf17d5ac5c5902aa95fc4dd8a560e45076bf
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: 552401a092380a5dae77328bcfb7f197b4b4cb59

--- a/release/2.25.9/stage/RC2/snapshot-fbc/snapshot-fbc-stage-ocp-420-rhoai-v2-25-1784218219.yaml
+++ b/release/2.25.9/stage/RC2/snapshot-fbc/snapshot-fbc-stage-ocp-420-rhoai-v2-25-1784218219.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-420-1784218219
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-420
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-420
+  components:
+    - name: rhoai-fbc-fragment-ocp-420
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:5aeda2791eaf7d9e03bc496e12529a58b8ff34b9666748a923beebcec2512d3a
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: 552401a092380a5dae77328bcfb7f197b4b4cb59

--- a/release/2.25.9/stage/RC2/snapshot-fbc/snapshot-fbc-stage-ocp-421-rhoai-v2-25-1784218219.yaml
+++ b/release/2.25.9/stage/RC2/snapshot-fbc/snapshot-fbc-stage-ocp-421-rhoai-v2-25-1784218219.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-421-1784218219
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-421
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-421
+  components:
+    - name: rhoai-fbc-fragment-ocp-421
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:2b715738a70decefc147f6ced324149c4394e7c9e737393acf66f2275e84b1c3
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: 552401a092380a5dae77328bcfb7f197b4b4cb59

--- a/release/2.25.9/stage/RC2/snapshot-fbc/snapshot-fbc-stage-ocp-422-rhoai-v2-25-1784218219.yaml
+++ b/release/2.25.9/stage/RC2/snapshot-fbc/snapshot-fbc-stage-ocp-422-rhoai-v2-25-1784218219.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: rhoai-fbc-fragment-ocp-422-1784218219
+  namespace: rhoai-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+    konflux-release-data/rbc-release-commit: 281b2b5fe490f515448fb0a29d33811811222d62
+    konflux-release-data/ocp-version: ocp-422
+    konflux-release-data/artifact-type: fbc
+spec:
+  application: rhoai-fbc-fragment-ocp-422
+  components:
+    - name: rhoai-fbc-fragment-ocp-422
+      containerImage: quay.io/rhoai/rhoai-fbc-fragment@sha256:73913bdfdc4aa754b61b8e4ffc3a9b21810ab91fa55932cc093713d2de4fa44b
+      source:
+        git:
+          url: https://github.com/red-hat-data-services/RHOAI-Build-Config
+          revision: 552401a092380a5dae77328bcfb7f197b4b4cb59


### PR DESCRIPTION
All the components are the same as in RC1, only FBC were updated to include the new 3.5.ea.2 release.