### PR TITLE
fix: validate PCC before commit; feat: run new validator in parallel

### DIFF
--- a/.github/workflows/process-fbc-fragment.yaml
+++ b/.github/workflows/process-fbc-fragment.yaml
@@ -163,38 +163,69 @@ jobs:
           done < <(yq e '.config.supported-ocp-versions[].version' ${CONFIG_PATH})
           
           ls -l main/pcc/
-      - name: Push latest PCC Cache
-        id: push-pcc-cache
+      - name: Check PCC catalog changes
+        id: check-pcc-changes
         if: ${{ steps.check-if-pcc-cache-valid.outputs.PCC_CACHE_VALID == 'NO' }}
         working-directory: main
         run: |
-          git config user.name "Openshift-AI DevOps"
-          git config user.email "openshift-ai-devops@redhat.com"
           git add -A
-          # Atomic commit: only commit if PCC catalog files actually changed.
-          # If only shipped_rhoai_versions_granular.txt changed (index hasn't caught up),
-          # revert it so the next run retries regeneration.
           if git diff --staged --name-only | grep -q "pcc/catalog-"; then
-            git commit -m "Regeneratd the PCC Cache" -m "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" && git push origin main
-            echo "pcc_committed=true" >> $GITHUB_OUTPUT
+            echo "pcc_catalogs_changed=true" >> $GITHUB_OUTPUT
           else
-            echo "No PCC catalog files changed — index may not have caught up yet. Skipping commit to retry on next run."
+            # Atomic commit: The versions file must only be committed alongside the corresponding catalog updates.. If the versions file is committed
+            # without updated catalogs, PCC_CACHE_VALID will read YES on the next run and skip regeneration — leaving stale catalogs permanently.
+            #
+            # If only the versions file changed, the indexes have not caught up yet. Revert all changes so the next run can retry.
+            echo "No PCC catalog files changed — indexes may not have caught up yet. Skipping commit to retry on next run."
             git checkout HEAD -- .
-            echo "pcc_committed=false" >> $GITHUB_OUTPUT
+            echo "pcc_catalogs_changed=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Validate PCC Cache
         id: validate-pcc-cache
-        if: ${{ steps.push-pcc-cache.outputs.pcc_committed == 'true' }}
+        if: ${{ steps.check-pcc-changes.outputs.pcc_catalogs_changed == 'true' }}
         env:
           BRANCH: ${{ steps.get_branch.outputs.branch }}
         run: |
           BUILD_CONFIG_PATH=main/config/config.yaml
           SHIPPED_RHOAI_VERSIONS_PATH=main/pcc/shipped_rhoai_versions_granular.txt
           PCC_FOLDER_PATH=main/pcc
-          GLOBAL_CONFIG_PATH=main/config/config.yaml
 
