### PR TITLE
refactor batch dockerfile labels

### DIFF
--- a/catalog/rhoai-2.25/v4.16/Dockerfile
+++ b/catalog/rhoai-2.25/v4.16/Dockerfile
@@ -57,9 +57,7 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
-ARG RBC_RELEASE_BRANCH_COMMIT_225=
-ARG RBC_RELEASE_BRANCH_COMMIT_33=
-ARG RBC_RELEASE_BRANCH_COMMIT_34=
+ARG RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON={}
 
 
 # Configure the entrypoint and command
@@ -130,9 +128,7 @@ LABEL \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
 
-LABEL rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
-    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}" \
-    rbc-release-branch-34.commit="${RBC_RELEASE_BRANCH_COMMIT_34}"
+LABEL rbc-batch-release-branch-commits="${RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-2.25/v4.16/Dockerfile
+++ b/catalog/rhoai-2.25/v4.16/Dockerfile
@@ -57,10 +57,9 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
-ARG RBC_RELEASE_BRANCH_COMMIT_216=
 ARG RBC_RELEASE_BRANCH_COMMIT_225=
-ARG RBC_RELEASE_BRANCH_COMMIT_32=
 ARG RBC_RELEASE_BRANCH_COMMIT_33=
+ARG RBC_RELEASE_BRANCH_COMMIT_34=
 
 
 # Configure the entrypoint and command
@@ -131,10 +130,9 @@ LABEL \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
 
-LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
-    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
-    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
-    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
+LABEL rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}" \
+    rbc-release-branch-34.commit="${RBC_RELEASE_BRANCH_COMMIT_34}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-2.25/v4.17/Dockerfile
+++ b/catalog/rhoai-2.25/v4.17/Dockerfile
@@ -57,9 +57,7 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
-ARG RBC_RELEASE_BRANCH_COMMIT_225=
-ARG RBC_RELEASE_BRANCH_COMMIT_33=
-ARG RBC_RELEASE_BRANCH_COMMIT_34=
+ARG RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON={}
 
 
 # Configure the entrypoint and command
@@ -130,9 +128,7 @@ LABEL \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
 
-LABEL rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
-    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}" \
-    rbc-release-branch-34.commit="${RBC_RELEASE_BRANCH_COMMIT_34}"
+LABEL rbc-batch-release-branch-commits="${RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-2.25/v4.17/Dockerfile
+++ b/catalog/rhoai-2.25/v4.17/Dockerfile
@@ -57,10 +57,9 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
-ARG RBC_RELEASE_BRANCH_COMMIT_216=
 ARG RBC_RELEASE_BRANCH_COMMIT_225=
-ARG RBC_RELEASE_BRANCH_COMMIT_32=
 ARG RBC_RELEASE_BRANCH_COMMIT_33=
+ARG RBC_RELEASE_BRANCH_COMMIT_34=
 
 
 # Configure the entrypoint and command
@@ -131,10 +130,9 @@ LABEL \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
 
-LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
-    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
-    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
-    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
+LABEL rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}" \
+    rbc-release-branch-34.commit="${RBC_RELEASE_BRANCH_COMMIT_34}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-2.25/v4.18/Dockerfile
+++ b/catalog/rhoai-2.25/v4.18/Dockerfile
@@ -57,9 +57,7 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
-ARG RBC_RELEASE_BRANCH_COMMIT_225=
-ARG RBC_RELEASE_BRANCH_COMMIT_33=
-ARG RBC_RELEASE_BRANCH_COMMIT_34=
+ARG RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON={}
 
 
 # Configure the entrypoint and command
@@ -130,9 +128,7 @@ LABEL \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
 
-LABEL rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
-    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}" \
-    rbc-release-branch-34.commit="${RBC_RELEASE_BRANCH_COMMIT_34}"
+LABEL rbc-batch-release-branch-commits="${RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-2.25/v4.18/Dockerfile
+++ b/catalog/rhoai-2.25/v4.18/Dockerfile
@@ -57,10 +57,9 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
-ARG RBC_RELEASE_BRANCH_COMMIT_216=
 ARG RBC_RELEASE_BRANCH_COMMIT_225=
