### PR TITLE
fix(kserve): add RELATED_IMAGE_ODH_KSERVE_AUTOGLUON_SERVER_IMAGE to RHAI helm values (rhoai-3.6-ea.2)

### DIFF
--- a/helm/xks-values-patch.yaml
+++ b/helm/xks-values-patch.yaml
@@ -75,6 +75,8 @@ rhaiOperator:
       value: "registry.redhat.io/rhoai/odh-kserve-module-operator-rhel9@sha256:d3c708777077ae74ee184d1f7dc10b5b05ab6140ab0f9cb829a244833b6eba6e"
     - name: RELATED_IMAGE_ODH_GUARDRAILS_DETECTOR_HUGGINGFACE_RUNTIME_IMAGE
       value: "registry.redhat.io/rhoai/odh-guardrails-detector-huggingface-runtime-rhel9@sha256:d5dc7b3156584bc96ac4f089e7e82ac4ad231e6d2385853a0fff8e237cad889e"
+    - name: RELATED_IMAGE_ODH_KSERVE_AUTOGLUON_SERVER_IMAGE
+      value: "registry.redhat.io/rhoai/odh-kserve-autogluon-server-rhel9@sha256:391c698fc7f7a3036b03308ef5765f60816220a7449576842596de34763e5f14"
     - name: RELATED_IMAGE_ODH_MLSERVER_IMAGE
       value: "registry.redhat.io/rhoai/odh-mlserver-rhel9@sha256:457212814dcaf5502bf1d96c21ec7d445b7f362a688879d0eed8639bd9f53bcd"
     - name: RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE


### PR DESCRIPTION
## Problem
`RELATED_IMAGE_ODH_KSERVE_AUTOGLUON_SERVER_IMAGE` is missing from the RHAI-on-xks helm chart values-patch on the rhoai-3.6 lineage. Autogluon serving was fixed in 3.5 GA and regressed in 3.6.

## Root cause
The RelatedImage propagates naturally into the operator CSV / `bundle/bundle-patch.yaml` (via the operator + `make bundle`), and it is present there on 3.6. But `helm/xks-values-patch.yaml` is a **downstream-only, hand-curated** list with **no upstream feeder** — it is only carried forward at release-branch cut time. The 3.6 lineage was cut from rhoai-3.5 on 2026-07-24, **before** the 3.5 fix (#28628, merged 2026-08-05) landed, so the entry was never carried forward.

Consequence: the operator bundle declares the RelatedImage but the helm-install path never sets the env, so autogluon has no image on helm-deployed 3.6.

## Fix
Add the entry to `helm/xks-values-patch.yaml`.

ea.2 does not inherit the ea.1 fix (parallel branch, cut from ea.1), so it needs the entry directly. Digest matches the current `rhods-operator.3.6.0-ea.1` bundle in [`catalog/v4.20/rhods-operator/catalog.yaml`](https://github.com/red-hat-data-services/RHOAI-Build-Config/blob/rhoai-3.6-ea.2/catalog/v4.20/rhods-operator/catalog.yaml) on this branch (`sha256:391c698fc7f7a3036b03308ef5765f60816220a7449576842596de34763e5f14`).

## How the digest was derived
1. The helm patch uses `registry.redhat.io` digests, which differ from the `quay.io` digests in `bundle/bundle-patch.yaml` (mirroring re-pushes the image, so the sha changes). The bundle-patch value cannot be reused.
2. The authoritative `registry.redhat.io` source is the branch FBC catalog: `catalog/v4.20/rhods-operator/catalog.yaml`.
3. In that catalog, the `beta` channel head bundle is `rhods-operator.3.6.0-ea.1` (the only 3.6 bundle). Its `relatedImages` entry `odh_kserve_autogluon_server_image` is the digest used here.
4. Disambiguation: the catalog also lists autogluon digests `6d55374e` and `2ed9af6a`, but those belong only to old `3.4.x` bundles, not the head — so they were not used.

Note: this digest is not yet pullable via skopeo (pre-GA, not mirrored to public registry.redhat.io), but the catalog is the release source of truth; konflux resolves the eventual mirror digest, so matching the catalog is correct. The Openshift-AI DevOps bot maintains the digest going forward.

## Related
- kserve-module miss (separate, real upstream gap): opendatahub-io/kserve#1855 still open — must merge + cherry-pick so it stops regressing.
- Operator/bundle side already correct.