### PR TITLE
Onboard 2.25.10 to catalog-patch — fix process-fbc-fragment validation failure (rhoai-2.25)

### DIFF
--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -5,29 +5,29 @@ patch:
   olm.channels:
     - name: fast
       entries:
-      - name: rhods-operator.2.25.9
-        replaces: rhods-operator.2.25.8
-        skipRange: '>=2.24.0 <2.25.9'
+      - name: rhods-operator.2.25.10
+        replaces: rhods-operator.2.25.9
+        skipRange: '>=2.24.0 <2.25.10'
     - name: alpha
       entries:
-      - name: rhods-operator.2.25.9
-        replaces: rhods-operator.2.25.8
-        skipRange: '>=2.24.0 <2.25.9'
+      - name: rhods-operator.2.25.10
+        replaces: rhods-operator.2.25.9
+        skipRange: '>=2.24.0 <2.25.10'
     - name: stable
       entries:
-      - name: rhods-operator.2.25.9
-        replaces: rhods-operator.2.25.8
-        skipRange: '>=2.22.0 <2.25.9'
+      - name: rhods-operator.2.25.10
+        replaces: rhods-operator.2.25.9
+        skipRange: '>=2.22.0 <2.25.10'
     - name: stable-2.25
       entries:
-      - name: rhods-operator.2.25.9
-        replaces: rhods-operator.2.25.8
-        skipRange: '>=2.22.0 <2.25.9'
+      - name: rhods-operator.2.25.10
+        replaces: rhods-operator.2.25.9
+        skipRange: '>=2.22.0 <2.25.10'
     - name: eus-2.25
       entries:
-      - name: rhods-operator.2.25.9
-        replaces: rhods-operator.2.25.8
-        skipRange: '>=2.16.0 <2.25.9'
+      - name: rhods-operator.2.25.10
+        replaces: rhods-operator.2.25.9
+        skipRange: '>=2.16.0 <2.25.10'
 
   olm.bundle:
     - quay.io/rhoai/odh-operator-bundle@sha256:d0d47805c1411f9ba2a8a3a4944f1e367e46d79579e3b64647b0a155fc3ecd1b


### PR DESCRIPTION
## Problem
process-fbc-fragment on rhoai-2.25 failing at "Validate Catalogs" step:
```
missing_bundles {'v4.16': ['rhods-operator.2.25.10'], 'v4.17': ['rhods-operator.2.25.10'], 'v4.18': ['rhods-operator.2.25.10']}
```

## Root cause
2.25.10 was shipped via embargo batch push (built on private GitLab, pushed directly to main stage catalogs). The release branch `catalog-patch.yaml` was never updated — it still has 2.25.9 as the latest. The PCC has 2.25.10, but the fbc-processor only includes versions listed in the catalog-patch channel entries. Without the 2.25.10 entry, the output catalogs miss it, and the validator fails.

## Fix
Add rhods-operator.2.25.10 entries (replaces 2.25.9) to all 5 channels: fast, alpha, stable, stable-2.25, eus-2.25.