### PR TITLE
Update RHAII vLLM images to 3.4.4 stage for RHOAI 3.4.4

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -40,12 +40,12 @@ additionalImages:
   - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
     value: "registry.redhat.io/rhaii/vllm-gaudi-rhel9:3.4.0-1777444681@sha256:71008b2151586551ec0969ffc5b175f726ed6f6bebee29cdc289549e216609bc"
   - name: RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-cuda-rhel9:3.5.0-1784900545@sha256:afdaeda1cd2cc2fd132f1ef5ea4d2226cf04d4c3123a45bd69ab85105a9d57f5"
+    value: "registry.stage.redhat.io/rhaii/vllm-cuda-rhel9:3.4.4@sha256:fb1cc3aae4b0638426312b005fd080e206fa0e8568cb601c26cd824749f4bc93"
   - name: RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-rocm-rhel9:3.5.0-1784802948@sha256:a98e4354ead0c9346f47688f0aaa96328ce57ceb102282e8d0f6ca1f62033b0d"
+    value: "registry.stage.redhat.io/rhaii/vllm-rocm-rhel9:3.4.4@sha256:db519f923fab92cfbde552e984303ac8dd5e3ffb2707a4bb761517eed780fe8a"
   - name: RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-spyre-rhel9:3.5.0-1784862998@sha256:473ef4ba67e557241750f227e939318994a579ea6d91e3999cd658bd00cffcc3"
+    value: "registry.stage.redhat.io/rhaii/vllm-spyre-rhel9:3.4.4@sha256:365a0a8911a803a1567124a3b0a495c1b51b8aaaf9932e65f9845dd4d00d9c6f"
   - name: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-cpu-rhel9:3.5.0-1784568351@sha256:22a8adb9f776061fbf2eaa775344529dbc610d612699bbb665e6daebc293779b"
+    value: "registry.stage.redhat.io/rhaii/vllm-cpu-rhel9:3.4.4@sha256:cb1a179c148d1501dd449643f1b245cfe2b2a93efb3b0569189a0c51a8ae2dec"
   - name: RELATED_IMAGE_UBI_MINIMAL_IMAGE
     value: "registry.redhat.io/ubi9/ubi-minimal:9.7@sha256:907b68736aa798b2d38255b7aa070b2a70acb90803864a40f05d0ec47556ddd0"


### PR DESCRIPTION
The following images were provided:
 - registry.stage.redhat.io/rhaii/vllm-cuda-rhel9:3.4.4
 - registry.stage.redhat.io/rhaii/vllm-rocm-rhel9:3.4.4
 - registry.stage.redhat.io/rhaii/vllm-cpu-rhel9:3.4.4
 - registry.stage.redhat.io/rhaii/vllm-spyre-rhel9:3.4.4

Stage registry entries are automatically replaced with registry.redhat.io during processing. RHOAIENG-80962