-          python3 utils/utils/validators/catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ${GLOBAL_CONFIG_PATH}
+          # --- Old validator (legacy config) ---
+          GLOBAL_CONFIG_PATH=main/config/config.yaml
+          echo "=== Running OLD PCC validator with config.yaml ==="
+          python3 utils/utils/validators/catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ${GLOBAL_CONFIG_PATH} && OLD_EXIT=0 || OLD_EXIT=$?
+
+          # --- New validator (range-based config, testing phase) ---
+          # See: https://github.com/red-hat-data-services/RHOAI-Konflux-Automation/pull/49
+          NEW_GLOBAL_CONFIG_PATH=main/config/new-config.yaml
+          echo ""
+          echo "=== Running NEW PCC validator with new-config.yaml ==="
+          pushd utils/utils/processors
+          python3 -m validator.catalog_validator -op validate-pcc --build-config-path ../../../${BUILD_CONFIG_PATH} --catalog-folder-path ../../../${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ../../../${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ../../../${NEW_GLOBAL_CONFIG_PATH} && NEW_EXIT=0 || NEW_EXIT=$?
+          popd
+
+          echo ""
+          echo "=== PCC Validation Summary ==="
+          echo "OLD validator: $([ $OLD_EXIT -eq 0 ] && echo 'PASSED' || echo 'FAILED')"
+          echo "NEW validator: $([ $NEW_EXIT -eq 0 ] && echo 'PASSED' || echo 'FAILED')"
+
+          if [ $OLD_EXIT -ne 0 ] || [ $NEW_EXIT -ne 0 ]; then
+            echo ""
+            echo "PCC validation failed. Please contact Rishab Prasad (riprasad@redhat.com) for assistance."
+            cd main && git checkout HEAD -- . && cd ..
+            exit 1
+          fi
+
+      - name: Push latest PCC Cache
+        id: push-pcc-cache
+        if: ${{ steps.check-pcc-changes.outputs.pcc_catalogs_changed == 'true' }}
+        working-directory: main
+        run: |
+          git config user.name "Openshift-AI DevOps"
+          git config user.email "openshift-ai-devops@redhat.com"
+          git commit -m "Regenerated the PCC Cache" -m "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" && git push origin main
+          echo "pcc_committed=true" >> $GITHUB_OUTPUT
 
       - name: Process FBC Fragment
         env:
@@ -310,14 +341,34 @@ jobs:
         env:
           BRANCH: ${{ steps.get_branch.outputs.branch }}
         run: |
-          #Declare basic variables
           BUILD_CONFIG_PATH=${BRANCH}/config/build-config.yaml
           SHIPPED_RHOAI_VERSIONS_PATH=main/pcc/shipped_rhoai_versions_granular.txt
           CATALOG_FOLDER_PATH=${BRANCH}/catalog
-          GLOBAL_CONFIG_PATH=main/config/config.yaml
 
-          #Validate Catalogs
-          python3 utils/utils/validators/catalog_validator.py -op validate-catalogs --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${CATALOG_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ${GLOBAL_CONFIG_PATH}
+          # --- Old validator (legacy config) ---
+          GLOBAL_CONFIG_PATH=main/config/config.yaml
+          echo "=== Running OLD catalog validator with config.yaml ==="
+          python3 utils/utils/validators/catalog_validator.py -op validate-catalogs --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${CATALOG_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ${GLOBAL_CONFIG_PATH} && OLD_EXIT=0 || OLD_EXIT=$?
+
+          # --- New validator (range-based config, testing phase) ---
+          # See: https://github.com/red-hat-data-services/RHOAI-Konflux-Automation/pull/49
+          NEW_GLOBAL_CONFIG_PATH=main/config/new-config.yaml
+          echo ""
+          echo "=== Running NEW catalog validator with new-config.yaml ==="
+          pushd utils/utils/processors
+          python3 -m validator.catalog_validator -op validate-catalogs --build-config-path ../../../${BUILD_CONFIG_PATH} --catalog-folder-path ../../../${CATALOG_FOLDER_PATH} --shipped-rhoai-versions-path ../../../${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ../../../${NEW_GLOBAL_CONFIG_PATH} && NEW_EXIT=0 || NEW_EXIT=$?
+          popd
+
+          echo ""
+          echo "=== Catalog Validation Summary ==="
+          echo "OLD validator: $([ $OLD_EXIT -eq 0 ] && echo 'PASSED' || echo 'FAILED')"
+          echo "NEW validator: $([ $NEW_EXIT -eq 0 ] && echo 'PASSED' || echo 'FAILED')"
+
+          if [ $OLD_EXIT -ne 0 ] || [ $NEW_EXIT -ne 0 ]; then
+            echo ""
+            echo "Catalog validation failed. Please contact Rishab Prasad (riprasad@redhat.com) for assistance."
+            exit 1
+          fi
 
       - name: Commit and push the changes to release branch
         uses: actions-js/push@master

--- a/.github/workflows/trigger-nightly-fbc-build.yaml
+++ b/.github/workflows/trigger-nightly-fbc-build.yaml
@@ -163,32 +163,70 @@ jobs:
           
           ls -l main/pcc/
 
+      - name: Check PCC catalog changes
+        id: check-pcc-changes
+        if: ${{ steps.check-if-pcc-cache-valid.outputs.PCC_CACHE_VALID == 'NO' }}
+        working-directory: main
+        run: |
+          # Atomic commit: catalogs + versions file must be committed
+          # together. If the versions file is committed without updated
+          # catalogs, PCC_CACHE_VALID will read YES on the next run and
+          # skip regeneration — leaving stale catalogs permanently.
+          # If only the versions file changed (indexes haven't caught up),
+          # revert everything so the next run retries.
+          git add -A
+          if git diff --staged --name-only | grep -q "pcc/catalog-"; then
+            echo "pcc_catalogs_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "No PCC catalog files changed — indexes may not have caught up yet. Skipping commit to retry on next run."
+            git checkout HEAD -- .
+            echo "pcc_catalogs_changed=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Validate PCC Cache
         id: validate-pcc-cache
-        if: ${{ steps.check-if-pcc-cache-valid.outputs.PCC_CACHE_VALID == 'NO' }}
+        if: ${{ steps.check-pcc-changes.outputs.pcc_catalogs_changed == 'true' }}
         env:
           BRANCH: ${{ steps.get_branch.outputs.branch }}
         run: |
-          #Declare basic variables
           BUILD_CONFIG_PATH=main/config/config.yaml
           SHIPPED_RHOAI_VERSIONS_PATH=main/pcc/shipped_rhoai_versions_granular.txt
           PCC_FOLDER_PATH=main/pcc
+
+          # --- Old validator (legacy config) ---
           GLOBAL_CONFIG_PATH=main/config/config.yaml
-          
-          #Validate PCC
-          python3 utils/utils/validators/catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ${GLOBAL_CONFIG_PATH}
+          echo "=== Running OLD PCC validator with config.yaml ==="
+          python3 utils/utils/validators/catalog_validator.py -op validate-pcc --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ${GLOBAL_CONFIG_PATH} && OLD_EXIT=0 || OLD_EXIT=$?
+
+          # --- New validator (range-based config, testing phase) ---
+          # See: https://github.com/red-hat-data-services/RHOAI-Konflux-Automation/pull/49
+          NEW_GLOBAL_CONFIG_PATH=main/config/new-config.yaml
+          echo ""
+          echo "=== Running NEW PCC validator with new-config.yaml ==="
+          pushd utils/utils/processors
+          python3 -m validator.catalog_validator -op validate-pcc --build-config-path ../../../${BUILD_CONFIG_PATH} --catalog-folder-path ../../../${PCC_FOLDER_PATH} --shipped-rhoai-versions-path ../../../${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ../../../${NEW_GLOBAL_CONFIG_PATH} && NEW_EXIT=0 || NEW_EXIT=$?
+          popd
+
+          echo ""
+          echo "=== PCC Validation Summary ==="
+          echo "OLD validator: $([ $OLD_EXIT -eq 0 ] && echo 'PASSED' || echo 'FAILED')"
+          echo "NEW validator: $([ $NEW_EXIT -eq 0 ] && echo 'PASSED' || echo 'FAILED')"
+
+          if [ $OLD_EXIT -ne 0 ] || [ $NEW_EXIT -ne 0 ]; then
+            echo ""
+            echo "PCC validation failed. Please contact Rishab Prasad (riprasad@redhat.com) for assistance."
+            cd main && git checkout HEAD -- . && cd ..
+            exit 1
+          fi
 
       - name: Push latest PCC Cache
-        if: ${{ steps.check-if-pcc-cache-valid.outputs.PCC_CACHE_VALID == 'NO' }}
-        uses: actions-js/push@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: main
-          message: "Regeneratd the PCC Cache"
-          repository: ${{ env.GITHUB_ORG }}/RHOAI-Build-Config
-          directory: main
-          author_name: Openshift-AI DevOps
-          author_email: openshift-ai-devops@redhat.com
+        id: push-pcc-cache
+        if: ${{ steps.check-pcc-changes.outputs.pcc_catalogs_changed == 'true' }}
+        working-directory: main
+        run: |
+          git config user.name "Openshift-AI DevOps"
+          git config user.email "openshift-ai-devops@redhat.com"
+          git commit -m "Regenerated the PCC Cache" -m "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" && git push origin main
 
 
       - name: Process FBC Fragment
@@ -311,14 +349,34 @@ jobs:
         env:
           BRANCH: ${{ steps.get_branch.outputs.branch }}
         run: |
-          #Declare basic variables
           BUILD_CONFIG_PATH=${BRANCH}/config/build-config.yaml
           SHIPPED_RHOAI_VERSIONS_PATH=main/pcc/shipped_rhoai_versions_granular.txt
           CATALOG_FOLDER_PATH=${BRANCH}/catalog
-          GLOBAL_CONFIG_PATH=main/config/config.yaml
 
-          #Validate Catalogs
-          python3 utils/utils/validators/catalog_validator.py -op validate-catalogs --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${CATALOG_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ${GLOBAL_CONFIG_PATH}
+          # --- Old validator (legacy config) ---
+          GLOBAL_CONFIG_PATH=main/config/config.yaml
+          echo "=== Running OLD catalog validator with config.yaml ==="
+          python3 utils/utils/validators/catalog_validator.py -op validate-catalogs --build-config-path ${BUILD_CONFIG_PATH} --catalog-folder-path ${CATALOG_FOLDER_PATH} --shipped-rhoai-versions-path ${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ${GLOBAL_CONFIG_PATH} && OLD_EXIT=0 || OLD_EXIT=$?
+
+          # --- New validator (range-based config, testing phase) ---
+          # See: https://github.com/red-hat-data-services/RHOAI-Konflux-Automation/pull/49
+          NEW_GLOBAL_CONFIG_PATH=main/config/new-config.yaml
+          echo ""
+          echo "=== Running NEW catalog validator with new-config.yaml ==="
+          pushd utils/utils/processors
+          python3 -m validator.catalog_validator -op validate-catalogs --build-config-path ../../../${BUILD_CONFIG_PATH} --catalog-folder-path ../../../${CATALOG_FOLDER_PATH} --shipped-rhoai-versions-path ../../../${SHIPPED_RHOAI_VERSIONS_PATH} --global-config-path ../../../${NEW_GLOBAL_CONFIG_PATH} && NEW_EXIT=0 || NEW_EXIT=$?
+          popd
+
+          echo ""
+          echo "=== Catalog Validation Summary ==="
+          echo "OLD validator: $([ $OLD_EXIT -eq 0 ] && echo 'PASSED' || echo 'FAILED')"
+          echo "NEW validator: $([ $NEW_EXIT -eq 0 ] && echo 'PASSED' || echo 'FAILED')"
+
+          if [ $OLD_EXIT -ne 0 ] || [ $NEW_EXIT -ne 0 ]; then
+            echo ""
+            echo "Catalog validation failed. Please contact Rishab Prasad (riprasad@redhat.com) for assistance."
+            exit 1
+          fi
 
 
       - name: Commit and push the changes to release branch


### PR DESCRIPTION
## Summary

Supersedes [#29535](https://github.com/red-hat-data-services/RHOAI-Build-Config/pull/29535).

This PR fixes partial PCC updates by reordering the workflow to validate before committing, and adds the new range-based catalog validator to run in parallel with the old one. The new validator has major bug fixes and improvements:

- https://github.com/red-hat-data-services/RHOAI-Konflux-Automation/pull/36
- https://github.com/red-hat-data-services/RHOAI-Konflux-Automation/pull/49

### Root Cause

The reason partial PCC updates went undetected was a bug in the old catalog validator's `is_latest_ea()` check that silently skipped missing GA bundles. That bug has been fixed in the below PRs:

- [RHOAI-Konflux-Automation PR #50](https://github.com/red-hat-data-services/RHOAI-Konflux-Automation/pull/50) — Validator fix
- [RHOAI-Build-Config PR #29743](https://github.com/red-hat-data-services/RHOAI-Build-Config/pull/29743) — Config fix

### Issues with [#29535](https://github.com/red-hat-data-services/RHOAI-Build-Config/pull/29535)'s approach

The consistency check introduced in [#29535](https://github.com/red-hat-data-services/RHOAI-Build-Config/pull/29535) has a flaw. It greps for new versions in ALL catalog files, but not every version is expected in every OCP catalog.

Example 1: `2.25.10` just shipped. The check greps all 9 catalog files (v4.14 through v4.22):

- `catalog-v4.19.yaml` — contains `rhods-operator.2.25.10` ✓
- `catalog-v4.20.yaml` — contains `rhods-operator.2.25.10` ✓
- `catalog-v4.21.yaml` — missing `rhods-operator.2.25.10` ✗ (index lag)
- `catalog-v4.14.yaml` through `catalog-v4.18.yaml` — will never have `2.25.10` (older OCP versions don't carry newer 2.25.x releases), so the check always flags them as inconsistent

Example 2: `3.4.3` just shipped. 3.x bundles are only published to OCP >= v4.19, so `catalog-v4.14.yaml` through `catalog-v4.18.yaml` will never have it — again flagged as inconsistent every time.

In both cases the check would never commit the versions file. Handling these rules correctly in a shell script would mean duplicating logic that the validator already has, adding unnecessary complexity and maintenance overhead.

### Proposed Fix

Instead, we reorder the workflow so PCC validation runs before the commit:

1. Regenerate PCC catalogs
2. Stage and check if any catalog files changed
3. Validate PCC (only if catalogs changed)
4. Commit and push (only if validation passed)

If indexes haven't fully caught up, the validator catches the missing bundles, nothing gets committed, and the next run retries cleanly. This is simpler than partial-commit logic and reuses the validator that already understands which bundles are expected in which catalogs.

### New validator (testing phase)

Both PCC and catalog validation steps now run the new range-based validator alongside the old one. Both must pass. Once validated over the next month, the old validator will be removed.

Applied to both `process-fbc-fragment.yaml` and `trigger-nightly-fbc-build.yaml`.