-ARG RBC_RELEASE_BRANCH_COMMIT_32=
 ARG RBC_RELEASE_BRANCH_COMMIT_33=
+ARG RBC_RELEASE_BRANCH_COMMIT_34=
 
 
 # Configure the entrypoint and command
@@ -131,10 +130,9 @@ LABEL \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
 
-LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
-    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
-    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
-    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
+LABEL rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}" \
+    rbc-release-branch-34.commit="${RBC_RELEASE_BRANCH_COMMIT_34}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-2.25/v4.19/Dockerfile
+++ b/catalog/rhoai-2.25/v4.19/Dockerfile
@@ -57,9 +57,7 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
-ARG RBC_RELEASE_BRANCH_COMMIT_225=
-ARG RBC_RELEASE_BRANCH_COMMIT_33=
-ARG RBC_RELEASE_BRANCH_COMMIT_34=
+ARG RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON={}
 
 
 # Configure the entrypoint and command
@@ -130,9 +128,7 @@ LABEL \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
 
-LABEL rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
-    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}" \
-    rbc-release-branch-34.commit="${RBC_RELEASE_BRANCH_COMMIT_34}"
+LABEL rbc-batch-release-branch-commits="${RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-2.25/v4.19/Dockerfile
+++ b/catalog/rhoai-2.25/v4.19/Dockerfile
@@ -57,10 +57,9 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
-ARG RBC_RELEASE_BRANCH_COMMIT_216=
 ARG RBC_RELEASE_BRANCH_COMMIT_225=
-ARG RBC_RELEASE_BRANCH_COMMIT_32=
 ARG RBC_RELEASE_BRANCH_COMMIT_33=
+ARG RBC_RELEASE_BRANCH_COMMIT_34=
 
 
 # Configure the entrypoint and command
@@ -131,10 +130,9 @@ LABEL \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
 
-LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
-    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
-    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
-    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
+LABEL rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}" \
+    rbc-release-branch-34.commit="${RBC_RELEASE_BRANCH_COMMIT_34}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-2.25/v4.20/Dockerfile
+++ b/catalog/rhoai-2.25/v4.20/Dockerfile
@@ -57,9 +57,7 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
-ARG RBC_RELEASE_BRANCH_COMMIT_225=
-ARG RBC_RELEASE_BRANCH_COMMIT_33=
-ARG RBC_RELEASE_BRANCH_COMMIT_34=
+ARG RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON={}
 
 
 # Configure the entrypoint and command
@@ -130,9 +128,7 @@ LABEL \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
 
-LABEL rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
-    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}" \
-    rbc-release-branch-34.commit="${RBC_RELEASE_BRANCH_COMMIT_34}"
+LABEL rbc-batch-release-branch-commits="${RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-2.25/v4.20/Dockerfile
+++ b/catalog/rhoai-2.25/v4.20/Dockerfile
@@ -57,10 +57,9 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
-ARG RBC_RELEASE_BRANCH_COMMIT_216=
 ARG RBC_RELEASE_BRANCH_COMMIT_225=
-ARG RBC_RELEASE_BRANCH_COMMIT_32=
 ARG RBC_RELEASE_BRANCH_COMMIT_33=
+ARG RBC_RELEASE_BRANCH_COMMIT_34=
 
 
 # Configure the entrypoint and command
@@ -131,10 +130,9 @@ LABEL \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
 
-LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
-    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
-    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
-    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
+LABEL rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}" \
+    rbc-release-branch-34.commit="${RBC_RELEASE_BRANCH_COMMIT_34}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-2.25/v4.21/Dockerfile
+++ b/catalog/rhoai-2.25/v4.21/Dockerfile
@@ -57,9 +57,7 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
-ARG RBC_RELEASE_BRANCH_COMMIT_225=
-ARG RBC_RELEASE_BRANCH_COMMIT_33=
-ARG RBC_RELEASE_BRANCH_COMMIT_34=
+ARG RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON={}
 
 
 # Configure the entrypoint and command
