### PR TITLE
fix: switch vLLM images to stream tags (rhoai-3.3)

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -29,14 +29,14 @@ additionalImages:
   - name: RELATED_IMAGE_OSE_PROM_LABEL_PROXY_IMAGE
     value: "registry.redhat.io/openshift4/ose-prom-label-proxy-rhel9:v4.20@sha256:03fa164d2d5672318ef58b2b0f1df3524ac6b9ecb1489971f4315dc4f54d17ed"
   - name: RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.3.5-1782352847@sha256:e6a64e3e4de7c7f585601379ecea204d2d045bb113331edd4b3799f52b8e92b7"
+    value: "registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.3@sha256:e6a64e3e4de7c7f585601379ecea204d2d045bb113331edd4b3799f52b8e92b7"
   - name: RELATED_IMAGE_RHAIIS_VLLM_ROCM_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-rocm-rhel9:3.3.5-1782353093@sha256:1b1f0b8673a2668040fc5362bafc0b7695850f886210801e7d45889aa2f354b9"
+    value: "registry.redhat.io/rhaiis/vllm-rocm-rhel9:3.3@sha256:1b1f0b8673a2668040fc5362bafc0b7695850f886210801e7d45889aa2f354b9"
   - name: RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.3.5-1782352919@sha256:45e641b46b4e3413057220a410e7397faaa4755aa391c7a096906e8a08fd6e9c"
+    value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.3@sha256:45e641b46b4e3413057220a410e7397faaa4755aa391c7a096906e8a08fd6e9c"
   - name: RELATED_IMAGE_ODH_PYTHON_312_IMAGE
     value: "registry.redhat.io/ubi9/python-312:latest@sha256:74689dbf82199b2099873d81941f8c2996edfb1cefe544f115f46be06c30e093"
   - name: RELATED_IMAGE_PERSES_IMAGE
     value: "registry.redhat.io/cluster-observability-operator/perses-rhel9:1.5.0-1782839109@sha256:a811b9345d884ba1c575584bec9be1d2a237902164a99887458a82d07e7c2376"
   - name: RELATED_IMAGE_RHAIIS_VLLM_CPU_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-cpu-rhel9:3.3.0-1771459339@sha256:f05e773647dddd37ec6c2215cb14bec87e4ab5a7d37f2e110d16cd92355427d3"
+    value: "registry.redhat.io/rhaiis/vllm-cpu-rhel9:3.3@sha256:f05e773647dddd37ec6c2215cb14bec87e4ab5a7d37f2e110d16cd92355427d3"


### PR DESCRIPTION
## Summary

- Replaces pinned build tags (e.g. `3.3.5-1782352847`) with the `3.3` stream tag for all 4 vLLM images (cuda, rocm, spyre, cpu)
- Enables Renovate to auto-update digests when new z-stream builds are published
- Images remain on `registry.redhat.io/rhaiis/` (already on prod registry)

## Test plan

- [ ] Verify digests resolve correctly with the `3.3` stream tag
- [ ] After merge, confirm Renovate tracks digest changes

Ref: [RHOAIENG-87029](https://redhat.atlassian.net/browse/RHOAIENG-87029)