### PR TITLE
Add odh-spark-operator-module to bundle relatedImages

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -212,6 +212,8 @@ ARG ODH_RHOAI_MCP_GIT_URL=
 ARG ODH_RHOAI_MCP_GIT_COMMIT=
 ARG ODH_WORKBENCH_JUPYTER_BASELINE_CPU_PY312_GIT_URL=
 ARG ODH_WORKBENCH_JUPYTER_BASELINE_CPU_PY312_GIT_COMMIT=
+ARG ODH_SPARK_OPERATOR_MODULE_GIT_URL=
+ARG ODH_SPARK_OPERATOR_MODULE_GIT_COMMIT=
 
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
@@ -436,7 +438,9 @@ LABEL \
       odh-rhoai-mcp.git.url="${ODH_RHOAI_MCP_GIT_URL}" \
       odh-rhoai-mcp.git.commit="${ODH_RHOAI_MCP_GIT_COMMIT}" \
       odh-workbench-jupyter-baseline-cpu-py312.git.url="${ODH_WORKBENCH_JUPYTER_BASELINE_CPU_PY312_GIT_URL}" \
-      odh-workbench-jupyter-baseline-cpu-py312.git.commit="${ODH_WORKBENCH_JUPYTER_BASELINE_CPU_PY312_GIT_COMMIT}"
+      odh-workbench-jupyter-baseline-cpu-py312.git.commit="${ODH_WORKBENCH_JUPYTER_BASELINE_CPU_PY312_GIT_COMMIT}" \
+      odh-spark-operator-module.git.url="${ODH_SPARK_OPERATOR_MODULE_GIT_URL}" \
+      odh-spark-operator-module.git.commit="${ODH_SPARK_OPERATOR_MODULE_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -235,6 +235,8 @@ patch:
       value: quay.io/rhoai/odh-rhoai-mcp-rhel9@sha256:985b3251644445cd5375d7deb2ae5d7853529b199ac10c1af9cb1d445ef539e3
     - name: RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_BASELINE_CPU_PY312_IMAGE
       value: quay.io/rhoai/odh-workbench-jupyter-baseline-cpu-py312-rhel9@sha256:9743405a176d755a63b7b9b90a7e5fa52fb0e30585ba9d9cd0328874f7a61fac
+    - name: RELATED_IMAGE_ODH_SPARK_OPERATOR_MODULE_IMAGE
+      value: quay.io/rhoai/odh-spark-operator-module-rhel9@sha256:ffdfd93b399240bf928ab75a01401701640c2526f817c2db8342b58b25233113
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -118,6 +118,7 @@ config:
         rhoai/odh-trustyai-service-py-rhel9: rhoai/odh-trustyai-service-py-rhel9
         rhoai/odh-rhoai-mcp-rhel9: rhoai/odh-rhoai-mcp-rhel9
         rhoai/odh-workbench-jupyter-baseline-cpu-py312-rhel9: rhoai/odh-workbench-jupyter-baseline-cpu-py312-rhel9
+        rhoai/odh-spark-operator-module-rhel9: rhoai/odh-spark-operator-module-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Add `odh-spark-operator-module` to the RHOAI bundle relatedImages and build-config.

**Changes:**
- `bundle/bundle-patch.yaml`: added `RELATED_IMAGE_ODH_SPARK_OPERATOR_MODULE_IMAGE`
- `bundle/Dockerfile`: added ARG and LABEL declarations
- `config/build-config.yaml`: added repo_mappings entry for `rhoai/odh-spark-operator-module-rhel9`

> **Note:** The image digest is a placeholder — update `bundle-patch.yaml` with the real digest before merging.

Jira: https://redhat.atlassian.net/browse/RHOAIENG-84385