### PR TITLE
Add odh-data-connect-hub-flight to bundle relatedImages

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -220,6 +220,8 @@ ARG ODH_TH_TORCH_CUDA_PY312_GIT_URL=
 ARG ODH_TH_TORCH_CUDA_PY312_GIT_COMMIT=
 ARG ODH_TH_TORCH_ROCM_PY312_GIT_URL=
 ARG ODH_TH_TORCH_ROCM_PY312_GIT_COMMIT=
+ARG ODH_DATA_CONNECT_HUB_FLIGHT_GIT_URL=
+ARG ODH_DATA_CONNECT_HUB_FLIGHT_GIT_COMMIT=
 
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
@@ -452,7 +454,9 @@ LABEL \
       odh-th-torch-cuda-py312.git.url="${ODH_TH_TORCH_CUDA_PY312_GIT_URL}" \
       odh-th-torch-cuda-py312.git.commit="${ODH_TH_TORCH_CUDA_PY312_GIT_COMMIT}" \
       odh-th-torch-rocm-py312.git.url="${ODH_TH_TORCH_ROCM_PY312_GIT_URL}" \
-      odh-th-torch-rocm-py312.git.commit="${ODH_TH_TORCH_ROCM_PY312_GIT_COMMIT}"
+      odh-th-torch-rocm-py312.git.commit="${ODH_TH_TORCH_ROCM_PY312_GIT_COMMIT}" \
+      odh-data-connect-hub-flight.git.url="${ODH_DATA_CONNECT_HUB_FLIGHT_GIT_URL}" \
+      odh-data-connect-hub-flight.git.commit="${ODH_DATA_CONNECT_HUB_FLIGHT_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -243,6 +243,8 @@ patch:
       value: quay.io/rhoai/odh-th-torch-cuda-py312-rhel9@sha256:c0754fc4d3245e5c1e3bfe85321ba827df5950f3dcd3ce6fd84572b90805245b
     - name: RELATED_IMAGE_ODH_TH_TORCH_ROCM_PY312_IMAGE
       value: quay.io/rhoai/odh-th-torch-rocm-py312-rhel9@sha256:f8b5bbd5bb591cede282a0fbee2f9a8cf599dc8e26558ab0a22a8d8f3eb83861
+    - name: RELATED_IMAGE_ODH_DATA_CONNECT_HUB_FLIGHT_IMAGE
+      value: quay.io/rhoai/odh-data-connect-hub-flight-rhel9@sha256:f48d816a38bbf4dd4ba56b8eb8e43c1937f1caed65709d73c3c39dccc36f6a6a
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -122,6 +122,7 @@ config:
         rhoai/odh-th-torch-cpu-py312-rhel9: rhoai/odh-th-torch-cpu-py312-rhel9
         rhoai/odh-th-torch-cuda-py312-rhel9: rhoai/odh-th-torch-cuda-py312-rhel9
         rhoai/odh-th-torch-rocm-py312-rhel9: rhoai/odh-th-torch-rocm-py312-rhel9
+        rhoai/odh-data-connect-hub-flight-rhel9: rhoai/odh-data-connect-hub-flight-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds relatedImages entry for 'odh-data-connect-hub-flight' to bundle/bundle-patch.yaml.

Image: quay.io/rhoai/odh-data-connect-hub-flight-rhel9@sha256:f48d816a38bbf4dd4ba56b8eb8e43c1937f1caed65709d73c3c39dccc36f6a6a
Jira: https://redhat.atlassian.net/browse/RHOAIENG-82405