### PR TITLE
Add RELATED_IMAGE_ODH_UBI_MICRO_IMAGE for OVMS auto-versioning

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -69,3 +69,5 @@ additionalImages:
     value: "registry.redhat.io/rhaii-early-access/vllm-gaudi-rhel9:3.5.0-ea.2-1782939839@sha256:bb49786e915fe9789ffec6d953827fee90ef30bf9accce3db135ed4a0a26a35d"
   - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_FAST_2_IMAGE
     value: "registry.redhat.io/rhaii-early-access/vllm-gaudi-rhel9:3.5.0-ea.2-1782939839@sha256:bb49786e915fe9789ffec6d953827fee90ef30bf9accce3db135ed4a0a26a35d"
+  - name: RELATED_IMAGE_ODH_UBI_MICRO_IMAGE
+    value: "registry.redhat.io/ubi9/ubi-micro:latest@sha256:38e934147827349f2b8b11ac9c38d7be23cb8e29f128b1c46e5c7ae54a2d23cd"

--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -70,4 +70,4 @@ additionalImages:
   - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_FAST_2_IMAGE
     value: "registry.redhat.io/rhaii-early-access/vllm-gaudi-rhel9:3.5.0-ea.2-1782939839@sha256:bb49786e915fe9789ffec6d953827fee90ef30bf9accce3db135ed4a0a26a35d"
   - name: RELATED_IMAGE_ODH_UBI_MICRO_IMAGE
-    value: "registry.redhat.io/ubi9/ubi-micro:latest@sha256:38e934147827349f2b8b11ac9c38d7be23cb8e29f128b1c46e5c7ae54a2d23cd"
+    value: "registry.redhat.io/ubi9/ubi-micro@sha256:b1e86b97028b8fcfb6d85f997c39e6b6b67496163ef8d80d243220a4918e8bef"


### PR DESCRIPTION
## Summary
Add `RELATED_IMAGE_ODH_UBI_MICRO_IMAGE` to the additional images patch for disconnected/air-gapped deployments.

## Why
This image is required for the OVMS model auto-versioning init container feature in KServe. Without it, OVMS deployments in disconnected environments will fail.

## Changes
- Added `RELATED_IMAGE_ODH_UBI_MICRO_IMAGE` with value `registry.redhat.io/ubi9/ubi-micro:latest@sha256:38e934147827349f2b8b11ac9c38d7be23cb8e29f128b1c46e5c7ae54a2d23cd`

## Related PRs
- RHOAI 3.5: https://github.com/red-hat-data-services/RHOAI-Build-Config/pull/28163
- opendatahub-operator: https://github.com/opendatahub-io/opendatahub-operator/pull/3906
- ODH-Build-Config: https://github.com/opendatahub-io/ODH-Build-Config/pull/3508

🤖 Generated with [Claude Code](https://claude.com/claude-code)