### PR TITLE
Add odh-ogx-module-operator to bundle relatedImages

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -220,6 +220,8 @@ ARG ODH_MLSERVER_CUDA_GIT_URL=
 ARG ODH_MLSERVER_CUDA_GIT_COMMIT=
 ARG ODH_TRUSTYAI_SERVICE_GIT_URL=
 ARG ODH_TRUSTYAI_SERVICE_GIT_COMMIT=
+ARG ODH_OGX_MODULE_OPERATOR_GIT_URL=
+ARG ODH_OGX_MODULE_OPERATOR_GIT_COMMIT=
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -451,7 +453,9 @@ LABEL \
       odh-mlserver-cuda.git.url="${ODH_MLSERVER_CUDA_GIT_URL}" \
       odh-mlserver-cuda.git.commit="${ODH_MLSERVER_CUDA_GIT_COMMIT}" \
       odh-trustyai-service.git.url="${ODH_TRUSTYAI_SERVICE_GIT_URL}" \
-      odh-trustyai-service.git.commit="${ODH_TRUSTYAI_SERVICE_GIT_COMMIT}"
+      odh-trustyai-service.git.commit="${ODH_TRUSTYAI_SERVICE_GIT_COMMIT}" \
+      odh-ogx-module-operator.git.url="${ODH_OGX_MODULE_OPERATOR_GIT_URL}" \
+      odh-ogx-module-operator.git.commit="${ODH_OGX_MODULE_OPERATOR_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -241,6 +241,8 @@ patch:
       value: quay.io/rhoai/odh-mlserver-cuda-rhel9@sha256:40e74a1b44e0252ba3986fc01102dcff0e7f300c564cba0b04e4a3d0bc95df50
     - name: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE
       value: quay.io/rhoai/odh-trustyai-service-rhel9@sha256:f4f91c346cc14c4fae366db7c54dfe25a4730f0caed47a2216b9fe3d51da0c4c
+    - name: RELATED_IMAGE_ODH_OGX_MODULE_OPERATOR_IMAGE
+      value: quay.io/rhoai/odh-ogx-module-operator-rhel9@sha256:ad2a297c6afc729f30e211931f086878c75d6af94b4e867da58488039f0a2ea3
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -121,6 +121,7 @@ config:
         rhoai/odh-kserve-module-operator-rhel9: rhoai/odh-kserve-module-operator-rhel9
         rhoai/odh-feast-module-operator-rhel9: rhoai/odh-feast-module-operator-rhel9
         rhoai/odh-mlserver-cuda-rhel9: rhoai/odh-mlserver-cuda-rhel9
+        rhoai/odh-ogx-module-operator-rhel9: rhoai/odh-ogx-module-operator-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds relatedImages entry for 'odh-ogx-module-operator' to bundle/bundle-patch.yaml.

Image: quay.io/rhoai/odh-ogx-module-operator-rhel9@sha256:ad2a297c6afc729f30e211931f086878c75d6af94b4e867da58488039f0a2ea3
Jira: https://redhat.atlassian.net/browse/RHOAIENG-78494