### PR TITLE
fix: correct vLLM images to 3.2.2 on rhoai-2.25

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -23,6 +23,6 @@ additionalImages:
   - name: RELATED_IMAGE_OSE_CLI_IMAGE
     value: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.18@sha256:534bc47a4db1538509731689b2e45698a51192c7eb532637e98f814c6c7f1763"
   - name: RELATED_IMAGE_RHAIIS_VLLM_CUDA_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.3.5-1782352847@sha256:d869df392f711437069fa0c808428694c945d4b79e5dd77c718f68403cd71629"
+    value: "registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.2@sha256:094db84a1da5e8a575d0c9eade114fa30f4a2061064a338e3e032f3578f8082a"
   - name: RELATED_IMAGE_RHAIIS_VLLM_SPYRE_IMAGE
-    value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.3.5-1782352919@sha256:45e641b46b4e3413057220a410e7397faaa4755aa391c7a096906e8a08fd6e9c"
+    value: "registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.2@sha256:80ae3e435a5be2c1f117f36599103ab05357917dd6e37f0df6613cb3ac2c13ea"


### PR DESCRIPTION
## Summary

RHOAI 2.25 maps to RHAII 3.2.2-xx. The branch incorrectly has 3.3.5 vLLM images. This PR replaces them with the latest 3.2.2 builds from registry.redhat.io.

Renovate will handle future build-timestamp bumps (3.2.2-<old> → 3.2.2-<new>) via the existing vLLM packageRule with regex versioning.

## Changes

| Image | Before | After |
|-------|--------|-------|
| vllm-cuda | `3.3.5-1782352847` | `3.2.2-1782951012` |
| vllm-spyre | `3.3.5-1782352919` | `3.2.2-1758739062` |

## Test plan

- [ ] Verify digests resolve correctly
- [ ] Confirm Renovate proposes build-timestamp bumps for 3.2.2 tags

Ref: [RHOAIENG-87033](https://redhat.atlassian.net/browse/RHOAIENG-87033)