### PR TITLE
Fix FBC build for rhoai-3.5 by updating base image registry

### DIFF
--- a/catalog/rhoai-3.5/v4.19/Dockerfile
+++ b/catalog/rhoai-3.5/v4.19/Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
 ARG ODH_RHEL9_OPERATOR_GIT_URL=

--- a/catalog/rhoai-3.5/v4.20/Dockerfile
+++ b/catalog/rhoai-3.5/v4.20/Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.20
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.20
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
 ARG ODH_RHEL9_OPERATOR_GIT_URL=

--- a/catalog/rhoai-3.5/v4.21/Dockerfile
+++ b/catalog/rhoai-3.5/v4.21/Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.21
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.21
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
 ARG ODH_RHEL9_OPERATOR_GIT_URL=


### PR DESCRIPTION
Switch OCP 4.19-4.21 stage Dockerfiles from brew.registry.redhat.io
to registry.redhat.io/openshift4/ose-operator-registry-rhel9 to fix
401 unauthorized pull failures during stage FBC builds.