@@ -130,9 +128,7 @@ LABEL \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
 
-LABEL rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
-    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}" \
-    rbc-release-branch-34.commit="${RBC_RELEASE_BRANCH_COMMIT_34}"
+LABEL rbc-batch-release-branch-commits="${RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-2.25/v4.21/Dockerfile
+++ b/catalog/rhoai-2.25/v4.21/Dockerfile
@@ -57,10 +57,9 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
-ARG RBC_RELEASE_BRANCH_COMMIT_216=
 ARG RBC_RELEASE_BRANCH_COMMIT_225=
-ARG RBC_RELEASE_BRANCH_COMMIT_32=
 ARG RBC_RELEASE_BRANCH_COMMIT_33=
+ARG RBC_RELEASE_BRANCH_COMMIT_34=
 
 
 # Configure the entrypoint and command
@@ -131,10 +130,9 @@ LABEL \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
 
-LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
-    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
-    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
-    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
+LABEL rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
+    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}" \
+    rbc-release-branch-34.commit="${RBC_RELEASE_BRANCH_COMMIT_34}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-3.3/v4.19/Dockerfile
+++ b/catalog/rhoai-3.3/v4.19/Dockerfile
@@ -3,6 +3,7 @@
 FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
+ARG RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON={}
 ARG ODH_RHEL9_OPERATOR_GIT_URL=
 ARG ODH_RHEL9_OPERATOR_GIT_COMMIT=
 ARG ODH_KF_NOTEBOOK_CONTROLLER_GIT_URL=
@@ -127,6 +128,7 @@ LABEL \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
 
+LABEL rbc-batch-release-branch-commits="${RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-3.3/v4.19/Dockerfile
+++ b/catalog/rhoai-3.3/v4.19/Dockerfile
@@ -57,10 +57,6 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
-ARG RBC_RELEASE_BRANCH_COMMIT_216=
-ARG RBC_RELEASE_BRANCH_COMMIT_225=
-ARG RBC_RELEASE_BRANCH_COMMIT_32=
-ARG RBC_RELEASE_BRANCH_COMMIT_33=
 
 
 # Configure the entrypoint and command
@@ -131,10 +127,6 @@ LABEL \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
 
-LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
-    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
-    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
-    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-3.3/v4.20/Dockerfile
+++ b/catalog/rhoai-3.3/v4.20/Dockerfile
@@ -3,6 +3,7 @@
 FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.20
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
+ARG RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON={}
 ARG ODH_RHEL9_OPERATOR_GIT_URL=
 ARG ODH_RHEL9_OPERATOR_GIT_COMMIT=
 ARG ODH_KF_NOTEBOOK_CONTROLLER_GIT_URL=
@@ -127,6 +128,7 @@ LABEL \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
 
+LABEL rbc-batch-release-branch-commits="${RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-3.3/v4.20/Dockerfile
+++ b/catalog/rhoai-3.3/v4.20/Dockerfile
@@ -57,10 +57,6 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
-ARG RBC_RELEASE_BRANCH_COMMIT_216=
-ARG RBC_RELEASE_BRANCH_COMMIT_225=
-ARG RBC_RELEASE_BRANCH_COMMIT_32=
-ARG RBC_RELEASE_BRANCH_COMMIT_33=
 
 
 # Configure the entrypoint and command
@@ -131,10 +127,6 @@ LABEL \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
 
-LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
-    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
-    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
-    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-3.3/v4.21/Dockerfile
+++ b/catalog/rhoai-3.3/v4.21/Dockerfile
@@ -3,6 +3,7 @@
 FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.21
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
+ARG RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON={}
 ARG ODH_RHEL9_OPERATOR_GIT_URL=
 ARG ODH_RHEL9_OPERATOR_GIT_COMMIT=
 ARG ODH_KF_NOTEBOOK_CONTROLLER_GIT_URL=
@@ -127,6 +128,7 @@ LABEL \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
 
