### PR TITLE
Add odh-th-torch-{cpu,cuda,rocm}-py312 to bundle relatedImages

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -216,6 +216,12 @@ ARG ODH_SPARK_OPERATOR_MODULE_GIT_URL=
 ARG ODH_SPARK_OPERATOR_MODULE_GIT_COMMIT=
 ARG ODH_MOD_ARCH_NOTEBOOKS_GIT_URL=
 ARG ODH_MOD_ARCH_NOTEBOOKS_GIT_COMMIT=
+ARG ODH_TH_TORCH_CPU_PY312_GIT_URL=
+ARG ODH_TH_TORCH_CPU_PY312_GIT_COMMIT=
+ARG ODH_TH_TORCH_CUDA_PY312_GIT_URL=
+ARG ODH_TH_TORCH_CUDA_PY312_GIT_COMMIT=
+ARG ODH_TH_TORCH_ROCM_PY312_GIT_URL=
+ARG ODH_TH_TORCH_ROCM_PY312_GIT_COMMIT=
 
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
@@ -444,7 +450,13 @@ LABEL \
       odh-spark-operator-module.git.url="${ODH_SPARK_OPERATOR_MODULE_GIT_URL}" \
       odh-spark-operator-module.git.commit="${ODH_SPARK_OPERATOR_MODULE_GIT_COMMIT}" \
       odh-mod-arch-notebooks.git.url="${ODH_MOD_ARCH_NOTEBOOKS_GIT_URL}" \
-      odh-mod-arch-notebooks.git.commit="${ODH_MOD_ARCH_NOTEBOOKS_GIT_COMMIT}"
+      odh-mod-arch-notebooks.git.commit="${ODH_MOD_ARCH_NOTEBOOKS_GIT_COMMIT}" \
+      odh-th-torch-cpu-py312.git.url="${ODH_TH_TORCH_CPU_PY312_GIT_URL}" \
+      odh-th-torch-cpu-py312.git.commit="${ODH_TH_TORCH_CPU_PY312_GIT_COMMIT}" \
+      odh-th-torch-cuda-py312.git.url="${ODH_TH_TORCH_CUDA_PY312_GIT_URL}" \
+      odh-th-torch-cuda-py312.git.commit="${ODH_TH_TORCH_CUDA_PY312_GIT_COMMIT}" \
+      odh-th-torch-rocm-py312.git.url="${ODH_TH_TORCH_ROCM_PY312_GIT_URL}" \
+      odh-th-torch-rocm-py312.git.commit="${ODH_TH_TORCH_ROCM_PY312_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -239,6 +239,12 @@ patch:
       value: quay.io/rhoai/odh-spark-operator-module-rhel9@sha256:ffdfd93b399240bf928ab75a01401701640c2526f817c2db8342b58b25233113
     - name: RELATED_IMAGE_ODH_MOD_ARCH_NOTEBOOKS_IMAGE
       value: quay.io/rhoai/odh-mod-arch-notebooks-rhel9@sha256:632e617a1cb7d2c792a6bd3c656dbfa4a1301b2900bdfd77891f04a99fab724c
+    - name: RELATED_IMAGE_ODH_TH_TORCH_CPU_PY312_IMAGE
+      value: quay.io/rhoai/odh-th-torch-cpu-py312-rhel9@sha256:aa97bb065e63c8b865c846744a765806a8a70b495b7da4f2d03c44ca111e6186
+    - name: RELATED_IMAGE_ODH_TH_TORCH_CUDA_PY312_IMAGE
+      value: quay.io/rhoai/odh-th-torch-cuda-py312-rhel9@sha256:c0754fc4d3245e5c1e3bfe85321ba827df5950f3dcd3ce6fd84572b90805245b
+    - name: RELATED_IMAGE_ODH_TH_TORCH_ROCM_PY312_IMAGE
+      value: quay.io/rhoai/odh-th-torch-rocm-py312-rhel9@sha256:f8b5bbd5bb591cede282a0fbee2f9a8cf599dc8e26558ab0a22a8d8f3eb83861
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -120,6 +120,9 @@ config:
         rhoai/odh-workbench-jupyter-baseline-cpu-py312-rhel9: rhoai/odh-workbench-jupyter-baseline-cpu-py312-rhel9
         rhoai/odh-spark-operator-module-rhel9: rhoai/odh-spark-operator-module-rhel9
         rhoai/odh-mod-arch-notebooks-rhel9: rhoai/odh-mod-arch-notebooks-rhel9
+        rhoai/odh-th-torch-cpu-py312-rhel9: rhoai/odh-th-torch-cpu-py312-rhel9
+        rhoai/odh-th-torch-cuda-py312-rhel9: rhoai/odh-th-torch-cuda-py312-rhel9
+        rhoai/odh-th-torch-rocm-py312-rhel9: rhoai/odh-th-torch-rocm-py312-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds relatedImages, build-config repo_mappings, and Dockerfile git labels for Training Hub torch images (cpu/cuda/rocm py312) to the 3.6-ea.2 bundle.

Same change as https://github.com/red-hat-data-services/RHOAI-Build-Config/pull/29938 (3.6-ea.1). relatedImages digests start from the 3.5 GA published images.

Jira:
- https://redhat.atlassian.net/browse/RHOAIENG-83765 (odh-th-torch-cpu-py312)
- https://redhat.atlassian.net/browse/RHOAIENG-83767 (odh-th-torch-cuda-py312)
- https://redhat.atlassian.net/browse/RHOAIENG-83768 (odh-th-torch-rocm-py312)