### PR TITLE
Onboard 3.3.6 to catalog-patch — post-embargo release branch update (rhoai-3.3)

### DIFF
--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -7,16 +7,16 @@ patch:
       package: rhods-operator
       schema: olm.channel
       entries:
-      - name: rhods-operator.3.3.5
-        replaces: rhods-operator.3.3.4
-        skipRange: '>=3.3.0 <3.3.5'
+      - name: rhods-operator.3.3.6
+        replaces: rhods-operator.3.3.5
+        skipRange: '>=3.3.0 <3.3.6'
     - name: support-required-upgrade
       package: rhods-operator
       schema: olm.channel
       entries:
-      - name: rhods-operator.3.3.5
-        replaces: rhods-operator.3.3.4
-        skipRange: '>=2.25.7 <2.26.0 || >=3.3.2 <3.3.5'
+      - name: rhods-operator.3.3.6
+        replaces: rhods-operator.3.3.5
+        skipRange: '>=2.25.7 <2.26.0 || >=3.3.2 <3.3.6'
 
   olm.bundle:
     - quay.io/rhoai/odh-operator-bundle@sha256:7e634dbdbb2823d95c9d47948c03d83c67c46b3fe7bcaa6d3c90939ef0886e5e


### PR DESCRIPTION
## Problem
process-fbc-fragment on rhoai-3.3 passes due to a bug in the validator's is_latest_ea() check that falsely skips GA versions. Once the EA auto-skip fix (RHOAI-Konflux-Automation#38) is merged, this will start failing because 3.3.6 is not in the output catalogs.

## Root cause
3.3.6 was shipped via embargo batch push (built on private GitLab, pushed directly to main stage catalogs). The release branch `catalog-patch.yaml` was never updated — it still has 3.3.5 as the latest. Without the 3.3.6 entry, the fbc-processor doesn't include it in the output catalogs.

## Fix
Add rhods-operator.3.3.6 entries (replaces 3.3.5) to stable-3.3 and support-required-upgrade channels.