### PR TITLE
Add RELATED_IMAGE entries for vLLM-Omni CUDA ServingRuntime

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -45,6 +45,12 @@ additionalImages:
     value: "registry.redhat.io/rhaii-early-access/vllm-cuda-rhel9:3.5.0-ea.2-1782953356@sha256:e95153e0bdce2b94d0470d4ac983d3c4b67576280afe99e97ce51700c57f3e5a"
   - name: RELATED_IMAGE_RHAII_VLLM_CUDA_FAST_2_IMAGE
     value: "registry.redhat.io/rhaii-early-access/vllm-cuda-rhel9:3.5.0-ea.2-1782953356@sha256:e95153e0bdce2b94d0470d4ac983d3c4b67576280afe99e97ce51700c57f3e5a"
+  - name: RELATED_IMAGE_RHAII_VLLM_OMNI_CUDA_IMAGE
+    value: "registry.redhat.io/rhaii-early-access/vllm-omni-cuda-rhel9:3.6.0-ea.1@sha256:e95153e0bdce2b94d0470d4ac983d3c4b67576280afe99e97ce51700c57f3e5a"
+  - name: RELATED_IMAGE_RHAII_VLLM_OMNI_CUDA_FAST_1_IMAGE
+    value: "registry.redhat.io/rhaii-early-access/vllm-omni-cuda-rhel9:3.6.0-ea.1@sha256:e95153e0bdce2b94d0470d4ac983d3c4b67576280afe99e97ce51700c57f3e5a"
+  - name: RELATED_IMAGE_RHAII_VLLM_OMNI_CUDA_FAST_2_IMAGE
+    value: "registry.redhat.io/rhaii-early-access/vllm-omni-cuda-rhel9:3.6.0-ea.1@sha256:e95153e0bdce2b94d0470d4ac983d3c4b67576280afe99e97ce51700c57f3e5a"
   - name: RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE
     value: "registry.redhat.io/rhaii-early-access/vllm-rocm-rhel9:3.5.0-ea.2-1782918845@sha256:7f338d908f857b9a0ccdf21049eb1828482ce9e604b379338b6d295270fd0af6"
   - name: RELATED_IMAGE_RHAII_VLLM_ROCM_FAST_1_IMAGE


### PR DESCRIPTION
Adds three RELATED_IMAGE env vars (stable, fast-1, fast-2) for the new vLLM-Omni CUDA serving runtime entering RHOAI as Tech Preview.

Signed-off-by: Syed Nomaan Ali <syedali@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED