### PR TITLE
fix(kserve): add RELATED_IMAGE_ODH_KSERVE_AUTOGLUON_SERVER_IMAGE to RHAI helm values

### DIFF
--- a/helm/xks-values-patch.yaml
+++ b/helm/xks-values-patch.yaml
@@ -69,6 +69,8 @@ rhaiOperator:
       value: "registry.redhat.io/rhoai/odh-kserve-module-operator-rhel9@sha256:9bd66374885ffc90ccb19fe22df00affe527a1a1f94d139422a4c0c5fe5e880d"
     - name: RELATED_IMAGE_ODH_GUARDRAILS_DETECTOR_HUGGINGFACE_RUNTIME_IMAGE
       value: "registry.redhat.io/rhoai/odh-guardrails-detector-huggingface-runtime-rhel9@sha256:b724e97c5ed97a190fef436527710c1d73d01d2913d87dc4ba92216c8f84cb3a"
+    - name: RELATED_IMAGE_ODH_KSERVE_AUTOGLUON_SERVER_IMAGE
+      value: "registry.redhat.io/rhoai/odh-kserve-autogluon-server-rhel9@sha256:300c127bf54b5774dccde525683283796273ccf3420321508a6a3d9f4a609a71"
     - name: RELATED_IMAGE_ODH_MLSERVER_IMAGE
       value: "registry.redhat.io/rhoai/odh-mlserver-rhel9@sha256:07525fba636eb01c464a187ef610badd1596765467270c4dd9ab5d2b935ee7e0"
     - name: RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE


### PR DESCRIPTION
## Summary

Adds `RELATED_IMAGE_ODH_KSERVE_AUTOGLUON_SERVER_IMAGE` to `helm/rhai-on-xks-chart/values.yaml`.

Image is already present in the `rhods-operator.3.5.0` bundle in `catalog/v4.20/rhods-operator/catalog.yaml` but was missing from the helm chart. All other images in this file are from the 3.5.0 bundle; this brings autogluon to parity.

Digest source: `catalog/v4.20/rhods-operator/catalog.yaml`, bundle `rhods-operator.3.5.0`.

Related: opendatahub-io/opendatahub-operator#3924, opendatahub-io/kserve#1855