### PR TITLE
Add odh-trustyai-service-py to bundle relatedImages

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -206,6 +206,8 @@ ARG ODH_TRAINER_OPERATOR_GIT_URL=
 ARG ODH_TRAINER_OPERATOR_GIT_COMMIT=
 ARG ODH_OBSERVABILITY_GIT_URL=
 ARG ODH_OBSERVABILITY_GIT_COMMIT=
+ARG ODH_TRUSTYAI_SERVICE_PY_GIT_URL=
+ARG ODH_TRUSTYAI_SERVICE_PY_GIT_COMMIT=
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -423,7 +425,9 @@ LABEL \
       odh-trainer-operator.git.url="${ODH_TRAINER_OPERATOR_GIT_URL}" \
       odh-trainer-operator.git.commit="${ODH_TRAINER_OPERATOR_GIT_COMMIT}" \
       odh-observability.git.url="${ODH_OBSERVABILITY_GIT_URL}" \
-      odh-observability.git.commit="${ODH_OBSERVABILITY_GIT_COMMIT}"
+      odh-observability.git.commit="${ODH_OBSERVABILITY_GIT_COMMIT}" \
+      odh-trustyai-service-py.git.url="${ODH_TRUSTYAI_SERVICE_PY_GIT_URL}" \
+      odh-trustyai-service-py.git.commit="${ODH_TRUSTYAI_SERVICE_PY_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -229,6 +229,8 @@ patch:
       value: quay.io/rhoai/odh-trainer-operator-rhel9@sha256:8c33bee898052d01e51ffb51d13c54c8ed329983ef44f3797db37d2ba6d0aac9
     - name: RELATED_IMAGE_ODH_OBSERVABILITY_IMAGE
       value: quay.io/rhoai/odh-observability-rhel9@sha256:ef1dfdafbe76c8d6f6dd04ee5b0a0f5d6673e4fdccedd52eeb21bf90c9ded3fb
+    - name: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_PY_IMAGE
+      value: quay.io/rhoai/odh-trustyai-service-py-rhel9@sha256:ccbc196ef8edb1aedb57aa1bf78bf8179f8a0508588e4578304422255c63d55c
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -230,7 +230,7 @@ patch:
     - name: RELATED_IMAGE_ODH_OBSERVABILITY_IMAGE
       value: quay.io/rhoai/odh-observability-rhel9@sha256:ef1dfdafbe76c8d6f6dd04ee5b0a0f5d6673e4fdccedd52eeb21bf90c9ded3fb
     - name: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_PY_IMAGE
-      value: quay.io/rhoai/odh-trustyai-service-py-rhel9@sha256:ccbc196ef8edb1aedb57aa1bf78bf8179f8a0508588e4578304422255c63d55c
+      value: quay.io/rhoai/odh-trustyai-service-py-rhel9@sha256:9cec24286fe4a681b7ec82b08e39b76548dcf3bce98f1f82bec6932be3401aaf
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -115,6 +115,7 @@ config:
         rhoai/odh-ogx-module-operator-rhel9: rhoai/odh-ogx-module-operator-rhel9
         rhoai/odh-trainer-operator-rhel9: rhoai/odh-trainer-operator-rhel9
         rhoai/odh-observability-rhel9: rhoai/odh-observability-rhel9
+        rhoai/odh-trustyai-service-py-rhel9: rhoai/odh-trustyai-service-py-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds relatedImages entry for 'odh-trustyai-service-py' to bundle/bundle-patch.yaml.

Image: quay.io/rhoai/odh-trustyai-service-py-rhel9@sha256:ccbc196ef8edb1aedb57aa1bf78bf8179f8a0508588e4578304422255c63d55c
Jira: https://redhat.atlassian.net/browse/RHOAIENG-79857