### PR TITLE
RHOAIENG-78037: remove phantom ODH_VLLM_CPU_FAST env vars from XKS helm charts

### DIFF
--- a/helm/rhai-on-xks-chart/values.yaml
+++ b/helm/rhai-on-xks-chart/values.yaml
@@ -80,10 +80,6 @@ rhaiOperator:
       value: "registry.redhat.io/rhaii-early-access/vllm-cpu-rhel9@sha256:f7d3636e1bafd71bdf1f4a8b6818d9e00b7c64516ed4e732e942514a60ecd680"
     - name: RELATED_IMAGE_RHAII_VLLM_CPU_FAST_2_IMAGE
       value: "registry.redhat.io/rhaii-early-access/vllm-cpu-rhel9@sha256:f7d3636e1bafd71bdf1f4a8b6818d9e00b7c64516ed4e732e942514a60ecd680"
-    - name: RELATED_IMAGE_ODH_VLLM_CPU_FAST_1_IMAGE
-      value: "registry.redhat.io/rhaii/vllm-cpu-rhel9@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
-    - name: RELATED_IMAGE_ODH_VLLM_CPU_FAST_2_IMAGE
-      value: "registry.redhat.io/rhaii/vllm-cpu-rhel9@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
     - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
       value: "registry.redhat.io/rhaii-early-access/vllm-gaudi-rhel9@sha256:bb49786e915fe9789ffec6d953827fee90ef30bf9accce3db135ed4a0a26a35d"
     - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_FAST_1_IMAGE

--- a/helm/xks-values-patch.yaml
+++ b/helm/xks-values-patch.yaml
@@ -39,10 +39,6 @@ rhaiOperator:
       value: "registry.redhat.io/rhaii-early-access/vllm-cpu-rhel9@sha256:f7d3636e1bafd71bdf1f4a8b6818d9e00b7c64516ed4e732e942514a60ecd680"
     - name: RELATED_IMAGE_RHAII_VLLM_CPU_FAST_2_IMAGE
       value: "registry.redhat.io/rhaii-early-access/vllm-cpu-rhel9@sha256:f7d3636e1bafd71bdf1f4a8b6818d9e00b7c64516ed4e732e942514a60ecd680"
-    - name: RELATED_IMAGE_ODH_VLLM_CPU_FAST_1_IMAGE
-      value: "registry.redhat.io/rhaii/vllm-cpu-rhel9@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
-    - name: RELATED_IMAGE_ODH_VLLM_CPU_FAST_2_IMAGE
-      value: "registry.redhat.io/rhaii/vllm-cpu-rhel9@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
     - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
       value: "registry.redhat.io/rhaii-early-access/vllm-gaudi-rhel9@sha256:bb49786e915fe9789ffec6d953827fee90ef30bf9accce3db135ed4a0a26a35d"
     - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_FAST_1_IMAGE


### PR DESCRIPTION
## Summary
- Removes `RELATED_IMAGE_ODH_VLLM_CPU_FAST_1_IMAGE` and `RELATED_IMAGE_ODH_VLLM_CPU_FAST_2_IMAGE` from `helm/rhai-on-xks-chart/values.yaml` and `helm/xks-values-patch.yaml`
- These env vars do not exist in the operator CSV and have no corresponding images — they were added by mistake in [9d12918b29](https://github.com/red-hat-data-services/RHOAI-Build-Config/commit/9d12918b294fbfae8592a9d45b9b6ab0f44e1d26) when FAST variants were introduced for RHAII images

## Test plan
- [x] Verify the removed env vars are not referenced anywhere else in the repo
- [x] Confirm the operator CSV does not define `RELATED_IMAGE_ODH_VLLM_CPU_FAST_1_IMAGE` or `RELATED_IMAGE_ODH_VLLM_CPU_FAST_2_IMAGE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)