### PR TITLE
fix: remove stable-3.x channel from rhoai-3.4 catalog-patch

### DIFF
--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -1,16 +1,9 @@
 patch:
   olm.package:
     name: rhods-operator
-    defaultChannel: stable-3.x
+    defaultChannel: stable-3.4
   olm.channels:
     - name: stable-3.4
-      package: rhods-operator
-      schema: olm.channel
-      entries:
-        - name: rhods-operator.3.4.4
-          replaces: rhods-operator.3.4.3
-          skipRange: '>=3.3.0 <3.4.4'
-    - name: stable-3.x
       package: rhods-operator
       schema: olm.channel
       entries:

--- a/catalog/catalog-patch.yaml
+++ b/catalog/catalog-patch.yaml
@@ -1,7 +1,7 @@
 patch:
   olm.package:
     name: rhods-operator
-    defaultChannel: stable-3.4
+    defaultChannel: stable-3.x
   olm.channels:
     - name: stable-3.4
       package: rhods-operator


### PR DESCRIPTION
## Summary
- Remove the `stable-3.x` channel from `catalog/catalog-patch.yaml` on `rhoai-3.4` since the channel head is moving to 3.5

## Test plan
- [ ] Verify catalog-patch.yaml only contains the `stable-3.4` channel
- [ ] Confirm stage promoter runs successfully after merge