### PR TITLE
Add trustyai service to build configuration

### DIFF
--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -10,6 +10,7 @@ config:
         rhoai/odh-kf-notebook-controller-rhel9: rhoai/odh-kf-notebook-controller-rhel9
         rhoai/odh-data-science-pipelines-operator-controller-rhel9: rhoai/odh-data-science-pipelines-operator-controller-rhel9
         rhoai/odh-model-controller-rhel9: rhoai/odh-model-controller-rhel9
+        rhoai/odh-trustyai-service-rhel9: rhoai/odh-trustyai-service-rhel9
         rhoai/odh-trustyai-service-operator-rhel9: rhoai/odh-trustyai-service-operator-rhel9
         rhoai/odh-training-operator-rhel9: rhoai/odh-training-operator-rhel9
         rhoai/odh-dashboard-rhel9: rhoai/odh-dashboard-rhel9


### PR DESCRIPTION
Step seemed to be left out in previous PR here https://github.com/red-hat-data-services/RHOAI-Build-Config/pull/27244/changes
https://redhat.atlassian.net/browse/RHOAIENG-78120