### PR TITLE
bump rhoai versions (2.25.10, 3.4.3) and disable slack notifications

### DIFF
--- a/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-416-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-416-push.yaml
@@ -46,9 +46,11 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "2.25.9"
+    value: "2.25.10"
   - name: ocp-version
     value: "4.16"
+  - name: disable-slack-notifications
+    value: "true"
   - name: fbc-pipeline-branch
     value: "rhoai-2.25"
   pipelineRef:

--- a/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-417-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-417-push.yaml
@@ -46,9 +46,11 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "2.25.9"
+    value: "2.25.10"
   - name: ocp-version
     value: "4.17"
+  - name: disable-slack-notifications
+    value: "true"
   - name: fbc-pipeline-branch
     value: "rhoai-2.25"
   pipelineRef:

--- a/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-418-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-418-push.yaml
@@ -46,9 +46,11 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "2.25.9"
+    value: "2.25.10"
   - name: ocp-version
     value: "4.18"
+  - name: disable-slack-notifications
+    value: "true"
   - name: fbc-pipeline-branch
     value: "rhoai-2.25"
   pipelineRef:

--- a/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-419-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-419-push.yaml
@@ -46,9 +46,11 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "2.25.9"
+    value: "2.25.10"
   - name: ocp-version
     value: "4.19"
+  - name: disable-slack-notifications
+    value: "true"
   - name: fbc-pipeline-branch
     value: "rhoai-2.25"
   pipelineRef:

--- a/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-420-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-420-push.yaml
@@ -46,9 +46,11 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "2.25.9"
+    value: "2.25.10"
   - name: ocp-version
     value: "4.20"
+  - name: disable-slack-notifications
+    value: "true"
   - name: fbc-pipeline-branch
     value: "rhoai-2.25"
   pipelineRef:

--- a/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-421-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-225-ocp-421-push.yaml
@@ -46,9 +46,11 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "2.25.9"
+    value: "2.25.10"
   - name: ocp-version
     value: "4.21"
+  - name: disable-slack-notifications
+    value: "true"
   - name: fbc-pipeline-branch
     value: "rhoai-2.25"
   pipelineRef:

--- a/.tekton/rhoai-fbc-fragment-rhoai-34-ocp-422-push.yaml
+++ b/.tekton/rhoai-fbc-fragment-rhoai-34-ocp-422-push.yaml
@@ -46,9 +46,11 @@ spec:
   - name: build-type
     value: "stage"   # Possible values: 'nightly', 'stage', 'ci'
   - name: rhoai-version
-    value: "3.4.2"
+    value: "3.4.3"
   - name: ocp-version
     value: "4.22"
+  - name: disable-slack-notifications
+    value: "true"
   - name: fbc-pipeline-branch
     value: "rhoai-3.4"
   pipelineRef:


### PR DESCRIPTION
JIRA - https://redhat.atlassian.net/browse/RHOAIENG-82089

Update rhoai-version to 2.25.10 for all 2.25 pipelines and 3.4.3 for the
3.4 OCP 4.22 pipeline, and add disable-slack-notifications param set to
true across all affected files.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
