### PR TITLE
Add odh-workbenches-controller to bundle relatedImages

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -222,6 +222,8 @@ ARG ODH_TH_TORCH_CUDA_PY312_GIT_URL=
 ARG ODH_TH_TORCH_CUDA_PY312_GIT_COMMIT=
 ARG ODH_TH_TORCH_ROCM_PY312_GIT_URL=
 ARG ODH_TH_TORCH_ROCM_PY312_GIT_COMMIT=
+ARG ODH_WORKBENCHES_CONTROLLER_GIT_URL=
+ARG ODH_WORKBENCHES_CONTROLLER_GIT_COMMIT=
 
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
@@ -456,7 +458,9 @@ LABEL \
       odh-th-torch-cuda-py312.git.url="${ODH_TH_TORCH_CUDA_PY312_GIT_URL}" \
       odh-th-torch-cuda-py312.git.commit="${ODH_TH_TORCH_CUDA_PY312_GIT_COMMIT}" \
       odh-th-torch-rocm-py312.git.url="${ODH_TH_TORCH_ROCM_PY312_GIT_URL}" \
-      odh-th-torch-rocm-py312.git.commit="${ODH_TH_TORCH_ROCM_PY312_GIT_COMMIT}"
+      odh-th-torch-rocm-py312.git.commit="${ODH_TH_TORCH_ROCM_PY312_GIT_COMMIT}" \
+      odh-workbenches-controller.git.url="${ODH_WORKBENCHES_CONTROLLER_GIT_URL}" \
+      odh-workbenches-controller.git.commit="${ODH_WORKBENCHES_CONTROLLER_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -245,6 +245,8 @@ patch:
       value: quay.io/rhoai/odh-th-torch-cuda-py312-rhel9@sha256:c0754fc4d3245e5c1e3bfe85321ba827df5950f3dcd3ce6fd84572b90805245b
     - name: RELATED_IMAGE_ODH_TH_TORCH_ROCM_PY312_IMAGE
       value: quay.io/rhoai/odh-th-torch-rocm-py312-rhel9@sha256:f8b5bbd5bb591cede282a0fbee2f9a8cf599dc8e26558ab0a22a8d8f3eb83861
+    - name: RELATED_IMAGE_ODH_WORKBENCHES_CONTROLLER_IMAGE
+      value: quay.io/rhoai/odh-workbenches-controller-rhel9@sha256:b1448088332e92516932226dde190cddc58e424be26520516bdbcf5c7cf5d145
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -123,6 +123,7 @@ config:
         rhoai/odh-th-torch-cpu-py312-rhel9: rhoai/odh-th-torch-cpu-py312-rhel9
         rhoai/odh-th-torch-cuda-py312-rhel9: rhoai/odh-th-torch-cuda-py312-rhel9
         rhoai/odh-th-torch-rocm-py312-rhel9: rhoai/odh-th-torch-rocm-py312-rhel9
+        rhoai/odh-workbenches-controller-rhel9: rhoai/odh-workbenches-controller-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds relatedImages entry for 'odh-workbenches-controller' to bundle/bundle-patch.yaml.

Image: quay.io/rhoai/odh-workbenches-controller-rhel9@sha256:b1448088332e92516932226dde190cddc58e424be26520516bdbcf5c7cf5d145
Jira: https://redhat.atlassian.net/browse/RHOAIENG-84638