### PR TITLE
fix: use RHOAI Quay RO credentials for quay.io SBOM pulls

### DIFF
--- a/.github/workflows/process-operator-bundle.yaml
+++ b/.github/workflows/process-operator-bundle.yaml
@@ -77,12 +77,12 @@ jobs:
           REGISTRY_REDHAT_IO_PASSWORD: ${{ secrets.REGISTRY_REDHAT_IO_PASSWORD }}
           REGISTRY_STAGE_REDHAT_IO_USERNAME: ${{ secrets.REGISTRY_STAGE_REDHAT_IO_USERNAME }}
           REGISTRY_STAGE_REDHAT_IO_PASSWORD: ${{ secrets.REGISTRY_STAGE_REDHAT_IO_PASSWORD }}
-          AIPCC_QUAY_RO_USERNAME: ${{ secrets.AIPCC_QUAY_RO_USERNAME }}
-          AIPCC_QUAY_RO_TOKEN: ${{ secrets.AIPCC_QUAY_RO_TOKEN }}
+          RHOAI_QUAY_RO_USERNAME: ${{ secrets.RHOAI_QUAY_RO_USERNAME }}
+          RHOAI_QUAY_RO_TOKEN: ${{ secrets.RHOAI_QUAY_RO_TOKEN }}
         run: |
           cosign login registry.redhat.io -u "${REGISTRY_REDHAT_IO_USERNAME}" -p "${REGISTRY_REDHAT_IO_PASSWORD}"
           cosign login registry.stage.redhat.io -u "${REGISTRY_STAGE_REDHAT_IO_USERNAME}" -p "${REGISTRY_STAGE_REDHAT_IO_PASSWORD}"
-          cosign login quay.io -u "${AIPCC_QUAY_RO_USERNAME}" -p "${AIPCC_QUAY_RO_TOKEN}"
+          cosign login quay.io -u "${RHOAI_QUAY_RO_USERNAME}" -p "${RHOAI_QUAY_RO_TOKEN}"
       - name: Process Operator Bundle
         env:
           BRANCH: ${{ steps.get_branch.outputs.branch }}

--- a/.github/workflows/trigger-nightly-bundle-build.yaml
+++ b/.github/workflows/trigger-nightly-bundle-build.yaml
@@ -70,12 +70,12 @@ jobs:
           REGISTRY_REDHAT_IO_PASSWORD: ${{ secrets.REGISTRY_REDHAT_IO_PASSWORD }}
           REGISTRY_STAGE_REDHAT_IO_USERNAME: ${{ secrets.REGISTRY_STAGE_REDHAT_IO_USERNAME }}
           REGISTRY_STAGE_REDHAT_IO_PASSWORD: ${{ secrets.REGISTRY_STAGE_REDHAT_IO_PASSWORD }}
-          AIPCC_QUAY_RO_USERNAME: ${{ secrets.AIPCC_QUAY_RO_USERNAME }}
-          AIPCC_QUAY_RO_TOKEN: ${{ secrets.AIPCC_QUAY_RO_TOKEN }}
+          RHOAI_QUAY_RO_USERNAME: ${{ secrets.RHOAI_QUAY_RO_USERNAME }}
+          RHOAI_QUAY_RO_TOKEN: ${{ secrets.RHOAI_QUAY_RO_TOKEN }}
         run: |
           cosign login registry.redhat.io -u "${REGISTRY_REDHAT_IO_USERNAME}" -p "${REGISTRY_REDHAT_IO_PASSWORD}"
           cosign login registry.stage.redhat.io -u "${REGISTRY_STAGE_REDHAT_IO_USERNAME}" -p "${REGISTRY_STAGE_REDHAT_IO_PASSWORD}"
-          cosign login quay.io -u "${AIPCC_QUAY_RO_USERNAME}" -p "${AIPCC_QUAY_RO_TOKEN}"
+          cosign login quay.io -u "${RHOAI_QUAY_RO_USERNAME}" -p "${RHOAI_QUAY_RO_TOKEN}"
       - name: Process Operator Bundle
         env:
           BRANCH: ${{ steps.get_branch.outputs.branch }}


### PR DESCRIPTION
## Summary
- Switch Process Operator Bundle / nightly workflows from `AIPCC_QUAY_RO_*` to `RHOAI_QUAY_RO_*` for `cosign login quay.io`, so SBOM extraction can read `quay.io/rhoai/*` images.

## Test plan
- [ ] Dry-run Process Operator Bundle from `fix/skopeo-rhoai-quay-login` with `rhoai_version=rhoai-3.5`
- [ ] Confirm quay.io login succeeds and SBOM pulls from `quay.io/rhoai/*` no longer fail with UNAUTHORIZED


Made with [Cursor](https://cursor.com)