### PR TITLE
Add odh-workbench-jupyter-baseline-cpu-py312 to bundle relatedImages

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -210,6 +210,8 @@ ARG ODH_TRUSTYAI_SERVICE_PY_GIT_URL=
 ARG ODH_TRUSTYAI_SERVICE_PY_GIT_COMMIT=
 ARG ODH_RHOAI_MCP_GIT_URL=
 ARG ODH_RHOAI_MCP_GIT_COMMIT=
+ARG ODH_WORKBENCH_JUPYTER_BASELINE_CPU_PY312_GIT_URL=
+ARG ODH_WORKBENCH_JUPYTER_BASELINE_CPU_PY312_GIT_COMMIT=
 
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
@@ -432,7 +434,9 @@ LABEL \
       odh-trustyai-service-py.git.url="${ODH_TRUSTYAI_SERVICE_PY_GIT_URL}" \
       odh-trustyai-service-py.git.commit="${ODH_TRUSTYAI_SERVICE_PY_GIT_COMMIT}" \
       odh-rhoai-mcp.git.url="${ODH_RHOAI_MCP_GIT_URL}" \
-      odh-rhoai-mcp.git.commit="${ODH_RHOAI_MCP_GIT_COMMIT}" 
+      odh-rhoai-mcp.git.commit="${ODH_RHOAI_MCP_GIT_COMMIT}" \
+      odh-workbench-jupyter-baseline-cpu-py312.git.url="${ODH_WORKBENCH_JUPYTER_BASELINE_CPU_PY312_GIT_URL}" \
+      odh-workbench-jupyter-baseline-cpu-py312.git.commit="${ODH_WORKBENCH_JUPYTER_BASELINE_CPU_PY312_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -233,6 +233,8 @@ patch:
       value: quay.io/rhoai/odh-trustyai-service-py-rhel9@sha256:9cec24286fe4a681b7ec82b08e39b76548dcf3bce98f1f82bec6932be3401aaf
     - name: RELATED_IMAGE_ODH_RHOAI_MCP_IMAGE
       value: quay.io/rhoai/odh-rhoai-mcp-rhel9@sha256:985b3251644445cd5375d7deb2ae5d7853529b199ac10c1af9cb1d445ef539e3
+    - name: RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_BASELINE_CPU_PY312_IMAGE
+      value: quay.io/rhoai/odh-workbench-jupyter-baseline-cpu-py312-rhel9@sha256:9743405a176d755a63b7b9b90a7e5fa52fb0e30585ba9d9cd0328874f7a61fac
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -117,6 +117,7 @@ config:
         rhoai/odh-observability-rhel9: rhoai/odh-observability-rhel9
         rhoai/odh-trustyai-service-py-rhel9: rhoai/odh-trustyai-service-py-rhel9
         rhoai/odh-rhoai-mcp-rhel9: rhoai/odh-rhoai-mcp-rhel9
+        rhoai/odh-workbench-jupyter-baseline-cpu-py312-rhel9: rhoai/odh-workbench-jupyter-baseline-cpu-py312-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds relatedImages entry for 'odh-workbench-jupyter-baseline-cpu-py312' to bundle/bundle-patch.yaml.

Image: quay.io/rhoai/odh-workbench-jupyter-baseline-cpu-py312-rhel9@sha256:9743405a176d755a63b7b9b90a7e5fa52fb0e30585ba9d9cd0328874f7a61fac
Jira: https://redhat.atlassian.net/browse/RHOAIENG-81140