### PR TITLE
Add odh-trainer-operator to bundle relatedImages

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -220,6 +220,8 @@ ARG ODH_TRUSTYAI_SERVICE_GIT_URL=
 ARG ODH_TRUSTYAI_SERVICE_GIT_COMMIT=
 ARG ODH_OGX_MODULE_OPERATOR_GIT_URL=
 ARG ODH_OGX_MODULE_OPERATOR_GIT_COMMIT=
+ARG ODH_TRAINER_OPERATOR_GIT_URL=
+ARG ODH_TRAINER_OPERATOR_GIT_COMMIT=
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -451,7 +453,9 @@ LABEL \
       odh-trustyai-service.git.url="${ODH_TRUSTYAI_SERVICE_GIT_URL}" \
       odh-trustyai-service.git.commit="${ODH_TRUSTYAI_SERVICE_GIT_COMMIT}" \
       odh-ogx-module-operator.git.url="${ODH_OGX_MODULE_OPERATOR_GIT_URL}" \
-      odh-ogx-module-operator.git.commit="${ODH_OGX_MODULE_OPERATOR_GIT_COMMIT}"
+      odh-ogx-module-operator.git.commit="${ODH_OGX_MODULE_OPERATOR_GIT_COMMIT}" \
+      odh-trainer-operator.git.url="${ODH_TRAINER_OPERATOR_GIT_URL}" \
+      odh-trainer-operator.git.commit="${ODH_TRAINER_OPERATOR_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -241,6 +241,8 @@ patch:
       value: quay.io/rhoai/odh-trustyai-service-rhel9@sha256:f4f91c346cc14c4fae366db7c54dfe25a4730f0caed47a2216b9fe3d51da0c4c
     - name: RELATED_IMAGE_ODH_OGX_MODULE_OPERATOR_IMAGE
       value: quay.io/rhoai/odh-ogx-module-operator-rhel9@sha256:f57c8ebb196b6f3b0ff7bdc9fae8de0950f3022f8930902d928c8196bac5e101
+    - name: RELATED_IMAGE_ODH_TRAINER_OPERATOR_IMAGE
+      value: quay.io/rhoai/odh-trainer-operator-rhel9@sha256:8c33bee898052d01e51ffb51d13c54c8ed329983ef44f3797db37d2ba6d0aac9
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -122,6 +122,7 @@ config:
         rhoai/odh-feast-module-operator-rhel9: rhoai/odh-feast-module-operator-rhel9
         rhoai/odh-mlserver-cuda-rhel9: rhoai/odh-mlserver-cuda-rhel9
         rhoai/odh-ogx-module-operator-rhel9: rhoai/odh-ogx-module-operator-rhel9
+        rhoai/odh-trainer-operator-rhel9: rhoai/odh-trainer-operator-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds relatedImages entry for 'odh-trainer-operator' to bundle/bundle-patch.yaml.

Image: quay.io/rhoai/odh-trainer-operator-rhel9@sha256:8c33bee898052d01e51ffb51d13c54c8ed329983ef44f3797db37d2ba6d0aac9
Jira: https://redhat.atlassian.net/browse/RHOAIENG-79242