### PR TITLE
fix: update skip-bundles after is_latest_ea() bug fix

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -11,32 +11,17 @@ config:
     - version: v4.18
       discontinued-from: rhods-operator.3.0.0
     - version: v4.19
-      skip-bundles:
-        - rhods-operator.3.4.0-ea.1
-        - rhods-operator.3.4.0-ea.2
-        - rhods-operator.3.5.0-ea.1
-        - rhods-operator.3.5.0-ea.2
     - version: v4.20
       onboarded-since: rhods-operator.2.25.0
-      skip-bundles:
-        - rhods-operator.3.4.0-ea.1
-        - rhods-operator.3.4.0-ea.2
-        - rhods-operator.3.5.0-ea.1
-        - rhods-operator.3.5.0-ea.2
     - version: v4.21
       onboarded-since: rhods-operator.2.25.0
       skip-bundles:
         - rhods-operator.3.2.1
-        - rhods-operator.3.4.0-ea.1
-        - rhods-operator.3.4.0-ea.2
-        - rhods-operator.3.5.0-ea.1
-        - rhods-operator.3.5.0-ea.2
     - version: v4.22
       onboarded-since: rhods-operator.2.25.0
       skip-bundles:
         - rhods-operator.2.25.9
+        - rhods-operator.2.25.10
         - rhods-operator.3.2.1
-        - rhods-operator.3.4.0-ea.1
-        - rhods-operator.3.4.0-ea.2
-        - rhods-operator.3.5.0-ea.1
-        - rhods-operator.3.5.0-ea.2
+        - rhods-operator.3.3.5
+        - rhods-operator.3.3.6

--- a/config/new-config.yaml
+++ b/config/new-config.yaml
@@ -21,10 +21,10 @@ config:
       onboarded-range: '>=2.25.0'
 
     - version: v4.21
-      onboarded-range: '>=2.25.0 <2.26.0 || >3.3.0'
+      onboarded-range: '>=2.25.0 <2.26.0 || >=3.3.0'
 
     - version: v4.22
-      onboarded-range: '>=2.25.0 <2.26.0 || >=3.5.0'
+      onboarded-range: '>=2.25.0 <2.26.0 || >=3.4.0'
       skip-bundles:
         # https://redhat-internal.slack.com/archives/C08UHLCPLQ6/p1785343129026979?thread_ts=1785336075.692629&cid=C08UHLCPLQ6
         - rhods-operator.2.25.9

--- a/config/new-config.yaml
+++ b/config/new-config.yaml
@@ -28,3 +28,4 @@ config:
       skip-bundles:
         # https://redhat-internal.slack.com/archives/C08UHLCPLQ6/p1785343129026979?thread_ts=1785336075.692629&cid=C08UHLCPLQ6
         - rhods-operator.2.25.9
+        - rhods-operator.2.25.10


### PR DESCRIPTION
Depends on https://github.com/red-hat-data-services/RHOAI-Konflux-Automation/pull/50
- Remove EA versions from skip-bundles-  the validator's EA superseding logic now correctly handles these.
- Add missing GA skip-bundles for 2.25.10, 3.3.5, 3.3.6 on v4.22 that were previously hidden by the bug.