### PR TITLE
switch all base image for all supported releases to registry.redhat.io

### DIFF
--- a/catalog/rhoai-2.25/v4.18/Dockerfile
+++ b/catalog/rhoai-2.25/v4.18/Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.18
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
 ARG ODH_RHEL8_OPERATOR_GIT_URL=

--- a/catalog/rhoai-2.25/v4.19/Dockerfile
+++ b/catalog/rhoai-2.25/v4.19/Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
 ARG ODH_RHEL8_OPERATOR_GIT_URL=

--- a/catalog/rhoai-2.25/v4.20/Dockerfile
+++ b/catalog/rhoai-2.25/v4.20/Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.20
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.20
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
 ARG ODH_RHEL9_OPERATOR_GIT_URL=

--- a/catalog/rhoai-2.25/v4.21/Dockerfile
+++ b/catalog/rhoai-2.25/v4.21/Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.21
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.21
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
 ARG ODH_RHEL9_OPERATOR_GIT_URL=

--- a/catalog/rhoai-3.3/v4.19/Dockerfile
+++ b/catalog/rhoai-3.3/v4.19/Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
 ARG ODH_RHEL9_OPERATOR_GIT_URL=

--- a/catalog/rhoai-3.3/v4.20/Dockerfile
+++ b/catalog/rhoai-3.3/v4.20/Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.20
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.20
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
 ARG ODH_RHEL9_OPERATOR_GIT_URL=

--- a/catalog/rhoai-3.3/v4.21/Dockerfile
+++ b/catalog/rhoai-3.3/v4.21/Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.21
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.21
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
 ARG ODH_RHEL9_OPERATOR_GIT_URL=

--- a/catalog/rhoai-3.4/v4.19/Dockerfile
+++ b/catalog/rhoai-3.4/v4.19/Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
 ARG ODH_RHEL9_OPERATOR_GIT_URL=

--- a/catalog/rhoai-3.4/v4.20/Dockerfile
+++ b/catalog/rhoai-3.4/v4.20/Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.20
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.20
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
 ARG ODH_RHEL9_OPERATOR_GIT_URL=

--- a/catalog/rhoai-3.4/v4.21/Dockerfile
+++ b/catalog/rhoai-3.4/v4.21/Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.21
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.21
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
 ARG ODH_RHEL9_OPERATOR_GIT_URL=


### PR DESCRIPTION
the base image used in the catalogs is no longer available to us on brew. switching to the production image instead. ref: https://redhat.atlassian.net/browse/RHOAIENG-82062
