### PR TITLE
Add odh-pipeline-runtime-baseline-cpu-py312 to bundle relatedImages

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -224,6 +224,8 @@ ARG ODH_DATA_CONNECT_HUB_REST_GIT_URL=
 ARG ODH_DATA_CONNECT_HUB_REST_GIT_COMMIT=
 ARG ODH_DATA_CONNECT_HUB_FLIGHT_GIT_URL=
 ARG ODH_DATA_CONNECT_HUB_FLIGHT_GIT_COMMIT=
+ARG ODH_PIPELINE_RUNTIME_BASELINE_CPU_PY312_GIT_URL=
+ARG ODH_PIPELINE_RUNTIME_BASELINE_CPU_PY312_GIT_COMMIT=
 
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
@@ -460,7 +462,9 @@ LABEL \
       odh-data-connect-hub-rest.git.url="${ODH_DATA_CONNECT_HUB_REST_GIT_URL}" \
       odh-data-connect-hub-rest.git.commit="${ODH_DATA_CONNECT_HUB_REST_GIT_COMMIT}"
       odh-data-connect-hub-flight.git.url="${ODH_DATA_CONNECT_HUB_FLIGHT_GIT_URL}" \
-      odh-data-connect-hub-flight.git.commit="${ODH_DATA_CONNECT_HUB_FLIGHT_GIT_COMMIT}"
+      odh-data-connect-hub-flight.git.commit="${ODH_DATA_CONNECT_HUB_FLIGHT_GIT_COMMIT}" \
+      odh-pipeline-runtime-baseline-cpu-py312.git.url="${ODH_PIPELINE_RUNTIME_BASELINE_CPU_PY312_GIT_URL}" \
+      odh-pipeline-runtime-baseline-cpu-py312.git.commit="${ODH_PIPELINE_RUNTIME_BASELINE_CPU_PY312_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -247,6 +247,8 @@ patch:
       value: quay.io/rhoai/odh-data-connect-hub-rest-rhel9@sha256:050621ee6adb207011cd51917409c5b94033c778ed4aa990c27afec179ed25aa
     - name: RELATED_IMAGE_ODH_DATA_CONNECT_HUB_FLIGHT_IMAGE
       value: quay.io/rhoai/odh-data-connect-hub-flight-rhel9@sha256:f48d816a38bbf4dd4ba56b8eb8e43c1937f1caed65709d73c3c39dccc36f6a6a
+    - name: RELATED_IMAGE_ODH_PIPELINE_RUNTIME_BASELINE_CPU_PY312_IMAGE
+      value: quay.io/rhoai/odh-pipeline-runtime-baseline-cpu-py312-rhel9@sha256:c5ce0d12fdbd6030a8e9ba6bcc5dd891eecba857e7ae62c0fc9957b2ec1957f8
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -125,6 +125,7 @@ config:
         rhoai/odh-data-connect-hub-rest-rhel9: rhoai/odh-data-connect-hub-rest-rhel9
         rhoai/odh-data-connect-hub-flight-rhel9: rhoai/odh-data-connect-hub-flight-rhel9
 
+        rhoai/odh-pipeline-runtime-baseline-cpu-py312-rhel9: rhoai/odh-pipeline-runtime-baseline-cpu-py312-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds relatedImages entry for 'odh-pipeline-runtime-baseline-cpu-py312' to bundle/bundle-patch.yaml.

Image: quay.io/rhoai/odh-pipeline-runtime-baseline-cpu-py312-rhel9@sha256:c5ce0d12fdbd6030a8e9ba6bcc5dd891eecba857e7ae62c0fc9957b2ec1957f8
Jira: https://redhat.atlassian.net/browse/RHOAIENG-81141