### PR TITLE
Add odh-trustyai-service to bundle relatedImages

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -220,6 +220,8 @@ ARG ODH_FEAST_MODULE_OPERATOR_GIT_URL=
 ARG ODH_FEAST_MODULE_OPERATOR_GIT_COMMIT=
 ARG ODH_MLSERVER_CUDA_GIT_URL=
 ARG ODH_MLSERVER_CUDA_GIT_COMMIT=
+ARG ODH_TRUSTYAI_SERVICE_GIT_URL=
+ARG ODH_TRUSTYAI_SERVICE_GIT_COMMIT=
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -451,7 +453,9 @@ LABEL \
       odh-feast-module-operator.git.url="${ODH_FEAST_MODULE_OPERATOR_GIT_URL}" \
       odh-feast-module-operator.git.commit="${ODH_FEAST_MODULE_OPERATOR_GIT_COMMIT}" \
       odh-mlserver-cuda.git.url="${ODH_MLSERVER_CUDA_GIT_URL}" \
-      odh-mlserver-cuda.git.commit="${ODH_MLSERVER_CUDA_GIT_COMMIT}"
+      odh-mlserver-cuda.git.commit="${ODH_MLSERVER_CUDA_GIT_COMMIT}" \
+      odh-trustyai-service.git.url="${ODH_TRUSTYAI_SERVICE_GIT_URL}" \
+      odh-trustyai-service.git.commit="${ODH_TRUSTYAI_SERVICE_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -241,6 +241,8 @@ patch:
       value: quay.io/rhoai/odh-feast-module-operator-rhel9@sha256:859467aba2e2c1f4b3971fe94f03476e0a2163bd975ac212f168da4d8a337be9
     - name: RELATED_IMAGE_ODH_MLSERVER_CUDA_IMAGE
       value: quay.io/rhoai/odh-mlserver-cuda-rhel9@sha256:40e74a1b44e0252ba3986fc01102dcff0e7f300c564cba0b04e4a3d0bc95df50
+    - name: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE
+      value: quay.io/rhoai/odh-trustyai-service-rhel9@sha256:f4f91c346cc14c4fae366db7c54dfe25a4730f0caed47a2216b9fe3d51da0c4c
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:


### PR DESCRIPTION
Adds relatedImages entry for 'odh-trustyai-service' to bundle/bundle-patch.yaml.

Image: quay.io/rhoai/odh-trustyai-service-rhel9@sha256:f4f91c346cc14c4fae366db7c54dfe25a4730f0caed47a2216b9fe3d51da0c4c
Jira: https://redhat.atlassian.net/browse/RHOAIENG-78120