### PR TITLE
Add odh-mod-arch-notebooks to bundle relatedImages

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -214,6 +214,8 @@ ARG ODH_WORKBENCH_JUPYTER_BASELINE_CPU_PY312_GIT_URL=
 ARG ODH_WORKBENCH_JUPYTER_BASELINE_CPU_PY312_GIT_COMMIT=
 ARG ODH_SPARK_OPERATOR_MODULE_GIT_URL=
 ARG ODH_SPARK_OPERATOR_MODULE_GIT_COMMIT=
+ARG ODH_MOD_ARCH_NOTEBOOKS_GIT_URL=
+ARG ODH_MOD_ARCH_NOTEBOOKS_GIT_COMMIT=
 
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
@@ -440,7 +442,9 @@ LABEL \
       odh-workbench-jupyter-baseline-cpu-py312.git.url="${ODH_WORKBENCH_JUPYTER_BASELINE_CPU_PY312_GIT_URL}" \
       odh-workbench-jupyter-baseline-cpu-py312.git.commit="${ODH_WORKBENCH_JUPYTER_BASELINE_CPU_PY312_GIT_COMMIT}" \
       odh-spark-operator-module.git.url="${ODH_SPARK_OPERATOR_MODULE_GIT_URL}" \
-      odh-spark-operator-module.git.commit="${ODH_SPARK_OPERATOR_MODULE_GIT_COMMIT}"
+      odh-spark-operator-module.git.commit="${ODH_SPARK_OPERATOR_MODULE_GIT_COMMIT}" \
+      odh-mod-arch-notebooks.git.url="${ODH_MOD_ARCH_NOTEBOOKS_GIT_URL}" \
+      odh-mod-arch-notebooks.git.commit="${ODH_MOD_ARCH_NOTEBOOKS_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -237,6 +237,8 @@ patch:
       value: quay.io/rhoai/odh-workbench-jupyter-baseline-cpu-py312-rhel9@sha256:9743405a176d755a63b7b9b90a7e5fa52fb0e30585ba9d9cd0328874f7a61fac
     - name: RELATED_IMAGE_ODH_SPARK_OPERATOR_MODULE_IMAGE
       value: quay.io/rhoai/odh-spark-operator-module-rhel9@sha256:ffdfd93b399240bf928ab75a01401701640c2526f817c2db8342b58b25233113
+    - name: RELATED_IMAGE_ODH_MOD_ARCH_NOTEBOOKS_IMAGE
+      value: quay.io/rhoai/odh-mod-arch-notebooks-rhel9@sha256:632e617a1cb7d2c792a6bd3c656dbfa4a1301b2900bdfd77891f04a99fab724c
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -119,6 +119,7 @@ config:
         rhoai/odh-rhoai-mcp-rhel9: rhoai/odh-rhoai-mcp-rhel9
         rhoai/odh-workbench-jupyter-baseline-cpu-py312-rhel9: rhoai/odh-workbench-jupyter-baseline-cpu-py312-rhel9
         rhoai/odh-spark-operator-module-rhel9: rhoai/odh-spark-operator-module-rhel9
+        rhoai/odh-mod-arch-notebooks-rhel9: rhoai/odh-mod-arch-notebooks-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds relatedImages entry for 'odh-mod-arch-notebooks' to bundle/bundle-patch.yaml.

Image: quay.io/rhoai/odh-mod-arch-notebooks-rhel9@sha256:632e617a1cb7d2c792a6bd3c656dbfa4a1301b2900bdfd77891f04a99fab724c
Jira: https://redhat.atlassian.net/browse/RHOAIENG-58837