### PR TITLE
Add RELATED_IMAGE for ODH vLLM CPU fast-1 and fast-2

### DIFF
--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -2060,6 +2060,10 @@ spec:
                   value: "registry.redhat.io/rhoai/odh-trustyai-vllm-orchestrator-gateway-rhel9@sha256:be4830548d9cb9eb5e8b4aaf18b3271253e2103a91e5c7526b9540d7cfe6fce0"
                 - name: RELATED_IMAGE_ODH_VLLM_CPU_IMAGE
                   value: "registry.redhat.io/rhoai/odh-vllm-cpu-rhel9@sha256:9eb179aa367002fa38a40c2934213173c1b8817a41de5c78d5b453b78760815c"
+                - name: RELATED_IMAGE_ODH_VLLM_CPU_FAST_1_IMAGE
+                  value: "registry.redhat.io/rhoai/odh-vllm-cpu-rhel9@sha256:9eb179aa367002fa38a40c2934213173c1b8817a41de5c78d5b453b78760815c"
+                - name: RELATED_IMAGE_ODH_VLLM_CPU_FAST_2_IMAGE
+                  value: "registry.redhat.io/rhoai/odh-vllm-cpu-rhel9@sha256:9eb179aa367002fa38a40c2934213173c1b8817a41de5c78d5b453b78760815c"
                 - name: RELATED_IMAGE_ODH_WORKBENCHES_OPERATOR_IMAGE
                   value: "registry.redhat.io/rhoai/odh-workbenches-operator-rhel9@sha256:9168307f5deee7af5838b39e8aff63641876aed7b59488eaebc3216e099997ad"
                 - name: RELATED_IMAGE_ODH_WORKBENCH_CODESERVER_DATASCIENCE_CPU_PY312_IMAGE


### PR DESCRIPTION
Added RELATED_IMAGE_ODH_VLLM_CPU_FAST_1_IMAGE and RELATED_IMAGE_ODH_VLLM_CPU_FAST_2_IMAGE with the same image as the stable RELATED_IMAGE_ODH_VLLM_CPU_IMAGE so the filtering code correctly suppresses the fast templates.
