### PR TITLE
fix: remove redundant -v3-5 suffix from odh-th-torch image names

### DIFF
--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -157,12 +157,12 @@ patch:
       value: "quay.io/rhoai/odh-training-rocm64-torch29-py312-rhel9@sha256:8f9ba738fe8411e598496cff70620465a5440c54db4072f7ab5cd3871a38b5ea"
     - name: RELATED_IMAGE_ODH_TRAINING_CUDA128_TORCH29_PY312_IMAGE
       value: "quay.io/rhoai/odh-training-cuda128-torch29-py312-rhel9@sha256:9ec61a637d9e45789d2b7c6cbdfbb85e1f9064e7e217664049fc946e02516f93"
-    - name: RELATED_IMAGE_ODH_TH_TORCH_CPU_PY312_V3_5_IMAGE
-      value: "quay.io/rhoai/odh-th-torch-cpu-py312-v3-5-rhel9@sha256:c6480c922ed3237d8fa92075d15fd0a0d0da2533e22728eb1639805b661d7899"
-    - name: RELATED_IMAGE_ODH_TH_TORCH_CUDA_PY312_V3_5_IMAGE
-      value: "quay.io/rhoai/odh-th-torch-cuda-py312-v3-5-rhel9@sha256:360616086f55474e3cf67193db39907dbc4ef3728d4d0bc143126b4c07cd9ba3"
-    - name: RELATED_IMAGE_ODH_TH_TORCH_ROCM_PY312_V3_5_IMAGE
-      value: "quay.io/rhoai/odh-th-torch-rocm-py312-v3-5-rhel9@sha256:acacfe94f0c0119838547cd70a34bd3046cb74fbf772adb26cba5abc850a7872"
+    - name: RELATED_IMAGE_ODH_TH_TORCH_CPU_PY312_IMAGE
+      value: "quay.io/rhoai/odh-th-torch-cpu-py312-rhel9@sha256:63e7a842bc5eaf0f303bc64dd6be35d7251d1ce3a86edaff37ea11f8513b47c6"
+    - name: RELATED_IMAGE_ODH_TH_TORCH_CUDA_PY312_IMAGE
+      value: "quay.io/rhoai/odh-th-torch-cuda-py312-rhel9@sha256:5b0de2dc3c1f7946eb09278fc7b3cb02ccd2bda736a1a04d97eeab27f152e9b9"
+    - name: RELATED_IMAGE_ODH_TH_TORCH_ROCM_PY312_IMAGE
+      value: "quay.io/rhoai/odh-th-torch-rocm-py312-rhel9@sha256:a9aa347f2f7f51d442d93b8c08a113a5dc99a3e4e4d49a77bd2d1cd3512f1b20"
     - name: RELATED_IMAGE_ODH_EVAL_HUB_IMAGE
       value: "quay.io/rhoai/odh-eval-hub-rhel9@sha256:1862c31d676890c4a7c779d1754690903d847b9f34bd4e9795bde72d71fd093f"
     - name: RELATED_IMAGE_ODH_SPARK_OPERATOR_IMAGE

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -79,9 +79,9 @@ config:
         rhoai/odh-mod-arch-maas-rhel9: rhoai/odh-mod-arch-maas-rhel9
         rhoai/odh-training-rocm64-torch29-py312-rhel9: rhoai/odh-training-rocm64-torch29-py312-rhel9
         rhoai/odh-training-cuda128-torch29-py312-rhel9: rhoai/odh-training-cuda128-torch29-py312-rhel9
-        rhoai/odh-th-torch-cpu-py312-v3-5-rhel9: rhoai/odh-th-torch-cpu-py312-v3-5-rhel9
-        rhoai/odh-th-torch-cuda-py312-v3-5-rhel9: rhoai/odh-th-torch-cuda-py312-v3-5-rhel9
-        rhoai/odh-th-torch-rocm-py312-v3-5-rhel9: rhoai/odh-th-torch-rocm-py312-v3-5-rhel9
+        rhoai/odh-th-torch-cpu-py312-rhel9: rhoai/odh-th-torch-cpu-py312-rhel9
+        rhoai/odh-th-torch-cuda-py312-rhel9: rhoai/odh-th-torch-cuda-py312-rhel9
+        rhoai/odh-th-torch-rocm-py312-rhel9: rhoai/odh-th-torch-rocm-py312-rhel9
         rhoai/odh-eval-hub-rhel9: rhoai/odh-eval-hub-rhel9
         rhoai/odh-spark-operator-rhel9: rhoai/odh-spark-operator-rhel9
         rhoai/odh-cli-rhel9: rhoai/odh-cli-rhel9


### PR DESCRIPTION
## Summary
- Removes the redundant `-v3-5` version suffix from odh-th-torch image names in `bundle/bundle-patch.yaml` and `config/build-config.yaml`
- The Quay repos exist as `odh-th-torch-{cpu,cuda,rocm}-py312-rhel9` (without `-v3-5`), but the config referenced them with the suffix, causing 404 errors in the operator-processor workflow
- Updates sha256 digests to match the latest builds from the correct repos

## Affected images
- `odh-th-torch-cpu-py312-rhel9`
- `odh-th-torch-cuda-py312-rhel9`
- `odh-th-torch-rocm-py312-rhel9`

## Test plan
- [ ] Verify operator-processor workflow no longer errors on these images

Made with [Cursor](https://cursor.com)

## Related PRs
- Operator: https://github.com/opendatahub-io/opendatahub-operator/pull/3905