### PR TITLE
Remove odh-workbench-jupyter-baseline-cpu-py312 from bundle (offboarding 3.6-ea.1)

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -210,8 +210,6 @@ ARG ODH_TRUSTYAI_SERVICE_PY_GIT_URL=
 ARG ODH_TRUSTYAI_SERVICE_PY_GIT_COMMIT=
 ARG ODH_RHOAI_MCP_GIT_URL=
 ARG ODH_RHOAI_MCP_GIT_COMMIT=
-ARG ODH_WORKBENCH_JUPYTER_BASELINE_CPU_PY312_GIT_URL=
-ARG ODH_WORKBENCH_JUPYTER_BASELINE_CPU_PY312_GIT_COMMIT=
 ARG ODH_SPARK_OPERATOR_MODULE_GIT_URL=
 ARG ODH_SPARK_OPERATOR_MODULE_GIT_COMMIT=
 ARG ODH_MOD_ARCH_NOTEBOOKS_GIT_URL=
@@ -447,8 +445,6 @@ LABEL \
       odh-trustyai-service-py.git.commit="${ODH_TRUSTYAI_SERVICE_PY_GIT_COMMIT}" \
       odh-rhoai-mcp.git.url="${ODH_RHOAI_MCP_GIT_URL}" \
       odh-rhoai-mcp.git.commit="${ODH_RHOAI_MCP_GIT_COMMIT}" \
-      odh-workbench-jupyter-baseline-cpu-py312.git.url="${ODH_WORKBENCH_JUPYTER_BASELINE_CPU_PY312_GIT_URL}" \
-      odh-workbench-jupyter-baseline-cpu-py312.git.commit="${ODH_WORKBENCH_JUPYTER_BASELINE_CPU_PY312_GIT_COMMIT}" \
       odh-spark-operator-module.git.url="${ODH_SPARK_OPERATOR_MODULE_GIT_URL}" \
       odh-spark-operator-module.git.commit="${ODH_SPARK_OPERATOR_MODULE_GIT_COMMIT}" \
       odh-mod-arch-notebooks.git.url="${ODH_MOD_ARCH_NOTEBOOKS_GIT_URL}" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -233,8 +233,6 @@ patch:
       value: quay.io/rhoai/odh-trustyai-service-py-rhel9@sha256:9cec24286fe4a681b7ec82b08e39b76548dcf3bce98f1f82bec6932be3401aaf
     - name: RELATED_IMAGE_ODH_RHOAI_MCP_IMAGE
       value: quay.io/rhoai/odh-rhoai-mcp-rhel9@sha256:985b3251644445cd5375d7deb2ae5d7853529b199ac10c1af9cb1d445ef539e3
-    - name: RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_BASELINE_CPU_PY312_IMAGE
-      value: quay.io/rhoai/odh-workbench-jupyter-baseline-cpu-py312-rhel9@sha256:9743405a176d755a63b7b9b90a7e5fa52fb0e30585ba9d9cd0328874f7a61fac
     - name: RELATED_IMAGE_ODH_SPARK_OPERATOR_MODULE_IMAGE
       value: quay.io/rhoai/odh-spark-operator-module-rhel9@sha256:ffdfd93b399240bf928ab75a01401701640c2526f817c2db8342b58b25233113
     - name: RELATED_IMAGE_ODH_MOD_ARCH_NOTEBOOKS_IMAGE

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -117,7 +117,6 @@ config:
         rhoai/odh-observability-rhel9: rhoai/odh-observability-rhel9
         rhoai/odh-trustyai-service-py-rhel9: rhoai/odh-trustyai-service-py-rhel9
         rhoai/odh-rhoai-mcp-rhel9: rhoai/odh-rhoai-mcp-rhel9
-        rhoai/odh-workbench-jupyter-baseline-cpu-py312-rhel9: rhoai/odh-workbench-jupyter-baseline-cpu-py312-rhel9
         rhoai/odh-spark-operator-module-rhel9: rhoai/odh-spark-operator-module-rhel9
         rhoai/odh-mod-arch-notebooks-rhel9: rhoai/odh-mod-arch-notebooks-rhel9
         rhoai/odh-th-torch-cpu-py312-rhel9: rhoai/odh-th-torch-cpu-py312-rhel9


### PR DESCRIPTION
Offboards `odh-workbench-jupyter-baseline-cpu-py312` from the RHOAI **3.6-ea.1** bundle.

Removes the `relatedImages` entry (`bundle-patch.yaml`), the build-config repo mapping, and the Dockerfile ARG/LABEL entries. CSV/catalog files regenerate from the bundle build (same convention as the trustyai offboard PR #26111). The `rhoai-3.6-ea.2` branch is separate and unaffected.

Jira: https://redhat.atlassian.net/browse/RHOAIENG-86347