### PR TITLE
fix: switch vLLM images to prod registry with stream tags

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -36,16 +36,15 @@ additionalImages:
     value: "registry.redhat.io/cluster-observability-operator/perses-rhel9:1.5.0-1782839109@sha256:a811b9345d884ba1c575584bec9be1d2a237902164a99887458a82d07e7c2376"
   - name: RELATED_IMAGE_NGINX_126_IMAGE
     value: "registry.redhat.io/ubi9/nginx-126:latest@sha256:45e1b68d39cb7e9f8a89f20ba0ab0c6cc7ade04e25d51d14ae75fa77b5320518"
-  # RHAII images are currently in stage registry, but will be promoted to production registry soon. Using stage registry for now to allow testing with the latest images. Once the images are promoted to production registry, the image references will be updated to use registry.redhat.io instead of registry.stage.redhat.io
   - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
-    value: "registry.redhat.io/rhaii/vllm-gaudi-rhel9:3.4.0-1777444681@sha256:71008b2151586551ec0969ffc5b175f726ed6f6bebee29cdc289549e216609bc"
+    value: "registry.redhat.io/rhaii/vllm-gaudi-rhel9:3.4@sha256:71008b2151586551ec0969ffc5b175f726ed6f6bebee29cdc289549e216609bc"
   - name: RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-cuda-rhel9:3.5.0-1786533823@sha256:ba060ec145e1b7ac3a3b25b89fc75f7d146746156990ff5858235eaa9d158e32"
+    value: "registry.redhat.io/rhaii/vllm-cuda-rhel9:3.4@sha256:dd65c7ed88a9369b962f1299ed19c6c8819ff0a64595c10e32f1e82ab0750e27"
   - name: RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-rocm-rhel9:3.5.0-1786491157@sha256:3c5d2ead2ec5002060eca315b69fc2970214208e9dfbc8eb4aa3a03ef875f706"
+    value: "registry.redhat.io/rhaii/vllm-rocm-rhel9:3.4@sha256:2c885ea9911d06623ca0b6b17757a76ccf875eef655d631fdc6730878aa5eec0"
   - name: RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-spyre-rhel9:3.5.0-1786473960@sha256:4bfee184fabace5020cfb2d9fa8c581ecf3d69e07583a0f333ea518604d5fc74"
+    value: "registry.redhat.io/rhaii/vllm-spyre-rhel9:3.4@sha256:17df7c3c52508a990bc5bdc75ae78284e15d17d0e83a15dadf3ec2787cfc6ab2"
   - name: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE
-    value: "registry.stage.redhat.io/rhaii/vllm-cpu-rhel9:3.5.0-1786546771@sha256:578e9946e60a14596185937f6a083c1d42f3cff343b18648090b9ac80691d2e0"
+    value: "registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4@sha256:5d20d59ed8af657eb23e54a6a2c5b2520791d8544c14e8e83061fae74f36e3e3"
   - name: RELATED_IMAGE_UBI_MINIMAL_IMAGE
     value: "registry.redhat.io/ubi9/ubi-minimal:9.7@sha256:907b68736aa798b2d38255b7aa070b2a70acb90803864a40f05d0ec47556ddd0"


### PR DESCRIPTION
## Summary

- Replaces incorrect `3.5.0` vLLM images (from `registry.stage.redhat.io`) with `registry.redhat.io` using the `3.4` stream tag
- All 5 vLLM images (gaudi, cuda, rocm, spyre, cpu) now point to the correct `3.4.x` production builds
- With stream tags, Renovate will automatically pick up new digests when future `3.4.x` builds are published — no manual image updates needed for z-streams

## Changes

| Image | Before | After |
|-------|--------|-------|
| vllm-gaudi | `registry.redhat.io/..:3.4.0-1777444681` | `registry.redhat.io/..:3.4` |
| vllm-cuda | `registry.stage.redhat.io/..:3.5.0-...` | `registry.redhat.io/..:3.4` |
| vllm-rocm | `registry.stage.redhat.io/..:3.5.0-...` | `registry.redhat.io/..:3.4` |
| vllm-spyre | `registry.stage.redhat.io/..:3.5.0-...` | `registry.redhat.io/..:3.4` |
| vllm-cpu | `registry.stage.redhat.io/..:3.5.0-...` | `registry.redhat.io/..:3.4` |

## Dependencies

- **Merge first:** [konflux-central #3248](https://github.com/red-hat-data-services/konflux-central/pull/3248) — fixes the Renovate config to block cross-stream bumps. Without this, Renovate may re-bump these images to `3.5.0`.

## Test plan

- [ ] Verify all 5 digests resolve correctly on `registry.redhat.io` with the `3.4` tag
- [ ] After merging both PRs, run Renovate dry run on `rhoai-3.4` to confirm correct behavior
- [ ] Once 3.4.4 images are published to prod, verify Renovate auto-updates digests

Ref: [RHOAIENG-83616](https://redhat.atlassian.net/browse/RHOAIENG-83616)