+LABEL rbc-batch-release-branch-commits="${RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-3.3/v4.21/Dockerfile
+++ b/catalog/rhoai-3.3/v4.21/Dockerfile
@@ -57,10 +57,6 @@ ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_URL=
 ARG ODH_MODEL_REGISTRY_OPERATOR_GIT_COMMIT=
 ARG ODH_OPERATOR_BUNDLE_GIT_COMMIT
 ARG ODH_OPERATOR_BUNDLE_GIT_URL
-ARG RBC_RELEASE_BRANCH_COMMIT_216=
-ARG RBC_RELEASE_BRANCH_COMMIT_225=
-ARG RBC_RELEASE_BRANCH_COMMIT_32=
-ARG RBC_RELEASE_BRANCH_COMMIT_33=
 
 
 # Configure the entrypoint and command
@@ -131,10 +127,6 @@ LABEL \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
 
-LABEL rbc-release-branch-216.commit="${RBC_RELEASE_BRANCH_COMMIT_216}" \
-    rbc-release-branch-225.commit="${RBC_RELEASE_BRANCH_COMMIT_225}" \
-    rbc-release-branch-32.commit="${RBC_RELEASE_BRANCH_COMMIT_32}" \
-    rbc-release-branch-33.commit="${RBC_RELEASE_BRANCH_COMMIT_33}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-3.4/v4.22/Dockerfile
+++ b/catalog/rhoai-3.4/v4.22/Dockerfile
@@ -3,6 +3,7 @@
 FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.22
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
+ARG RBC_RELEASE_BRANCH_COMMIT_34=
 ARG ODH_RHEL9_OPERATOR_GIT_URL=
 ARG ODH_RHEL9_OPERATOR_GIT_COMMIT=
 ARG ODH_KF_NOTEBOOK_CONTROLLER_GIT_URL=
@@ -126,6 +127,8 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-release-branch-34.commit="${RBC_RELEASE_BRANCH_COMMIT_34}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-3.4/v4.22/Dockerfile
+++ b/catalog/rhoai-3.4/v4.22/Dockerfile
@@ -3,7 +3,7 @@
 FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.22
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
-ARG RBC_RELEASE_BRANCH_COMMIT_34=
+ARG RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON={}
 ARG ODH_RHEL9_OPERATOR_GIT_URL=
 ARG ODH_RHEL9_OPERATOR_GIT_COMMIT=
 ARG ODH_KF_NOTEBOOK_CONTROLLER_GIT_URL=
@@ -128,7 +128,7 @@ LABEL \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
 
-LABEL rbc-release-branch-34.commit="${RBC_RELEASE_BRANCH_COMMIT_34}"
+LABEL rbc-batch-release-branch-commits="${RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-3.5/v4.19/Dockerfile
+++ b/catalog/rhoai-3.5/v4.19/Dockerfile
@@ -3,6 +3,7 @@
 FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
+ARG RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON={}
 ARG ODH_RHEL9_OPERATOR_GIT_URL=
 ARG ODH_RHEL9_OPERATOR_GIT_COMMIT=
 ARG ODH_KF_NOTEBOOK_CONTROLLER_GIT_URL=
@@ -126,6 +127,8 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-batch-release-branch-commits="${RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-3.5/v4.20/Dockerfile
+++ b/catalog/rhoai-3.5/v4.20/Dockerfile
@@ -3,6 +3,7 @@
 FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.20
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
+ARG RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON={}
 ARG ODH_RHEL9_OPERATOR_GIT_URL=
 ARG ODH_RHEL9_OPERATOR_GIT_COMMIT=
 ARG ODH_KF_NOTEBOOK_CONTROLLER_GIT_URL=
@@ -126,6 +127,8 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-batch-release-branch-commits="${RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-3.5/v4.21/Dockerfile
+++ b/catalog/rhoai-3.5/v4.21/Dockerfile
@@ -3,6 +3,7 @@
 FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.21
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
+ARG RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON={}
 ARG ODH_RHEL9_OPERATOR_GIT_URL=
 ARG ODH_RHEL9_OPERATOR_GIT_COMMIT=
 ARG ODH_KF_NOTEBOOK_CONTROLLER_GIT_URL=
