### PR TITLE
[RHAI-456] Add RELATED_IMAGE entries for vLLM CPU Power/Z

### DIFF
--- a/bundle/additional-images-patch.yaml
+++ b/bundle/additional-images-patch.yaml
@@ -75,6 +75,12 @@ additionalImages:
     value: "registry.redhat.io/rhaii-early-access/vllm-gaudi-rhel9:3.5.0-ea.2-1782939839@sha256:bb49786e915fe9789ffec6d953827fee90ef30bf9accce3db135ed4a0a26a35d"
   - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_FAST_2_IMAGE
     value: "registry.redhat.io/rhaii-early-access/vllm-gaudi-rhel9:3.5.0-ea.2-1782939839@sha256:bb49786e915fe9789ffec6d953827fee90ef30bf9accce3db135ed4a0a26a35d"
+  - name: RELATED_IMAGE_RHAII_VLLM_CPU_PZ_IMAGE
+    value: "registry.redhat.io/rhaii-early-access/vllm-cpu-pz-rhel9:3.5.0-ea.2-1782965184@sha256:f7d3636e1bafd71bdf1f4a8b6818d9e00b7c64516ed4e732e942514a60ecd680"
+  - name: RELATED_IMAGE_RHAII_VLLM_CPU_PZ_FAST_1_IMAGE
+    value: "registry.redhat.io/rhaii-early-access/vllm-cpu-pz-rhel9:3.5.0-ea.2-1782965184@sha256:f7d3636e1bafd71bdf1f4a8b6818d9e00b7c64516ed4e732e942514a60ecd680"
+  - name: RELATED_IMAGE_RHAII_VLLM_CPU_PZ_FAST_2_IMAGE
+    value: "registry.redhat.io/rhaii-early-access/vllm-cpu-pz-rhel9:3.5.0-ea.2-1782965184@sha256:f7d3636e1bafd71bdf1f4a8b6818d9e00b7c64516ed4e732e942514a60ecd680"
   - name: RELATED_IMAGE_ODH_UBI_MICRO_IMAGE
     value: "registry.redhat.io/ubi9/ubi-micro@sha256:b1e86b97028b8fcfb6d85f997c39e6b6b67496163ef8d80d243220a4918e8bef"
     # RHAII MODEL_OPT_CUDA image temp added


### PR DESCRIPTION
## Summary

Adds `RELATED_IMAGE_RHAII_VLLM_CPU_PZ_*` entries to the ClusterServiceVersion manifest to resolve ImagePullBackOff blocker (RHOAIENG-88193) and enable proper digest injection by OLM for the vLLM CPU Power/Z runtime template.

## Context

This PR is part of the vLLM CPU Power/Z AIPCC migration (RHAI-121 Epic, RHAISTRAT-2304 parent). Related PRs have already merged:
- opendatahub-operator #3996 (RHAI-455) — Added `RELATED_IMAGE_RHAII_VLLM_CPU_PZ_*` environment variable declarations to handler.go
- odh-model-controller #925 (RHAI-455) — Switched `vllm-cpu-runtime-template` from `$(vllm-cpu-image)` to `$(vllm-cpu-pz-image)`

However, the CSV is currently missing these entries, causing the template parameter to resolve to a placeholder digest instead of the actual multi-arch image. This blocks P/Z deployment with ImagePullBackOff errors.

## Changes

Adds three new entries to `bundle/additional-images-patch.yaml`:
- `RELATED_IMAGE_RHAII_VLLM_CPU_PZ_IMAGE`
- `RELATED_IMAGE_RHAII_VLLM_CPU_PZ_FAST_1_IMAGE`
- `RELATED_IMAGE_RHAII_VLLM_CPU_PZ_FAST_2_IMAGE`

All entries use the x86 CPU image digest as a placeholder, following the atomic swap pattern established during vLLM Gaudi AIPCC migration (RHAI-120, PR #18857).

## Test Plan

- Verify CSV generation includes the new RELATED_IMAGE entries
- Confirm vllm-cpu-runtime-template resolves to actual digest (not placeholder)
- Deploy on P/Z hardware once image is available (RHAI-457)

Resolves: RHAI-456
Parent Epic: RHAI-121
Blocker: RHOAIENG-88193