### PR TITLE
Remove odh-trainer-operator from bundle relatedImages (offboarding)

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -212,8 +212,6 @@ ARG ODH_WORKBENCHES_OPERATOR_GIT_URL=
 ARG ODH_WORKBENCHES_OPERATOR_GIT_COMMIT=
 ARG ODH_CORE_BFF_GIT_URL=
 ARG ODH_CORE_BFF_GIT_COMMIT=
-ARG ODH_TRAINER_OPERATOR_GIT_URL=
-ARG ODH_TRAINER_OPERATOR_GIT_COMMIT=
 ARG ODH_KSERVE_MODULE_OPERATOR_GIT_URL=
 ARG ODH_KSERVE_MODULE_OPERATOR_GIT_COMMIT=
 ARG ODH_FEAST_MODULE_OPERATOR_GIT_URL=
@@ -444,8 +442,6 @@ LABEL \
       odh-workbenches-operator.git.commit="${ODH_WORKBENCHES_OPERATOR_GIT_COMMIT}" \
       odh-core-bff.git.url="${ODH_CORE_BFF_GIT_URL}" \
       odh-core-bff.git.commit="${ODH_CORE_BFF_GIT_COMMIT}" \
-      odh-trainer-operator.git.url="${ODH_TRAINER_OPERATOR_GIT_URL}" \
-      odh-trainer-operator.git.commit="${ODH_TRAINER_OPERATOR_GIT_COMMIT}" \
       odh-kserve-module-operator.git.url="${ODH_KSERVE_MODULE_OPERATOR_GIT_URL}" \
       odh-kserve-module-operator.git.commit="${ODH_KSERVE_MODULE_OPERATOR_GIT_COMMIT}" \
       odh-feast-module-operator.git.url="${ODH_FEAST_MODULE_OPERATOR_GIT_URL}" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -233,8 +233,6 @@ patch:
       value: "quay.io/rhoai/odh-workbenches-operator-rhel9@sha256:dfd63251f5bbb6aef704ef2c75bbd44447d11a2b8eee7f0f38944c265f284640"
     - name: RELATED_IMAGE_ODH_CORE_BFF_IMAGE
       value: "quay.io/rhoai/odh-core-bff-rhel9@sha256:801fb44541cd4e026684e38638fdce518757dd6eca236f1ef48169f4f9a28cf4"
-    - name: RELATED_IMAGE_ODH_TRAINER_OPERATOR_IMAGE
-      value: "quay.io/rhoai/odh-trainer-operator-rhel9@sha256:7db9b5943acadba3804fbb652888be11de6785a4a2941c43d7f565affa51aeb9"
     - name: RELATED_IMAGE_ODH_KSERVE_MODULE_OPERATOR_IMAGE
       value: "quay.io/rhoai/odh-kserve-module-operator-rhel9@sha256:235a9d9471ae55ac4939c0c3cb82d79c8f5379387d936af5f773b2a16bb994ef"
     - name: RELATED_IMAGE_ODH_FEAST_MODULE_OPERATOR_IMAGE

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -118,7 +118,6 @@ config:
         rhoai/odh-mcp-lifecycle-operator-rhel9: rhoai/odh-mcp-lifecycle-operator-rhel9
         rhoai/odh-workbenches-operator-rhel9: rhoai/odh-workbenches-operator-rhel9
         rhoai/odh-core-bff-rhel9: rhoai/odh-core-bff-rhel9
-        rhoai/odh-trainer-operator-rhel9: rhoai/odh-trainer-operator-rhel9
         rhoai/odh-kserve-module-operator-rhel9: rhoai/odh-kserve-module-operator-rhel9
         rhoai/odh-feast-module-operator-rhel9: rhoai/odh-feast-module-operator-rhel9
         rhoai/odh-mlserver-cuda-rhel9: rhoai/odh-mlserver-cuda-rhel9


### PR DESCRIPTION
Removes relatedImages entry for 'odh-trainer-operator' from bundle/bundle-patch.yaml.

Jira: https://redhat.atlassian.net/browse/RHOAIENG-78576