### PR TITLE
Build failure fix: update base catalog images to registry.redhat.io/openshift4/ose-operator-registry-rhel9

### DIFF
--- a/catalog/v4.18/Dockerfile
+++ b/catalog/v4.18/Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.18
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18
 
 ARG ODH_BUILT_IN_DETECTOR_GIT_URL=
 ARG ODH_BUILT_IN_DETECTOR_GIT_COMMIT=

--- a/catalog/v4.19/Dockerfile
+++ b/catalog/v4.19/Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19
 
 ARG ODH_BUILT_IN_DETECTOR_GIT_URL=
 ARG ODH_BUILT_IN_DETECTOR_GIT_COMMIT=

--- a/catalog/v4.20/Dockerfile
+++ b/catalog/v4.20/Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.20
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.20
 
 ARG ODH_BUILT_IN_DETECTOR_GIT_URL=
 ARG ODH_BUILT_IN_DETECTOR_GIT_COMMIT=

--- a/catalog/v4.21/Dockerfile
+++ b/catalog/v4.21/Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.21
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.21
 
 ARG ODH_BUILT_IN_DETECTOR_GIT_URL=
 ARG ODH_BUILT_IN_DETECTOR_GIT_COMMIT=


### PR DESCRIPTION
Fixing rhoai-fbc-fragment-v2-25 build failures.
```
[retry] executing: buildah pull --retry 3 brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
Trying to pull brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19...
Error: unable to copy from source docker://brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19: initializing source docker://brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19: unable to retrieve auth token: invalid username/password: unauthorized: Please login to the Red Hat Registry using your Customer Portal credentials. Further instructions can be found here: https://access.redhat.com/articles/3399531
[retry] giving up after 1 attempts: stderr matches 'unauthorized'
ERROR: Failed to pull base image brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
```

This is a back-port of similar fixes from 3.5 and 3.6 EA1 branches. 

**References**:

rhoai-3.5: https://github.com/red-hat-data-services/RHOAI-Build-Config/commit/64c67944d4d5ebf15bc0b44c43d176e36cc8e9f4

rhoai-3.6-ea.1:  https://github.com/red-hat-data-services/RHOAI-Build-Config/commit/63bfa9326e14b1f9f676d3a294a656325056c17e