### PR TITLE
add rhoai-private as a mirror

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -8,3 +8,4 @@ spec:
   - source: registry.redhat.io/rhoai
     mirrors:
       - quay.io/rhoai
+      - quay.io/rhoai-private

--- a/builds/force-trigger-rhoai-2.25-ocp-416.txt
+++ b/builds/force-trigger-rhoai-2.25-ocp-416.txt
@@ -1,1 +1,1 @@
-Thu Aug  7 12:00:00 EDT 2026
+Fri Aug  7 11:20:08 EDT 2026

--- a/builds/force-trigger-rhoai-2.25-ocp-417.txt
+++ b/builds/force-trigger-rhoai-2.25-ocp-417.txt
@@ -1,1 +1,1 @@
-Thu Aug  7 12:00:00 EDT 2026
+Fri Aug  7 11:20:08 EDT 2026

--- a/builds/force-trigger-rhoai-2.25-ocp-418.txt
+++ b/builds/force-trigger-rhoai-2.25-ocp-418.txt
@@ -1,1 +1,1 @@
-Thu Aug  7 12:00:00 EDT 2026
+Fri Aug  7 11:20:08 EDT 2026

--- a/builds/force-trigger-rhoai-2.25-ocp-419.txt
+++ b/builds/force-trigger-rhoai-2.25-ocp-419.txt
@@ -1,1 +1,1 @@
-Thu Aug  7 12:00:00 EDT 2026
+Fri Aug  7 11:20:08 EDT 2026

--- a/builds/force-trigger-rhoai-2.25-ocp-420.txt
+++ b/builds/force-trigger-rhoai-2.25-ocp-420.txt
@@ -1,1 +1,1 @@
-Thu Aug  7 12:00:00 EDT 2026
+Fri Aug  7 11:20:08 EDT 2026

--- a/builds/force-trigger-rhoai-2.25-ocp-421.txt
+++ b/builds/force-trigger-rhoai-2.25-ocp-421.txt
@@ -1,1 +1,1 @@
-Thu Aug  7 12:00:00 EDT 2026
+Fri Aug  7 11:20:08 EDT 2026

--- a/builds/force-trigger-rhoai-3.4-ocp-422.txt
+++ b/builds/force-trigger-rhoai-3.4-ocp-422.txt
@@ -1,1 +1,1 @@
-Tue Jul  1 12:00:00 EDT 2026
+Fri Aug  7 11:20:08 EDT 2026


### PR DESCRIPTION
required since the embargoed images now remain in rhoai-private until pushed to stage. https://redhat.atlassian.net/browse/RHOAIENG-82080

