### PR TITLE
RHOAIENG-79243: move fbc processor workflow refs from rhoai-rhtap to red-hat-data-services (rhoai-3.3)

### DIFF
--- a/.github/workflows/fbc-insta-merge.yaml
+++ b/.github/workflows/fbc-insta-merge.yaml
@@ -16,7 +16,7 @@ on:
 
 env:
   GITHUB_ORG: red-hat-data-services
-  GITHUB_RKA_ORG: rhoai-rhtap
+  GITHUB_RKA_ORG: red-hat-data-services
   RESOLVE_CONFLICTS_FOR: 'catalog/catalog-patch.yaml,schedule/catalog-github-trigger.txt'
 
 

--- a/.github/workflows/process-fbc-fragment.yaml
+++ b/.github/workflows/process-fbc-fragment.yaml
@@ -15,7 +15,7 @@ permissions:
 
 env:
   GITHUB_ORG: red-hat-data-services
-  GITHUB_RKA_ORG: rhoai-rhtap
+  GITHUB_RKA_ORG: red-hat-data-services
   PREVIOUS_RELEASE: rhoai-2.25
 jobs:
   process-fbc:

--- a/.github/workflows/process-fbc-fragment.yaml
+++ b/.github/workflows/process-fbc-fragment.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ env.GITHUB_RKA_ORG }}/RHOAI-Konflux-Automation
-          ref: '3.0'
+          ref: main
           path: utils
       - name: Install dependencies
         env:

--- a/.github/workflows/trigger-nightly-fbc-build.yaml
+++ b/.github/workflows/trigger-nightly-fbc-build.yaml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ env.GITHUB_RKA_ORG }}/RHOAI-Konflux-Automation
-          ref: '3.0'
+          ref: main
           path: utils
       - name: Install dependencies
         env:

--- a/.github/workflows/trigger-nightly-fbc-build.yaml
+++ b/.github/workflows/trigger-nightly-fbc-build.yaml
@@ -14,7 +14,7 @@ permissions:
   contents: write
 env:
   GITHUB_ORG: red-hat-data-services
-  GITHUB_RKA_ORG: rhoai-rhtap
+  GITHUB_RKA_ORG: red-hat-data-services
   PREVIOUS_RELEASE: rhoai-2.25
 jobs:
   process-fbc:


### PR DESCRIPTION
## Summary

- Switch `GITHUB_RKA_ORG` from `rhoai-rhtap` to `red-hat-data-services` in FBC processor workflow files (`process-fbc-fragment.yaml`, `trigger-nightly-fbc-build.yaml`, `fbc-insta-merge.yaml`)
- Update RHOAI-Konflux-Automation checkout `ref` from `3.0` to `main` (the `red-hat-data-services` repo has no `3.0` branch; `main` now carries the 3.0-equivalent code)

## Dependencies

Merge https://github.com/red-hat-data-services/RHOAI-Konflux-Automation/pull/43 **first** (adds validators directory and updates fbc-processor to 3.0 version on `main`).

## Verification

- 3.0 `fbc-processor.py` is backward-compatible (`--purge-bundles` defaults to `''`)
- `catalog_validator.py` is self-contained (stdlib + pyyaml only)
- Both scripts have no cross-directory imports

Resolves [RHOAIENG-79243](https://redhat.atlassian.net/browse/RHOAIENG-79243)