### PR TITLE
Remove odh-trustyai-service from bundle relatedImages (offboarding)

### DIFF
--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -221,8 +221,6 @@ patch:
       value: quay.io/rhoai/odh-feast-module-operator-rhel9@sha256:859467aba2e2c1f4b3971fe94f03476e0a2163bd975ac212f168da4d8a337be9
     - name: RELATED_IMAGE_ODH_MLSERVER_CUDA_IMAGE
       value: quay.io/rhoai/odh-mlserver-cuda-rhel9@sha256:40e74a1b44e0252ba3986fc01102dcff0e7f300c564cba0b04e4a3d0bc95df50
-    - name: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE
-      value: quay.io/rhoai/odh-trustyai-service-rhel9@sha256:f4f91c346cc14c4fae366db7c54dfe25a4730f0caed47a2216b9fe3d51da0c4c
     - name: RELATED_IMAGE_ODH_OGX_MODULE_OPERATOR_IMAGE
       value: quay.io/rhoai/odh-ogx-module-operator-rhel9@sha256:f57c8ebb196b6f3b0ff7bdc9fae8de0950f3022f8930902d928c8196bac5e101
     - name: RELATED_IMAGE_ODH_TRAINER_OPERATOR_IMAGE

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -10,7 +10,6 @@ config:
         rhoai/odh-kf-notebook-controller-rhel9: rhoai/odh-kf-notebook-controller-rhel9
         rhoai/odh-data-science-pipelines-operator-controller-rhel9: rhoai/odh-data-science-pipelines-operator-controller-rhel9
         rhoai/odh-model-controller-rhel9: rhoai/odh-model-controller-rhel9
-        rhoai/odh-trustyai-service-rhel9: rhoai/odh-trustyai-service-rhel9
         rhoai/odh-trustyai-service-operator-rhel9: rhoai/odh-trustyai-service-operator-rhel9
         rhoai/odh-dashboard-rhel9: rhoai/odh-dashboard-rhel9
         rhoai/odh-data-science-pipelines-argo-workflowcontroller-rhel9: rhoai/odh-data-science-pipelines-argo-workflowcontroller-rhel9


### PR DESCRIPTION
Removes relatedImages entry for 'odh-trustyai-service' from bundle/bundle-patch.yaml.

Jira: https://redhat.atlassian.net/browse/RHOAIENG-85598