### PR TITLE
fix: use build-specific tags for vLLM images (rhoai-3.4)

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -37,14 +37,14 @@ additionalImages:
   - name: RELATED_IMAGE_NGINX_126_IMAGE
     value: "registry.redhat.io/ubi9/nginx-126:latest@sha256:45e1b68d39cb7e9f8a89f20ba0ab0c6cc7ade04e25d51d14ae75fa77b5320518"
   - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
-    value: "registry.redhat.io/rhaii/vllm-gaudi-rhel9:3.4@sha256:71008b2151586551ec0969ffc5b175f726ed6f6bebee29cdc289549e216609bc"
+    value: "registry.redhat.io/rhaii/vllm-gaudi-rhel9:3.4.0-1777444681@sha256:71008b2151586551ec0969ffc5b175f726ed6f6bebee29cdc289549e216609bc"
   - name: RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE
-    value: "registry.redhat.io/rhaii/vllm-cuda-rhel9:3.4@sha256:dd65c7ed88a9369b962f1299ed19c6c8819ff0a64595c10e32f1e82ab0750e27"
+    value: "registry.redhat.io/rhaii/vllm-cuda-rhel9:3.4.4-1787151771@sha256:dd65c7ed88a9369b962f1299ed19c6c8819ff0a64595c10e32f1e82ab0750e27"
   - name: RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE
-    value: "registry.redhat.io/rhaii/vllm-rocm-rhel9:3.4@sha256:2c885ea9911d06623ca0b6b17757a76ccf875eef655d631fdc6730878aa5eec0"
+    value: "registry.redhat.io/rhaii/vllm-rocm-rhel9:3.4.4-1787151774@sha256:2c885ea9911d06623ca0b6b17757a76ccf875eef655d631fdc6730878aa5eec0"
   - name: RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE
-    value: "registry.redhat.io/rhaii/vllm-spyre-rhel9:3.4@sha256:17df7c3c52508a990bc5bdc75ae78284e15d17d0e83a15dadf3ec2787cfc6ab2"
+    value: "registry.redhat.io/rhaii/vllm-spyre-rhel9:3.4.4-1787151840@sha256:17df7c3c52508a990bc5bdc75ae78284e15d17d0e83a15dadf3ec2787cfc6ab2"
   - name: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE
-    value: "registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4@sha256:5d20d59ed8af657eb23e54a6a2c5b2520791d8544c14e8e83061fae74f36e3e3"
+    value: "registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.4-1787151769@sha256:5d20d59ed8af657eb23e54a6a2c5b2520791d8544c14e8e83061fae74f36e3e3"
   - name: RELATED_IMAGE_UBI_MINIMAL_IMAGE
     value: "registry.redhat.io/ubi9/ubi-minimal:9.7@sha256:907b68736aa798b2d38255b7aa070b2a70acb90803864a40f05d0ec47556ddd0"


### PR DESCRIPTION
## Summary

Switches vLLM images from floating `3.4` stream tags to build-specific tags (e.g. `3.4.4-1787151771`) for better traceability. The Renovate vLLM rule with regex versioning will handle bumping to newer build timestamps and patch versions automatically.

Follows up on #30245 which initially used stream tags — team agreed build-specific tags are preferred for visibility into which exact RHAII release is in the bundle.

## Changes

| Image | Before | After |
|-------|--------|-------|
| vllm-gaudi | `3.4` | `3.4.0-1777444681` |
| vllm-cuda | `3.4` | `3.4.4-1787151771` |
| vllm-rocm | `3.4` | `3.4.4-1787151774` |
| vllm-spyre | `3.4` | `3.4.4-1787151840` |
| vllm-cpu | `3.4` | `3.4.4-1787151769` |

Digests unchanged — same images, just explicit tags.

## Test plan

- [ ] Verify Renovate dry run correctly proposes build-number bumps for these tags

Ref: [RHOAIENG-87028](https://redhat.atlassian.net/browse/RHOAIENG-87028)