### PR TITLE
Remove odh-authbridge-proxy from bundle relatedImages (offboarding)

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -190,8 +190,6 @@ ARG ODH_LLM_D_BATCH_GATEWAY_OPERATOR_GIT_URL=
 ARG ODH_LLM_D_BATCH_GATEWAY_OPERATOR_GIT_COMMIT=
 ARG ODH_AI_GATEWAY_OPERATOR_GIT_URL=
 ARG ODH_AI_GATEWAY_OPERATOR_GIT_COMMIT=
-ARG ODH_AUTHBRIDGE_PROXY_GIT_URL=
-ARG ODH_AUTHBRIDGE_PROXY_GIT_COMMIT=
 ARG ODH_LLM_D_ASYNC_GIT_URL=
 ARG ODH_LLM_D_ASYNC_GIT_COMMIT=
 ARG ODH_LLM_D_ROUTER_ENDPOINT_PICKER_GIT_URL=
@@ -424,8 +422,6 @@ LABEL \
       odh-llm-d-batch-gateway-operator.git.commit="${ODH_LLM_D_BATCH_GATEWAY_OPERATOR_GIT_COMMIT}" \
       odh-ai-gateway-operator.git.url="${ODH_AI_GATEWAY_OPERATOR_GIT_URL}" \
       odh-ai-gateway-operator.git.commit="${ODH_AI_GATEWAY_OPERATOR_GIT_COMMIT}" \
-      odh-authbridge-proxy.git.url="${ODH_AUTHBRIDGE_PROXY_GIT_URL}" \
-      odh-authbridge-proxy.git.commit="${ODH_AUTHBRIDGE_PROXY_GIT_COMMIT}" \
       odh-llm-d-async.git.url="${ODH_LLM_D_ASYNC_GIT_URL}" \
       odh-llm-d-async.git.commit="${ODH_LLM_D_ASYNC_GIT_COMMIT}" \
       odh-llm-d-router-endpoint-picker.git.url="${ODH_LLM_D_ROUTER_ENDPOINT_PICKER_GIT_URL}" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -211,8 +211,6 @@ patch:
       value: "quay.io/rhoai/odh-llm-d-batch-gateway-operator-rhel9@sha256:9d75138ab2a901d80b813f59137127dac12d6bb97f7531e066956383de087ca9"
     - name: RELATED_IMAGE_ODH_AI_GATEWAY_OPERATOR_IMAGE
       value: "quay.io/rhoai/odh-ai-gateway-operator-rhel9@sha256:9005837b608155b2bac646bc9402394a977227d837393ec38de40cef06653243"
-    - name: RELATED_IMAGE_ODH_AUTHBRIDGE_PROXY_IMAGE
-      value: "quay.io/rhoai/odh-authbridge-proxy-rhel9@sha256:74a09104fc4a27b4e354ccbb81d0a2dfc4544f48f78622c76d2303f3b26ba8ba"
     - name: RELATED_IMAGE_ODH_LLM_D_ASYNC_IMAGE
       value: "quay.io/rhoai/odh-llm-d-async-rhel9@sha256:f426fcb2a860b0e082df80112a44ff1882fa625f7ec5a2bfa0826fde5cfd24b2"
     - name: RELATED_IMAGE_ODH_LLM_D_ROUTER_ENDPOINT_PICKER_IMAGE

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -113,7 +113,6 @@ config:
         rhoai/odh-llm-d-router-endpoint-picker-rhel9: rhoai/odh-llm-d-router-endpoint-picker-rhel9
         rhoai/odh-llm-d-router-disagg-sidecar-rhel9: rhoai/odh-llm-d-router-disagg-sidecar-rhel9
         rhoai/odh-ai-gateway-operator-rhel9: rhoai/odh-ai-gateway-operator-rhel9
-        rhoai/odh-authbridge-proxy-rhel9: rhoai/odh-authbridge-proxy-rhel9
         rhoai/odh-dashboard-operator-rhel9: rhoai/odh-dashboard-operator-rhel9
         rhoai/odh-mcp-lifecycle-module-operator-rhel9: rhoai/odh-mcp-lifecycle-module-operator-rhel9
         rhoai/odh-mcp-lifecycle-operator-rhel9: rhoai/odh-mcp-lifecycle-operator-rhel9


### PR DESCRIPTION
Removes relatedImages entry for 'odh-authbridge-proxy' from bundle/bundle-patch.yaml.

Jira: https://redhat.atlassian.net/browse/RHOAIENG-78358