@@ -126,6 +127,8 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-batch-release-branch-commits="${RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-3.5/v4.22/Dockerfile
+++ b/catalog/rhoai-3.5/v4.22/Dockerfile
@@ -3,6 +3,7 @@
 FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.22
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
+ARG RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON={}
 ARG ODH_RHEL9_OPERATOR_GIT_URL=
 ARG ODH_RHEL9_OPERATOR_GIT_COMMIT=
 ARG ODH_KF_NOTEBOOK_CONTROLLER_GIT_URL=
@@ -126,6 +127,8 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-batch-release-branch-commits="${RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-3.6-ea.1/v4.19/Dockerfile
+++ b/catalog/rhoai-3.6-ea.1/v4.19/Dockerfile
@@ -3,6 +3,7 @@
 FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
+ARG RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON={}
 ARG ODH_RHEL9_OPERATOR_GIT_URL=
 ARG ODH_RHEL9_OPERATOR_GIT_COMMIT=
 ARG ODH_KF_NOTEBOOK_CONTROLLER_GIT_URL=
@@ -126,6 +127,8 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-batch-release-branch-commits="${RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-3.6-ea.1/v4.20/Dockerfile
+++ b/catalog/rhoai-3.6-ea.1/v4.20/Dockerfile
@@ -3,6 +3,7 @@
 FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.20
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
+ARG RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON={}
 ARG ODH_RHEL9_OPERATOR_GIT_URL=
 ARG ODH_RHEL9_OPERATOR_GIT_COMMIT=
 ARG ODH_KF_NOTEBOOK_CONTROLLER_GIT_URL=
@@ -126,6 +127,8 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-batch-release-branch-commits="${RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-3.6-ea.1/v4.21/Dockerfile
+++ b/catalog/rhoai-3.6-ea.1/v4.21/Dockerfile
@@ -3,6 +3,7 @@
 FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.21
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
+ARG RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON={}
 ARG ODH_RHEL9_OPERATOR_GIT_URL=
 ARG ODH_RHEL9_OPERATOR_GIT_COMMIT=
 ARG ODH_KF_NOTEBOOK_CONTROLLER_GIT_URL=
@@ -126,6 +127,8 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-batch-release-branch-commits="${RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \

--- a/catalog/rhoai-3.6-ea.1/v4.22/Dockerfile
+++ b/catalog/rhoai-3.6-ea.1/v4.22/Dockerfile
@@ -3,6 +3,7 @@
 FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.22
 
 ARG RBC_RELEASE_BRANCH_COMMIT=
+ARG RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON={}
 ARG ODH_RHEL9_OPERATOR_GIT_URL=
 ARG ODH_RHEL9_OPERATOR_GIT_COMMIT=
 ARG ODH_KF_NOTEBOOK_CONTROLLER_GIT_URL=
@@ -126,6 +127,8 @@ LABEL \
       odh-operator-bundle.git.url="${ODH_OPERATOR_BUNDLE_GIT_URL}" \
       odh-operator-bundle.git.commit="${ODH_OPERATOR_BUNDLE_GIT_COMMIT}" \
       rbc-release-branch.commit="${RBC_RELEASE_BRANCH_COMMIT}"
+
+LABEL rbc-batch-release-branch-commits="${RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON}"
 
 LABEL com.redhat.component="rhoai-fbc-fragment" \
       description="rhoai-fbc-fragment" \


### PR DESCRIPTION
ref - https://redhat.atlassian.net/browse/RHOAIENG-79505

part of ongoing embargo release work. labels have been added to 3.5 and 3.6-ea.1 as well, in order to propagate this to future embargoed cve work

- **fix rbc-release-branch build labels and ARGs for 2.25, 3.3, and 3.4**
- **switch rbc-release-branch labels to JSON format (RBC_BATCH_RELEASE_BRANCH_COMMITS_JSON)**
