### PR TITLE
Add RELATED_IMAGE_ODH_UBI_MICRO_IMAGE for OVMS auto-versioning

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -70,4 +70,4 @@ additionalImages:
   - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_FAST_2_IMAGE
     value: "registry.stage.redhat.io/rhaii/vllm-gaudi-rhel9:3.5.0-1784726643@sha256:e9ba6bf6e467692efda5b122742616340b2a45561f8bfa693d72b2334d89d6d5"
   - name: RELATED_IMAGE_ODH_UBI_MICRO_IMAGE
-    value: "registry.redhat.io/ubi9/ubi-micro:latest@sha256:38e934147827349f2b8b11ac9c38d7be23cb8e29f128b1c46e5c7ae54a2d23cd"
+    value: "registry.redhat.io/ubi9/ubi-micro@sha256:b1e86b97028b8fcfb6d85f997c39e6b6b67496163ef8d80d243220a4918e8bef"

--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -69,3 +69,5 @@ additionalImages:
     value: "registry.stage.redhat.io/rhaii/vllm-gaudi-rhel9:3.5.0-1784726643@sha256:e9ba6bf6e467692efda5b122742616340b2a45561f8bfa693d72b2334d89d6d5"
   - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_FAST_2_IMAGE
     value: "registry.stage.redhat.io/rhaii/vllm-gaudi-rhel9:3.5.0-1784726643@sha256:e9ba6bf6e467692efda5b122742616340b2a45561f8bfa693d72b2334d89d6d5"
+  - name: RELATED_IMAGE_ODH_UBI_MICRO_IMAGE
+    value: "registry.redhat.io/ubi9/ubi-micro:latest@sha256:38e934147827349f2b8b11ac9c38d7be23cb8e29f128b1c46e5c7ae54a2d23cd"


### PR DESCRIPTION
## Summary
Add `RELATED_IMAGE_ODH_UBI_MICRO_IMAGE` to the additional images patch for disconnected/air-gapped deployments.

## Why
This image is required for the OVMS model auto-versioning init container feature in KServe. Without it, OVMS deployments in disconnected environments will fail.

## Changes
- Added `RELATED_IMAGE_ODH_UBI_MICRO_IMAGE` with value `registry.redhat.io/ubi9/ubi-micro:latest@sha256:38e934147827349f2b8b11ac9c38d7be23cb8e29f128b1c46e5c7ae54a2d23cd`

## Related PRs
- opendatahub-operator: Adding to RelatedImages list
- ODH-Build-Config: Same change for ODH

🤖 Generated with [Claude Code](https://claude.com/claude-code)