### PR TITLE
feat: add odh-th-torch cpu/cuda/rocm v3-5 to bundle relatedImages

### DIFF
--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -157,6 +157,12 @@ patch:
       value: "quay.io/rhoai/odh-training-rocm64-torch29-py312-rhel9@sha256:8f9ba738fe8411e598496cff70620465a5440c54db4072f7ab5cd3871a38b5ea"
     - name: RELATED_IMAGE_ODH_TRAINING_CUDA128_TORCH29_PY312_IMAGE
       value: "quay.io/rhoai/odh-training-cuda128-torch29-py312-rhel9@sha256:9ec61a637d9e45789d2b7c6cbdfbb85e1f9064e7e217664049fc946e02516f93"
+    - name: RELATED_IMAGE_ODH_TH_TORCH_CPU_PY312_V3_5_IMAGE
+      value: "quay.io/rhoai/odh-th-torch-cpu-py312-v3-5-rhel9@sha256:c6480c922ed3237d8fa92075d15fd0a0d0da2533e22728eb1639805b661d7899"
+    - name: RELATED_IMAGE_ODH_TH_TORCH_CUDA_PY312_V3_5_IMAGE
+      value: "quay.io/rhoai/odh-th-torch-cuda-py312-v3-5-rhel9@sha256:360616086f55474e3cf67193db39907dbc4ef3728d4d0bc143126b4c07cd9ba3"
+    - name: RELATED_IMAGE_ODH_TH_TORCH_ROCM_PY312_V3_5_IMAGE
+      value: "quay.io/rhoai/odh-th-torch-rocm-py312-v3-5-rhel9@sha256:acacfe94f0c0119838547cd70a34bd3046cb74fbf772adb26cba5abc850a7872"
     - name: RELATED_IMAGE_ODH_EVAL_HUB_IMAGE
       value: "quay.io/rhoai/odh-eval-hub-rhel9@sha256:1862c31d676890c4a7c779d1754690903d847b9f34bd4e9795bde72d71fd093f"
     - name: RELATED_IMAGE_ODH_SPARK_OPERATOR_IMAGE

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -79,6 +79,9 @@ config:
         rhoai/odh-mod-arch-maas-rhel9: rhoai/odh-mod-arch-maas-rhel9
         rhoai/odh-training-rocm64-torch29-py312-rhel9: rhoai/odh-training-rocm64-torch29-py312-rhel9
         rhoai/odh-training-cuda128-torch29-py312-rhel9: rhoai/odh-training-cuda128-torch29-py312-rhel9
+        rhoai/odh-th-torch-cpu-py312-v3-5-rhel9: rhoai/odh-th-torch-cpu-py312-v3-5-rhel9
+        rhoai/odh-th-torch-cuda-py312-v3-5-rhel9: rhoai/odh-th-torch-cuda-py312-v3-5-rhel9
+        rhoai/odh-th-torch-rocm-py312-v3-5-rhel9: rhoai/odh-th-torch-rocm-py312-v3-5-rhel9
         rhoai/odh-eval-hub-rhel9: rhoai/odh-eval-hub-rhel9
         rhoai/odh-spark-operator-rhel9: rhoai/odh-spark-operator-rhel9
         rhoai/odh-cli-rhel9: rhoai/odh-cli-rhel9


### PR DESCRIPTION
Adds relatedImages entries for odh-th-torch-cpu/cuda/rocm-py312-v3-5 to `bundle/bundle-patch.yaml` and `config/build-config.yaml`.

Placeholder SHAs are used — these will be updated automatically by nudging once the Konflux builds complete.

Jira: RHOAIENG-79950, RHOAIENG-79951, RHOAIENG-79952

Made with [Cursor](https://cursor.com)