### PR TITLE
fix: add latency predictor images to xks-values-patch

### DIFF
--- a/helm/xks-values-patch.yaml
+++ b/helm/xks-values-patch.yaml
@@ -11,6 +11,10 @@ rhaiOperator:
       value: "registry.redhat.io/rhoai/odh-kserve-router-rhel9@sha256:8e081b78afd3dab540bb8921d88e5e9f5a2437223c7a2a0cb869e78451894746"
     - name: RELATED_IMAGE_ODH_KSERVE_STORAGE_INITIALIZER_IMAGE
       value: "registry.redhat.io/rhoai/odh-kserve-storage-initializer-rhel9@sha256:8811fc48a03f11824375fc84d5bb62bef678464a67ad0f7611d32eb3217e81ee"
+    - name: RELATED_IMAGE_ODH_LATENCY_PREDICTOR_PREDICTION_IMAGE
+      value: "quay.io/rhoai/odh-latency-predictor-prediction-rhel9@sha256:76345428d15d0dadeb277e20f413f1a07e62a3b5c25e0ae1df30e5def437f366"
+    - name: RELATED_IMAGE_ODH_LATENCY_PREDICTOR_TRAINING_IMAGE
+      value: "quay.io/rhoai/odh-latency-predictor-training-rhel9@sha256:b7af8428538be549f49969d906352175999c2f442b6d36fee127cb7a60511977"
     - name: RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE
       value: "registry.redhat.io/rhaii-early-access/vllm-cuda-rhel9@sha256:e95153e0bdce2b94d0470d4ac983d3c4b67576280afe99e97ce51700c57f3e5a"
     - name: RELATED_IMAGE_RHAII_VLLM_CUDA_FAST_1_IMAGE


### PR DESCRIPTION
## Summary
- Add `RELATED_IMAGE_ODH_LATENCY_PREDICTOR_PREDICTION_IMAGE` and `RELATED_IMAGE_ODH_LATENCY_PREDICTOR_TRAINING_IMAGE` to `helm/xks-values-patch.yaml`
- These images were onboarded via Konflux (RHOAIENG-68941, RHOAIENG-68940) and added to `bundle-patch.yaml`, but were missed in the xKS Helm chart values patch


