### PR TITLE
feat: add post-codefreeze-gatekeeper evaluation workflow

### DIFF
--- a/.github/workflows/post-codefreeze-gatekeeper.yaml
+++ b/.github/workflows/post-codefreeze-gatekeeper.yaml
@@ -1,0 +1,13 @@
+name: Post-Codefreeze Gatekeeper
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, labeled]
+    branches:
+      - 'rhoai-[0-9].[0-9]'
+      - 'rhoai-[0-9].[0-9][0-9]'
+jobs:
+  post-codefreeze-gate:
+    if: github.event.action != 'labeled' || github.event.label.name == 'run-gatekeeper'
+    uses: red-hat-data-services/devops-shared-resources/.github/workflows/post-codefreeze-gate-logic.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Adds the thin caller workflow (`.github/workflows/post-codefreeze-gatekeeper.yaml`) that delegates to the central reusable workflow in `devops-shared-resources`
- The gatekeeper runs in **evaluation (advisory-only) mode** -- it posts a PR comment with pass/fail results but does **not** block merges
- Teams can use the `run-gatekeeper` label to manually re-trigger the check

Resolves: [RHOAIENG-82298](https://redhat.atlassian.net/browse/RHOAIENG-82298)